### PR TITLE
Add prompt support to Shell lexer

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -36,7 +36,7 @@ module Rouge
 
         rule /\b(#{BUILTINS})\s*\b(?!\.)/, 'Name.Builtin'
 
-        rule /^\$ +/, 'Generic.Prompt'
+        rule /^\S*[\$%>#] +/, 'Generic.Prompt'
 
         rule /(\b\w+)(=)/ do |m|
           group 'Name.Variable'

--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -31,7 +31,32 @@ describe Rouge::Lexers::Shell do
   end
 
   it 'parses a basic shell string with a prompt' do
+    # Single '$' prompt
     tokens = subject.lex('$ foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Single '>' prompt
+    tokens = subject.lex('> foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Single '%' prompt
+    tokens = subject.lex('% foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Complex prompt with trailing '$'
+    tokens = subject.lex('me@host:~$ foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Complex prompt with trailing '>'
+    tokens = subject.lex('me@host:~> foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Complex prompt with trailing '%'
+    tokens = subject.lex('me@host:~% foo=bar').to_a
+    assert { tokens.size == 4 }
+    assert { tokens.first[0].name == 'Generic.Prompt' }
+    # Complex prompt with trailing '#'
+    tokens = subject.lex('root@host:/root# foo=bar').to_a
     assert { tokens.size == 4 }
     assert { tokens.first[0].name == 'Generic.Prompt' }
   end
@@ -40,6 +65,12 @@ describe Rouge::Lexers::Shell do
     tokens = subject.lex('$foo').to_a
     assert { tokens.size == 1 }
     assert { tokens.first[0].name == 'Name.Variable' }
+  end
+
+  it 'does not confuse a prompt with a comment' do
+    tokens = subject.lex('# commentaire').to_a
+    assert { tokens.size == 1 }
+    assert { tokens.first[0].name == 'Comment' }
   end
 
   describe 'guessing' do


### PR DESCRIPTION
This PR adds support for prompt (a leading dollar sign followed by one or more spaces) in the Shell lexer.

It introduces Generic.Prompt token in this shell (Pygments compatible).

It does not confuse a prompt (`$ foo`) and a variable (`$foo`).

It includes 2 tests.
