### PR TITLE
Check if the bashrc file exists, otherwise skip

### DIFF
--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -8,14 +8,8 @@ describe Rouge::Lexers::Shell do
     assert { tokens.first[0].name == 'Name.Variable' }
   end
 
-  it 'parses bashrc' do
-    if File.exists?('/etc/bash.bashrc')
-      assert_no_errors File.read('/etc/bash.bashrc')
-    elsif File.exists?('/etc/bashrc')
-      assert_no_errors File.read('/etc/bashrc')
-    else
-      skip "no bashrc file present"
-    end
+  it 'parses samples/shell' do
+    assert_no_errors File.read('spec/visual/samples/shell')
   end
 
   it 'parses case statements correctly' do


### PR DESCRIPTION
On OSX the default bashrc file is under /etc/bashrc thus the test suite fails
with the 'parses /etc/bash.bashrc' case.
The changes check if the file exists, uses the osx path or skips the case in question.
