### PR TITLE
Provide option to skip the <pre> wrapper

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -12,6 +12,7 @@ module Rouge
       def initialize(opts={})
         @css_class = opts[:css_class] || 'highlight'
         @line_numbers = opts.fetch(:line_numbers) { false }
+        @wrap = opts.fetch(:wrap, true)
       end
 
       # @yield the html output.
@@ -24,11 +25,11 @@ module Rouge
       end
 
       def stream_untableized(tokens, &b)
-        yield "<pre class=#{@css_class.inspect}>"
+        yield "<pre class=#{@css_class.inspect}>" if @wrap
         tokens.each do |tok, val|
           span(tok, val, &b)
         end
-        yield '</pre>'
+        yield '</pre>' if @wrap
       end
 
       def stream_tableized(tokens, &b)
@@ -48,7 +49,7 @@ module Rouge
           %<<div class="lineno">#{x+1}</div>>
         end.join
 
-        yield "<pre class=#{@css_class.inspect}>"
+        yield "<pre class=#{@css_class.inspect}>" if @wrap
         yield "<table><tbody><tr>"
 
         # the "gl" class applies the style for Generic.Lineno
@@ -61,7 +62,7 @@ module Rouge
         yield '</td>'
 
         yield '</tr></tbody></table>'
-        yield '</pre>'
+        yield '</pre>' if @wrap
       end
 
     private

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -6,4 +6,10 @@ describe Rouge::Formatters::HTML do
     out = subject.format([[Token['Name'], 'foo']])
     assert { out == '<pre class="highlight"><span class="n">foo</span></pre>' }
   end
+
+  it 'skips <pre> wrapper' do
+    formatter = Rouge::Formatters::HTML.new(:wrap => false)
+    out = formatter.format([[Token['Name'], 'foo']])
+    assert { out == '<span class="n">foo</span>' }
+  end
 end


### PR DESCRIPTION
In my opinion it would be preferable if the &lt;pre> wrapper wasn't produced by the formatter at all, as it is very simple to add on your own, and needlessly limits the use of the built-in HTML formatter. However, if you don't want to remove it, I'm hoping you will consider this patch that at least makes it possible to configure it away.
