### PR TITLE
Fix unmatched close parenthesis in Perl Lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -55,7 +55,7 @@ module Rouge
         rule %r({(\\\\|\\}|[^}])*}[egimosx]*), re_tok, :pop!
         rule %r(<(\\\\|\\>|[^>])*>[egimosx]*), re_tok, :pop!
         rule %r(\[(\\\\|\\\]|[^\]])*\][egimosx]*), re_tok, :pop!
-        rule %r(\((\\\\|\\\)|[^\)])*\)[egimosx]*), re_tok, :pop!
+        rule %r[\((\\\\|\\\)|[^\)])*\)[egimosx]*], re_tok, :pop!
         rule %r(@(\\\\|\\\@|[^\@])*@[egimosx]*), re_tok, :pop!
         rule %r(%(\\\\|\\\%|[^\%])*%[egimosx]*), re_tok, :pop!
         rule %r(\$(\\\\|\\\$|[^\$])*\$[egimosx]*), re_tok, :pop!
@@ -87,7 +87,7 @@ module Rouge
         rule %r(s{(\\\\|\\}|[^}])*}\s*), re_tok, :balanced_regex
         rule %r(s<(\\\\|\\>|[^>])*>\s*), re_tok, :balanced_regex
         rule %r(s\[(\\\\|\\\]|[^\]])*\]\s*), re_tok, :balanced_regex
-        rule %r(s\((\\\\|\\\)|[^\)])*\)\s*), re_tok, :balanced_regex
+        rule %r[s\((\\\\|\\\)|[^\)])*\)\s*], re_tok, :balanced_regex
 
         rule %r(m?/(\\\\|\\/|[^/\n])*/[gcimosx]*), re_tok
         rule %r(m(?=[/!\\{<\[\(@%\$])), re_tok, :balanced_regex


### PR DESCRIPTION
When running the tests in Ruby 2.0.0-preview1, I get:

```
/Users/murphy/ruby/rouge/lib/rouge/lexers/perl.rb:58:
unmatched close parenthesis: /\((\\\\|\\)|[^)])*)[egimosx]*/ (SyntaxError)
```

Reason seems to be that `\)` inside a `%r(…)` is being sent as just `)` to the Regexp interpreter.

This patch fixes it. Should be an error in other Ruby versions, too IMO.
