### PR TITLE
Updates to Racket lexer:

### DIFF
--- a/lib/rouge/lexers/racket.rb
+++ b/lib/rouge/lexers/racket.rb
@@ -477,7 +477,9 @@ module Rouge
         )
       end
 
-      id = /[[:alnum:]!$\%&*+,\/:<=>?@^_~|-]+/i
+      # Since Racket allows identifiers to consist of nearly anything,
+      # it's simpler to describe what an ID is _not_.
+      id = /[^\s\(\)\[\]\{\}'`,.]+/i
 
       state :root do
         # comments
@@ -492,7 +494,7 @@ module Rouge
         rule /-?\d+\.\d+/, 'Literal.Number.Float'
         rule /-?\d+/, 'Literal.Number.Integer'
 
-        rule /#:#{id}+/, 'Name.Tag'
+        rule /#:#{id}+/, 'Name.Tag'  # keyword
 
         rule /#b[01]+/, 'Literal.Number.Binary'
         rule /#o[0-7]+/, 'Literal.Number.Oct'
@@ -501,7 +503,7 @@ module Rouge
         rule /#[ei][\d.]+/, 'Literal.Number.Other'
 
         rule /"(\\\\|\\"|[^"])*"/, 'Literal.String'
-        rule /'#{id}/i, 'Literal.String.Symbol'
+        rule /['`]#{id}/i, 'Literal.String.Symbol'
         rule /#\\([()\/'"._!\$%& ?=+-]{1}|[a-z0-9]+)/i,
           'Literal.String.Char'
         rule /#t|#f/, 'Name.Constant'

--- a/spec/visual/samples/racket
+++ b/spec/visual/samples/racket
@@ -1,10 +1,16 @@
 #lang racket
 
-;; See "<<<" for two small changes, then jump down
-;; to `send/suspend'.
+;; Single-line comment
 
-'(a list)
+#| Multi-line comment on one line |#
+
+#| Multi-line comment on
+   two lines |#
+
 'symbol
+`symbol
+'(a quoted list)
+`(a quasiquoted expr with ,unquasiquoted item)
 #:keyword
 -inf.f
 +inf.f
@@ -14,6 +20,10 @@
 +max.0
 -nan.0
 +nan.0
+
+(define (1-crazy-identifier-疯狂的标识符-τρελό-αναγνωριστικό x)
+  (add1 x))
+(check-equal? (1-crazy-identifier-疯狂的标识符-τρελό-αναγνωριστικό 1) 2)
 
 (require xml net/url
          racket/control) ;; <<< new import


### PR DESCRIPTION
- Actually the \u03BB lambda char does work fine inside %w() with the
  others.
- Since Racket allows identifiers to consist of nearly anything,
  instead of describing what they are, describe what they are _not_.
- Handle quasiquote as well as quote.
