### PR TITLE
Moonscript: Correct lexing of string table keys

### DIFF
--- a/lib/rouge/lexers/moonscript.rb
+++ b/lib/rouge/lexers/moonscript.rb
@@ -46,7 +46,8 @@ module Rouge
         rule %r(\d+), Num::Integer
         rule %r(@#{ident}*), Name::Variable::Instance
         rule %r([A-Z][\w\d_]*), Name::Class
-        rule %r("?#{ident}+"?:), Literal::String::Symbol
+        rule %r("?[^"]+":), Literal::String::Symbol
+        rule %r(#{ident}:), Literal::String::Symbol
         rule %r(:#{ident}), Literal::String::Symbol
 
         rule %r(\s+), Text::Whitespace


### PR DESCRIPTION
Fixes lexing of string-keys in tables, something that unfortunately got lost in the original pull request. 
