### PR TITLE
Lexer for the Go programming language

### DIFF
--- a/lib/rouge/demos/go
+++ b/lib/rouge/demos/go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}

--- a/lib/rouge/lexers/go.rb
+++ b/lib/rouge/lexers/go.rb
@@ -1,0 +1,175 @@
+module Rouge
+  module Lexers
+    class Go < RegexLexer
+      desc 'The Go programming language'
+      tag 'go'
+      aliases 'go', 'golang'
+      filenames '*.go'
+
+      mimetypes 'text/x-go', 'application/x-go'
+
+      def self.analyze_text(text)
+        return 0
+      end
+
+      # Characters
+
+      WHITE_SPACE            = /[\s\t\r\n]+/
+
+      NEWLINE                = /\n/
+      UNICODE_CHAR           = /[^\n]/
+      UNICODE_LETTER         = /[[:alpha:]]/
+      UNICODE_DIGIT          = /[[:digit:]]/
+
+      # Letters and digits
+
+      LETTER                 = /#{UNICODE_LETTER}|_/
+      DECIMAL_DIGIT          = /[0-9]/
+      OCTAL_DIGIT            = /[0-7]/
+      HEX_DIGIT              = /[0-9A-Fa-f]/
+
+      # Comments
+
+      LINE_COMMENT           = /\/\/(?:(?!#{NEWLINE}).)*/
+      GENERAL_COMMENT        = /\/\*(?:(?!\*\/).)*\*\//m
+      COMMENT                = /#{LINE_COMMENT}|#{GENERAL_COMMENT}/
+
+      # Keywords
+
+      KEYWORD                = /\b(?:
+                                 break       | default     | func
+                               | interface   | select      | case
+                               | defer       | go          | map
+                               | struct      | chan        | else
+                               | goto        | package     | switch
+                               | const       | fallthrough | if
+                               | range       | type        | continue
+                               | for         | import      | return
+                               | var
+                               )\b/x
+
+      # Identifiers
+
+      IDENTIFIER             = / (?!#{KEYWORD})
+                                 #{LETTER}(?:#{LETTER}|#{UNICODE_DIGIT})* /x
+
+      # Operators and delimiters
+
+      OPERATOR               = / \+=    | \+\+   | \+     | &\^=   | &\^
+                               | &=     | &&     | &      | ==     | =
+                               | \!=    | \!     | -=     | --     | -
+                               | \|=    | \|\|   | \|     | <=     | <-
+                               | <<=    | <<     | <      | \*=    | \*
+                               | \^=    | \^     | >>=    | >>     | >=
+                               | >      | \/     | \/=    | :=     | %
+                               | %=     | \.\.\. | \.     | :
+                               /x
+
+      SEPARATOR              = / \(     | \)     | \[     | \]     | \{
+                               | \}     | ,      | ;
+                               /x
+
+      # Integer literals
+
+      DECIMAL_LIT            = /[0-9]#{DECIMAL_DIGIT}*/
+      OCTAL_LIT              = /0#{OCTAL_DIGIT}*/
+      HEX_LIT                = /0[xX]#{HEX_DIGIT}+/
+      INT_LIT                = /#{HEX_LIT}|#{DECIMAL_LIT}|#{OCTAL_LIT}/
+
+      # Floating-point literals
+
+      DECIMALS               = /#{DECIMAL_DIGIT}+/
+      EXPONENT               = /[eE][+\-]?#{DECIMALS}/
+      FLOAT_LIT              = / #{DECIMALS} \. #{DECIMALS}? #{EXPONENT}?
+                               | #{DECIMALS} #{EXPONENT}
+                               | \. #{DECIMALS} #{EXPONENT}?
+                               /x
+
+      # Imaginary literals
+
+      IMAGINARY_LIT          = /(?:#{DECIMALS}|#{FLOAT_LIT})i/
+
+      # Rune literals
+
+      ESCAPED_CHAR           = /\\[abfnrtv\\'"]/
+      LITTLE_U_VALUE         = /\\u#{HEX_DIGIT}{4}/
+      BIG_U_VALUE            = /\\U#{HEX_DIGIT}{8}/
+      UNICODE_VALUE          = / #{UNICODE_CHAR} | #{LITTLE_U_VALUE}
+                               | #{BIG_U_VALUE}  | #{ESCAPED_CHAR}
+                               /x
+      OCTAL_BYTE_VALUE       = /\\#{OCTAL_DIGIT}{3}/
+      HEX_BYTE_VALUE         = /\\x#{HEX_DIGIT}{2}/
+      BYTE_VALUE             = /#{OCTAL_BYTE_VALUE}|#{HEX_BYTE_VALUE}/
+      CHAR_LIT               = /'(?:#{UNICODE_VALUE}|#{BYTE_VALUE})'/
+      ESCAPE_SEQUENCE        = / #{ESCAPED_CHAR}
+                               | #{LITTLE_U_VALUE}
+                               | #{BIG_U_VALUE}
+                               | #{HEX_BYTE_VALUE}
+                               /x
+
+      # String literals
+
+      RAW_STRING_LIT         = /`(?:#{UNICODE_CHAR}|#{NEWLINE})*`/
+      INTERPRETED_STRING_LIT = / "(?: (?!")
+                                      (?: #{UNICODE_VALUE} | #{BYTE_VALUE} )
+                                  )*" /x
+      STRING_LIT             = /#{RAW_STRING_LIT}|#{INTERPRETED_STRING_LIT}/
+
+      # Predeclared identifiers
+
+      PREDECLARED_TYPES      = /\b(?:
+                                 bool       | byte       | complex64
+                               | complex128 | error      | float32
+                               | float64    | int8       | int16
+                               | int32      | int64      | int
+                               | rune       | string     | uint8
+                               | uint16     | uint32     | uint64
+                               | uintptr    | uint
+      	                       )\b/x
+
+      PREDECLARED_CONSTANTS  = /\b(?:true|false|iota|nil)\b/
+
+      PREDECLARED_FUNCTIONS  = /\b(?:
+                                 append  | cap     | close   | complex
+                               | copy    | delete  | imag    | len
+                               | make    | new     | panic   | print
+                               | println | real    | recover
+                               )\b/x
+
+      state :simple_tokens do
+        rule(COMMENT,               "Comment")
+        rule(KEYWORD,               "Keyword")
+        rule(PREDECLARED_TYPES,     "Keyword.Type")
+        rule(PREDECLARED_FUNCTIONS, "Name.Builtin")
+        rule(PREDECLARED_CONSTANTS, "Name.Constant")
+        rule(IMAGINARY_LIT,         "Literal.Number")
+        rule(FLOAT_LIT,             "Literal.Number")
+        rule(INT_LIT,               "Literal.Number")
+        rule(CHAR_LIT,              "Literal.String.Char")
+        rule(OPERATOR,              "Operator")
+        rule(SEPARATOR,             "Punctuation")
+        rule(IDENTIFIER,            "Name")
+        rule(WHITE_SPACE,           "Other")
+      end
+
+      state :root do
+        mixin :simple_tokens
+
+        rule(/`/,             "Literal.String", :raw_string)
+        rule(/"/,             "Literal.String", :interpreted_string)
+      end
+
+      state :interpreted_string do
+        rule(ESCAPE_SEQUENCE, "Literal.String.Escape")
+        rule(/\\./,           "Error")
+        rule(/"/,             "Literal.String", :pop!)
+        rule(/./,             "Literal.String")
+      end
+
+      state :raw_string do
+        rule(/`/,             "Literal.String", :pop!)
+        rule(/./m,            "Literal.String")
+      end
+    end
+  end
+end

--- a/spec/lexers/go_spec.rb
+++ b/spec/lexers/go_spec.rb
@@ -1,0 +1,17 @@
+describe Rouge::Lexers::Go do
+  let(:subject) { Rouge::Lexers::Go.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.go'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-go'
+      assert_guess :mimetype => 'application/x-go'
+    end
+  end
+end
+

--- a/spec/visual/samples/go
+++ b/spec/visual/samples/go
@@ -1,0 +1,181 @@
+// A line comment.
+
+/*
+A general comment.
+*/
+
+// Keywords
+
+	break        default      func         interface    select
+	case         defer        go           map          struct
+	chan         else         goto         package      switch
+	const        fallthrough  if           range        type
+	continue     for          import       return       var
+
+// Operators, delimiters and special tokens
+
+	+    &     +=    &=     &&    ==    !=    (    )
+	-    |     -=    |=     ||    <     <=    [    ]
+	*    ^     *=    ^=     <-    >     >=    {    }
+	/    <<    /=    <<=    ++    =     :=    ,    ;
+	%    >>    %=    >>=    --    !     ...   .    :
+	     &^          &^=
+
+// Integer literals
+
+	42
+	0600
+	0xBadFace
+	170141183460469231731687303715884105727
+
+// Floating-point literals
+
+	0.
+	72.40
+	072.40
+	2.71828
+	1.e+0
+	6.67428e-11
+	1E6
+	.25
+	.12345E+5
+
+// Imaginary literals
+
+	0i
+	011i
+	0.i
+	2.71828i
+	1.e+0i
+	6.67428e-11i
+	1E6i
+	.25i
+	.12345E+5i
+
+// Character literals
+
+	'a'
+	'ä'
+	'本'
+	'\t'
+	'\000'
+	'\007'
+	'\377'
+	'\x07'
+	'\xff'
+	'\u12e4'
+	'\U00101234'
+
+// String literals
+
+	`abc`
+	`\n
+	\n`
+	"\n"
+	""
+	"Hello, world!\n"
+	"日本語"
+	"\u65e5本\U00008a9e"
+	"\xff\u00FF"
+	"\uD800"       // illegal: surrogate half
+	"\U00110000"   // illegal: invalid Unicode code point
+	"\z"           // illegal
+
+// Predeclared identifiers
+
+	// Types:
+	bool byte complex64 complex128 error float32 float64
+	int int8 int16 int32 int64 rune string
+	uint uint8 uint16 uint32 uint64 uintptr
+
+	// Constants:
+	true false iota
+
+	// Zero value:
+	nil
+
+	// Functions:
+	append cap close complex copy delete imag len
+	make new panic print println real recover
+
+// Types
+
+	type T1 string
+	type T2 T1
+	type T3 []T1
+	type T4 T3
+
+// Array types
+
+	[32]byte
+	[2*N] struct { x, y int32 }
+	[1000]*float64
+	[3][5]int
+	[2][2][2]float64
+
+// Struct types
+
+	struct {}
+
+	struct {
+		x, y int
+		u float32
+		_ float32
+		A *[]int
+		F func()
+	}
+
+	struct {
+		T1
+		*T2
+		P.T3
+		*P.T4
+		x, y int
+	}
+
+	struct {
+		T
+		*T
+		*P.T
+	}
+
+	struct {
+		microsec  uint64 "field 1"
+		serverIP6 uint64 "field 2"
+		process   string "field 3"
+	}
+
+// Function types
+
+	func()
+	func(x int) int
+	func(a, _ int, z float32) bool
+	func(a, b int, z float32) (bool)
+	func(prefix string, values ...int)
+	func(a, b int, z float64, opt ...interface{}) (success bool)
+	func(int, int, float64) (float64, *[]int)
+	func(n int) func(p *T)
+
+// Interface types
+
+	interface {
+		Read(b Buffer) bool
+		Write(b Buffer) bool
+		Close()
+	}
+
+	type Lock interface {
+		Lock()
+		Unlock()
+	}
+
+// Channel types
+
+	chan T
+	chan<- float64
+	<-chan int
+
+	chan<- chan int
+	chan<- <-chan int
+	<-chan <-chan int
+	chan (<-chan int)


### PR DESCRIPTION
As an answer to [Issue 60](https://github.com/jayferd/rouge/issues/60), I implemented a lexer for Go.

It highlights tokens as well as escape sequences in strings. I followed the [language specification](http://golang.org/ref/spec) closely so hopefully I did not forget anything.

I did not implement more advanced parts (yet!) such as highlighting exported identifiers or function prototypes, but I believe the current lexer still makes Go code easier to read and lays down foundations for future enhancements.
