### PR TITLE
Omit whitespaces when lexing Elixir's keywords.

### DIFF
--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -24,7 +24,7 @@ module Rouge
         rule %r{\b(case|cond|end|bc|lc|if|unless|try|loop|receive|fn|defmodule|
              defp?|defprotocol|defimpl|defrecord|defmacrop?|defdelegate|
              defexception|exit|raise|throw|unless|after|rescue|catch|else)\b(?![?!])|
-             (?<!\.)\b(do|\-\>)\b\s*}x, 'Keyword'
+             (?<!\.)\b(do|\-\>)\b}x, 'Keyword'
         rule /\b(import|require|use|recur|quote|unquote|super|refer)\b(?![?!])/, 'Keyword.Namespace'
         rule /(?<!\.)\b(and|not|or|when|xor|in)\b/, 'Operator.Word'
         rule %r{%=|\*=|\*\*=|\+=|\-=|\^=|\|\|=|

--- a/spec/lexers/elixir_spec.rb
+++ b/spec/lexers/elixir_spec.rb
@@ -25,6 +25,15 @@ describe Rouge::Lexers::Elixir do
         ['Name.Constant', 'Builtin']
     end
 
+    it 'lexes keywords without following whitespaces' do
+      assert_tokens %{cond do\nend},
+        ['Keyword', 'cond'],
+        ['Text',    ' '],
+        ['Keyword', 'do'],
+        ['Text',    "\n"],
+        ['Keyword', 'end']
+    end
+
     private
 
     def assert_tokens(text, *expected)

--- a/spec/visual/samples/elixir
+++ b/spec/visual/samples/elixir
@@ -361,3 +361,12 @@ defmodule Module do
         "could not call #{fun} on module #{module} because it was already compiled"
   end
 end
+
+defp interpret(input) do
+  cond do
+    is_empty? input -> :silence
+    all_caps? input -> :exclamation
+    question? input -> :question
+    true            -> :statement
+  end
+end


### PR DESCRIPTION
This commit fixes #89.
