### PR TITLE
Performance tuning for RegexLexer and HTML formatter

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -46,7 +46,7 @@ module Rouge
         yield '</pre>' if @wrap
       end
 
-      def stream_tableized(tokens, &b)
+      def stream_tableized(tokens)
         num_lines = 0
         last_val = ''
         formatted = ''
@@ -86,30 +86,27 @@ module Rouge
         yield '</div>' if @wrap
       end
 
-      def span(tok, val, &b)
-        # TODO: properly html-encode val
-        val = CGI.escape_html(val)
+      # TODO: properly html-encode val
+      TABLE_FOR_ESCAPE_HTML = {
+        '&' => '&amp;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+      }
 
-        case tok.shortname
-        when ''
+      def span(tok, val)
+        val = val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
+        shortname = tok.shortname or raise "unknown token: #{tok.inspect} for #{val.inspect}"
+
+        if shortname.empty?
           yield val
-        when nil
-          raise "unknown token: #{tok.inspect} for #{val.inspect}"
         else
           if @inline_theme
             rules = @inline_theme.style_for(tok).rendered_rules
 
-            yield '<span style='
-            yield rules.to_a.join(';').inspect
-            yield '>'
+            yield "<span style=\"#{rules.to_a.join(';')}\">#{val}</span>"
           else
-            yield '<span class='
-            yield tok.shortname.inspect
-            yield '>'
+            yield "<span class=\"#{shortname}\">#{val}</span>"
           end
-
-          yield val
-          yield '</span>'
         end
       end
     end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -322,6 +322,8 @@ module Rouge
     #   tried and each stream consumed.  Try it, it's pretty useful.
     def initialize(opts={})
       options(opts)
+
+      @debug = option(:debug)
     end
 
     # get and/or specify the options for this lexer.
@@ -344,21 +346,13 @@ module Rouge
     # is given as a block because some debug messages contain calculated
     # information that is unnecessary for lexing in the real world.
     #
+    # Calls to this method should be guarded with "if @debug" for best
+    # performance when debugging is turned off.
+    #
     # @example
-    #   debug { "hello, world!" }
-    def debug(&b)
-      # This method is a hotspot, unfortunately.
-      #
-      # For performance reasons, the "debug" option of a lexer cannot
-      # be changed once it has begun lexing.  This method will redefine
-      # itself on the first call to a noop if "debug" is not set.
-      if option(:debug)
-        def self.debug; puts yield; end
-      else
-        def self.debug; end
-      end
-
-      debug(&b)
+    #   debug { "hello, world!" } if @debug
+    def debug
+      puts yield if @debug
     end
 
     # @abstract

--- a/lib/rouge/lexers/haml.rb
+++ b/lib/rouge/lexers/haml.rb
@@ -115,7 +115,7 @@ module Rouge
           @filter_lexer = self.filters[filter_name]
           @filter_lexer.reset! unless @filter_lexer.nil?
 
-          debug { "    haml: filter #{filter_name.inspect} #{@filter_lexer.inspect}" }
+          debug { "    haml: filter #{filter_name.inspect} #{@filter_lexer.inspect}" } if @debug
         end
 
         mixin :eval_or_plain

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -42,8 +42,8 @@ module Rouge
           interp = /[rQWxI]/ === m[1]
           toktype = Str::Other
 
-          debug { "    open: #{open.inspect}" }
-          debug { "    close: #{close.inspect}" }
+          debug { "    open: #{open.inspect}" } if @debug
+          debug { "    close: #{close.inspect}" } if @debug
 
           # regexes
           if m[1] == 'r'
@@ -269,7 +269,7 @@ module Rouge
             <<? | >>? | <=>? | >= | ===?
           )
         )x do |m|
-          debug { "matches: #{[m[0], m[1], m[2], m[3]].inspect}" }
+          debug { "matches: #{[m[0], m[1], m[2], m[3]].inspect}" } if @debug
           groups Name::Class, Operator, Name::Function
           pop!
         end

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -109,13 +109,13 @@ module Rouge
 
         rule /[\[{(]/ do |m|
           @macro_delims[delim_map[m[0]]] += 1
-          debug { "    macro_delims: #{@macro_delims.inspect}" }
+          debug { "    macro_delims: #{@macro_delims.inspect}" } if @debug
           token Punctuation
         end
 
         rule /[\]})]/ do |m|
           @macro_delims[m[0]] -= 1
-          debug { "    macro_delims: #{@macro_delims.inspect}" }
+          debug { "    macro_delims: #{@macro_delims.inspect}" } if @debug
           pop! if macro_closed?
           token Punctuation
         end

--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -17,7 +17,7 @@ module Rouge
 
       # reset the indentation levels
       def reset_indent
-        debug { "    yaml: reset_indent" }
+        debug { "    yaml: reset_indent" } if @debug
         @indent_stack = [0]
         @next_indent = 0
         @block_scalar_indent = nil
@@ -39,12 +39,12 @@ module Rouge
       # Save a possible indentation level
       def save_indent(match)
         @next_indent = match.size
-        debug { "    yaml: indent: #{self.indent}/#@next_indent" }
-        debug { "    yaml: popping indent stack - before: #@indent_stack" }
+        debug { "    yaml: indent: #{self.indent}/#@next_indent" } if @debug
+        debug { "    yaml: popping indent stack - before: #@indent_stack" } if @debug
         if dedent?(@next_indent)
           @indent_stack.pop while dedent?(@next_indent)
-          debug { "    yaml: popping indent stack - after: #@indent_stack" }
-          debug { "    yaml: indent: #{self.indent}/#@next_indent" }
+          debug { "    yaml: popping indent stack - after: #@indent_stack" } if @debug
+          debug { "    yaml: indent: #{self.indent}/#@next_indent" } if @debug
 
           # dedenting to a state not previously indented to is an error
           [match[0...self.indent], match[self.indent..-1]]
@@ -54,7 +54,7 @@ module Rouge
       end
 
       def continue_indent(match)
-        debug { "    yaml: continue_indent" }
+        debug { "    yaml: continue_indent" } if @debug
         @next_indent += match.size
       end
 

--- a/lib/rouge/token.rb
+++ b/lib/rouge/token.rb
@@ -1,9 +1,9 @@
 module Rouge
   class Token
     class << self
-      def name; @name; end
-      def parent; @parent; end
-      def shortname; @shortname; end
+      attr_reader :name
+      attr_reader :parent
+      attr_reader :shortname
 
       def cache
         @cache ||= {}

--- a/lib/rouge/util.rb
+++ b/lib/rouge/util.rb
@@ -72,14 +72,14 @@ module Rouge
     def starts_block(block_state)
       @block_state = block_state
       @block_indentation = @last_indentation || ''
-      debug { "    starts_block #{block_state.inspect}" }
-      debug { "    block_indentation: #{@block_indentation.inspect}" }
+      debug { "    starts_block #{block_state.inspect}" } if @debug
+      debug { "    block_indentation: #{@block_indentation.inspect}" } if @debug
     end
 
     # handle a single indented line
     def indentation(indent_str)
-      debug { "    indentation #{indent_str.inspect}" }
-      debug { "    block_indentation: #{@block_indentation.inspect}" }
+      debug { "    indentation #{indent_str.inspect}" } if @debug
+      debug { "    block_indentation: #{@block_indentation.inspect}" } if @debug
       @last_indentation = indent_str
 
       # if it's an indent and we know where to go next,


### PR DESCRIPTION
## TL;DR

Merge it to make Rouge 2x as fast.
## Story

This branch is called "[hiddensee](https://en.wikipedia.org/wiki/Hiddensee)" because that's where I am right now, on holiday ;-)

Continuing my tinkering with the internals of CodeRay and Rouge, I dug deeper into the DSL-/rule-based lexer system, comparing it to CodeRay's hand-written approach to find out where they differ and what's standing in the way of better performance. It took a few days, but I think I have a set of patches ready that make Rouge much faster than current master (especially faster than Pygments.rb) without changing any of the lexer's definitions.

I tried to reduce the changes to a minimum, and while some of them may have a relatively minor impact on performance, all of them together give Rouge a remarkable speed boost, running at least twice as fast in my benchmarks.
## Benchmarks

The tests include example inputs in C, CSS, HTML, JavaScript, JSON, Perl, and Ruby.

![hiddensee-shootout](https://f.cloud.github.com/assets/1037292/1588351/095e40d6-524f-11e3-9ba1-e6bb4f1f55f7.png)

Depending on input size, Pygments.rb is mostly faster than Rouge right now for files larger than 1kB. Below that, the additional overhead of switching to Python seems to slow it down.

With these patches, Rouge can match and surpass Pygments' speed, even for large files.

If you have Numbers, you can [download](https://www.dropbox.com/s/axfghoxczmqzooa/Shootout%20hiddensee.numbers) the detailed result tables that I used to create the graph. All benchmarks were done with Ruby 2.0.0p247 on the [Shootout](https://github.com/rubychan/shootout) v1.6.
## Changes

Here's an overview of the changes, roughly ordered by the impact they have on performance:
### Lexer / RegexLexer
- Unroll deeply nested calls during rule recognition and rule execution. Especially:
  - Remove `#with_output_stream`. I found no reason for the use of `Enumerator::Yielder`; the whole thing with the nested callbacks seemed pretty convoluted, but perhaps I'm missing something?
  - Remove the block parameter from `#step`, because the value is static. Instead, `@output_stream` is set by `#stream_tokens` at the beginning.
  - The three main actions (token, state push and `:pop!`) are no longer using DRY method calls, but are optimized to manipulate the stack and output stream directly. This allows for several other optimizations, like knowing that the state is already a Symbol when pushing. They also make use of the given `stream` parameter.
  - `::get_state` uses Symbols instead of Strings as keys for the `states` hash now, because we can directly try `@states[next_state]` when pushing.
  - Inline `#run_rule` and `#run_callback` into the `#step` method to reduce the number of method calls considerably, and use local variables as far as possible. This allows using `next` instead of `return`.
- Using `if @debug` as a guard for debug statements, because evaluating an instance variable is much faster than calling a method with a block. This eliminates the need for the hack that redefines the method when it's called for the first time, but makes `debug { … }` lines a bit more ugly.
- Optimize the hotspot, `#step`:
  - Use `StringScanner#skip` instead of `StringScanner#scan`, because it's faster, and the size of the match is more useful at this point than the match itself.
  - Check `@null_steps` only after incrementing it.
  - Use `if` instead of `case` in `#step`, and rely on `rule` being a `Rule` when it's not a `State`.
  - Make `Rule#beginning_of_line` an attribute instead of a method.
- Define `@states` as a cache for `self.class.states`.
- Define `@null_steps` beforehand because we need it anyway.
- Set the default value for the second parameter of `#token` directly in the signature. Using a magic value like `:__absent__` seems strange to me.
- `Token#name`, `#parent`, and `#shortname` are now attributes instead of methods.
### HTML formatter
- Replace `CGI.escape_html` (which is quite slow) with a simplified version that only escapes `&`, `<`, and `>`.
  - In my opinion there's no need to escape `"`, `'`, and `/` outside of argument lists and script tags.
  - I left your TODO in because I'm not sure what it was about.
- Optimize the hotspot, `#span`:
  - Combine `yield` calls as much as possible.
  - Don't use `inspect` to wrap the token shortname in quotes. Its definition could change in the future, and it's faster to add the quotes to the wrapping strings.
  - Call `tok.shortname` only once.
  - Use `if` instead of `case`.
- Remove block parameter in `#stream_tableized` and `span` (it already uses `yield` instead).
## Open issues

There are more things that I wanted to optimize:
- The `@group_count = 0` line in `#step` looks awfully wasteful, but I couldn't find a better way.
- Do we really need the `@null_steps` check? It seems to be a good tool for debugging, but the Lexers shouldn't have such bugs in the first place. Silently failing here is also a bit weird…it would be great to get rid of this construction.

Cheers!
