### PR TITLE
Fix background color for terminal256

### DIFF
--- a/lib/rouge/formatters/terminal256.rb
+++ b/lib/rouge/formatters/terminal256.rb
@@ -83,7 +83,7 @@ module Rouge
             attrs = []
 
             attrs << ['38', '5', fg.to_s] if fg
-            attrs << ['45', '5', bg.to_s] if bg
+            attrs << ['48', '5', bg.to_s] if bg
             attrs << '01' if style[:bold]
             attrs << '04' if style[:italic] # underline, but hey, whatevs
             escape(attrs)


### PR DESCRIPTION
At least on my OS X 10.8 terminal, the background color of `Text::Whitespace` appears as violet instead of dark:

![screenshot_01](https://f.cloud.github.com/assets/1037292/1558255/f8aa03b2-4f77-11e3-9e25-8c4326e56e44.png)
(Second line is after the patch.)

Looking at the parameters table on [Wikipedia](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes), it seems that code 48 is the correct one, not 45.
