### PR TITLE
fix parse error on markdown

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -31,7 +31,7 @@ module Rouge
         # TODO: syntax highlight the code block, github style
         rule /(\n[ \t]*)(```|~~~)(.*?)(\n.*?)(\2)/m do |m|
           sublexer = Lexer.find_fancy(m[3].strip, m[4])
-          sublexer ||= Text.new(:token => Str::Backtick)
+          sublexer ||= PlainText.new(:token => Str::Backtick)
 
           token Text, m[1]
           token Punctuation, m[2]


### PR DESCRIPTION
`Rouge::Lexers::Text` renamed to `Rouge::Lexers::PlainText`
