### PR TITLE
bugfix: fix error on parse ruby

### DIFF
--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -368,7 +368,7 @@ module Rouge
       push_state = if state_name
         get_state(state_name)
       elsif block_given?
-        State.new(b.inspect, &b).load!(self.class)
+        StateDSL.new(b.inspect, &b).to_state(self.class)
       else
         # use the top of the stack by default
         self.state


### PR DESCRIPTION
Ruby and shell lexer raises error.

``` ruby
%i(#{@interpolation})
```

```
wrong number of arguments (1 for 2)
file: regex_lexer.rb
location: initialize
line: 39
```
