### PR TITLE
Python: single quotes inside double and vice-versa

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -146,7 +146,16 @@ module Rouge
 
       state :strings do
         rule /%(\([a-z0-9_]+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/i, 'Literal.String.Interpol'
-        rule /[^\\'"%\n]+/, 'Literal.String'
+      end
+
+      state :strings_double do
+        rule /[^\\"%\n]+/, 'Literal.String'
+        mixin :strings
+      end
+
+      state :strings_single do
+        rule /[^\\'%\n]+/, 'Literal.String'
+        mixin :strings
       end
 
       state :nl do
@@ -169,24 +178,25 @@ module Rouge
       state :dqs do
         rule /"/, 'Literal.String', :pop!
         rule /\\\\|\\"|\\\n/, 'Literal.String.Escape'
-        mixin :strings
+        mixin :strings_double
       end
 
       state :sqs do
         rule /'/, 'Literal.String', :pop!
         rule /\\\\|\\'|\\\n/, 'Literal.String.Escape'
-        mixin :strings
+        mixin :strings_single
       end
 
       state :tdqs do
         rule /"""/, 'Literal.String', :pop!
-        mixin :strings
+        mixin :strings_double
         mixin :nl
       end
 
       state :tsqs do
         rule /'''/, 'Literal.String', :pop!
-        mixin :strings
+        rule /[^\\'%\n]+/, 'Literal.String'
+        mixin :strings_single
         mixin :nl
       end
 

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -11,6 +11,19 @@ def lex(code, lexer):
                             'not a class')
         raise
 
+# quotes in strings
+def foo():
+    "it's working"
+
+def foo():
+    'he said "hi"'
+
+def foo():
+    """it's working"""
+
+def foo():
+    '''he said "hi"'''
+
 # unicode docstrings
 def foo():
     ur"""unicode-raw"""


### PR DESCRIPTION
Currently, in this code:

``` python
"it's working"
```

the single quote (apostrophe) gets highlighted as an error. It's valid Python, though. This is also true of double quotes inside single-quoted strings, and the equivalents for triple-quoted strings.

The problem seems to be is that the lexer considers either ' or " to terminate a string. I've split the base `string` mixin into one for single-quoted strings and one for double-quoted strings.

There's one thing that confuses me: if I remove the strings_single mixin from the tsqs state entirely, it still works. I don't know what's going on there. Perhaps the lexer is incorrectly lexing the triple-quoted string as multiple single-quoted strings? Everything looks right, in any case.
