### PR TITLE
Add Prolog Lexer

### DIFF
--- a/lib/rouge/demos/prolog
+++ b/lib/rouge/demos/prolog
@@ -1,0 +1,81 @@
+# Atoms
+
+x
+blue
+'Burrito'
+'some atom'
+
+# Numbers
+
+1
+123123123123
+12312.1231
+0.1
+
+# Variables
+
+Hello
+How_are_you_doing
+_amazing
+Wow123
+
+# Compound terms
+
+truck_year('Mazda', 1986)
+'Person_Friends'(zelda,[tom,jim])
+
+# List
+
+[]
+[1,2,3]
+[red,green,blue]
+
+# Strings
+
+"to be, or not to be"
+"東京都"
+
+# This example was taken from
+# http://en.wikipedia.org/wiki/Prolog#Turing_completeness
+turing(Tape0, Tape) :-
+    perform(q0, [], Ls, Tape0, Rs),
+    reverse(Ls, Ls1),
+    append(Ls1, Rs, Tape).
+
+/*
+*
+ * This is a multiline comment.
+*/
+
+perform(qf, Ls, Ls, Rs, Rs) :- !.
+perform(Q0, Ls0, Ls, Rs0, Rs) :-
+    symbol(Rs0, Sym, RsRest),
+    once(rule(Q0, Sym, Q1, NewSym, Action)),
+    action(Action, Ls0, Ls1, [NewSym|RsRest], Rs1),
+    perform(Q1, Ls1, Ls, Rs1, Rs).
+
+symbol([], b, []).
+symbol([Sym|Rs], Sym, Rs).
+
+action(left, Ls0, Ls, Rs0, Rs) :- left(Ls0, Ls, Rs0, Rs).
+action(stay, Ls, Ls, Rs, Rs).
+action(right, Ls0, [Sym|Ls0], [Sym|Rs], Rs).
+
+left([], [], Rs0, [b|Rs0]).
+left([L|Ls], Ls, Rs, [L|Rs]).
+
+## Example from pygments
+
+partition([], _, [], []).
+partition([X|Xs], Pivot, Smalls, Bigs) :-
+    (   X @< Pivot ->
+        Smalls = [X|Rest],
+        partition(Xs, Pivot, Rest, Bigs)
+    ;   Bigs = [X|Rest],
+        partition(Xs, Pivot, Smalls, Rest)
+    ).
+
+quicksort([])     --> [].
+quicksort([X|Xs]) --> 
+    { partition(Xs, X, Smaller, Bigger) },
+    quicksort(Smaller), [X], quicksort(Bigger).

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -1,0 +1,60 @@
+module Rouge
+  module Lexers
+    class Prolog < RegexLexer
+      desc "The Prolog programming language (http://en.wikipedia.org/wiki/Prolog)"
+      tag 'prolog'
+      aliases 'prolog'
+      filenames '*.pro', '*.P', '*.prolog'
+      mimetypes 'text/x-prolog'
+
+      def self.analyze_text(text)
+        return 1 if text =~ /\A\w+(\(\w+\,\s*\w+\))*\./
+      end
+
+      state :basic do
+        rule /\s+/, 'Text'
+        rule /^#.*/, 'Comment.Single'
+        rule /\/\*/, 'Comment.Multiline', :nested_comment
+
+        rule /[\[\](){}|.,;!]/, 'Punctuation'
+        rule /:-|-->/, 'Punctuation'
+
+        rule /"[^"]*"/, 'Literal.String.Double'
+
+        rule /\d+\.\d+/, 'Literal.Number.Float'
+        rule /\d+/, 'Literal.Number'
+      end
+
+      state :atoms do
+        rule /[[:lower:]]+(_|[[:lower]]|[[:digit:]])*/, 'Literal.String.Atom'
+        rule /'[^']*'/, 'Literal.String.Atom'
+      end
+
+      state :operators do
+        rule /(<|>|=<|>=|==|=:=|=|\/|\/\/|\*|\+|-)(?=\s|[a-zA-Z0-9\[])/,
+          'Operator'
+        rule /is/, 'Operator'
+        rule /(mod|div|not)/, 'Operator'
+        rule /[#&*+-.\/:<=>?@^~]+/, 'Operator'
+      end
+
+      state :variables do
+        rule /[A-Z]+\S*/, 'Name.Variable'
+        rule /_[[:word:]]*/, 'Name.Variable'
+      end
+
+      state :root do
+        mixin :basic
+        mixin :atoms
+        mixin :variables
+        mixin :operators
+      end
+
+      state :nested_comment do
+        rule /\/\*/, 'Comment.Multiline', :push
+        rule /\s*\*[^*\/]+/, 'Comment.Multiline'
+        rule /\*\//, 'Comment.Multiline', :pop!
+      end
+    end
+  end
+end

--- a/spec/lexers/prolog_spec.rb
+++ b/spec/lexers/prolog_spec.rb
@@ -1,0 +1,30 @@
+describe Rouge::Lexers::Prolog do
+  let(:subject) { Rouge::Lexers::Prolog.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.pro'
+      assert_guess :filename => 'foo.P'
+      assert_guess :filename => 'foo.prolog'
+      assert_guess :filename => 'foo.pl'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-prolog'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => <<-PROLOG
+mother_child(trude, sally).
+
+father_child(tom, sally).
+father_child(tom, erica).
+father_child(mike, tom).
+
+sibling(X, Y)      :- parent_child(Z, X), parent_child(Z, Y).
+      PROLOG
+    end
+  end
+end

--- a/spec/visual/samples/prolog
+++ b/spec/visual/samples/prolog
@@ -1,0 +1,81 @@
+# Atoms
+
+x
+blue
+'Burrito'
+'some atom'
+
+# Numbers
+
+1
+123123123123
+12312.1231
+0.1
+
+# Variables
+
+Hello
+How_are_you_doing
+_amazing
+Wow123
+
+# Compound terms
+
+truck_year('Mazda', 1986)
+'Person_Friends'(zelda,[tom,jim])
+
+# List
+
+[]
+[1,2,3]
+[red,green,blue]
+
+# Strings
+
+"to be, or not to be"
+"東京都"
+
+# This example was taken from
+# http://en.wikipedia.org/wiki/Prolog#Turing_completeness
+turing(Tape0, Tape) :-
+    perform(q0, [], Ls, Tape0, Rs),
+    reverse(Ls, Ls1),
+    append(Ls1, Rs, Tape).
+
+/*
+*
+ * This is a multiline comment.
+*/
+
+perform(qf, Ls, Ls, Rs, Rs) :- !.
+perform(Q0, Ls0, Ls, Rs0, Rs) :-
+    symbol(Rs0, Sym, RsRest),
+    once(rule(Q0, Sym, Q1, NewSym, Action)),
+    action(Action, Ls0, Ls1, [NewSym|RsRest], Rs1),
+    perform(Q1, Ls1, Ls, Rs1, Rs).
+
+symbol([], b, []).
+symbol([Sym|Rs], Sym, Rs).
+
+action(left, Ls0, Ls, Rs0, Rs) :- left(Ls0, Ls, Rs0, Rs).
+action(stay, Ls, Ls, Rs, Rs).
+action(right, Ls0, [Sym|Ls0], [Sym|Rs], Rs).
+
+left([], [], Rs0, [b|Rs0]).
+left([L|Ls], Ls, Rs, [L|Rs]).
+
+## Example from pygments
+
+partition([], _, [], []).
+partition([X|Xs], Pivot, Smalls, Bigs) :-
+    (   X @< Pivot ->
+        Smalls = [X|Rest],
+        partition(Xs, Pivot, Rest, Bigs)
+    ;   Bigs = [X|Rest],
+        partition(Xs, Pivot, Smalls, Rest)
+    ).
+
+quicksort([])     --> [].
+quicksort([X|Xs]) --> 
+    { partition(Xs, X, Smaller, Bigger) },
+    quicksort(Smaller), [X], quicksort(Bigger).


### PR DESCRIPTION
This implements a Prolog Lexer.

However there is a bit of a problem concerning the guessing of the source using the filename because both Perl as well as Prolog apparently are using `.pl`.
