### PR TITLE
When using Rouge with Redcarpet, require 'rouge' is compulsory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ $ rougify foo.rb
 ## You can even use it with Redcarpet
 
 ``` ruby
+require 'rouge'
 require 'rouge/plugins/redcarpet'
+
 class HTML < Redcarpet::Render::HTML
   include Rouge::Plugins::Redcarpet # yep, that's it.
 end


### PR DESCRIPTION
`rouge/lexer` is loaded in `lib/rouge.rb`, not in `lib/rouge/plugins/redcarpet.rb`. Thus user would get the error `uninitialized constant Rouge::Plugins::Redcarpet::Lexer` if `require 'rouge'` is not included.
