### PR TITLE
additional file types for Ruby

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -5,7 +5,8 @@ module Rouge
       tag 'ruby'
       aliases 'rb'
       filenames '*.rb', '*.ruby', '*.rbw', '*.rake', '*.gemspec',
-                'Rakefile', 'Guardfile', 'Gemfile'
+                'Rakefile', 'Guardfile', 'Gemfile', 'Capfile',
+                'Vagrantfile', '*.ru', '*.prawn'
 
       mimetypes 'text/x-ruby', 'application/x-ruby'
 

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -12,6 +12,11 @@ describe Rouge::Lexers::Ruby do
       assert_guess :filename => 'Rakefile'
       assert_guess :filename => 'Guardfile'
       assert_guess :filename => 'Gemfile'
+      assert_guess :filename => 'foo.rake'
+      assert_guess :filename => 'Capfile'
+      assert_guess :filename => 'Vagrantfile'
+      assert_guess :filename => 'config.ru'
+      assert_guess :filename => 'foo.pdf.prawn'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
This adds a few additional file types to the Ruby lexer:
- Capfile  
- Vagrantfile
- *.ru (for rackup)
- *.prawn
