### PR TITLE
New theme version, wrap options, inline theme settings and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,34 @@ formatter.format(lexer.lex(source))
 Rouge::Themes::ThankfulEyes.render(:scope => '.highlight')
 ```
 
+####Full options:
+
+Formatter options:
+
+      css_class: 'highlight'  #  Apply a class to the syntax-highlighted output.
+                              #  Set to false to not apply any css class
+      line_numbers: false     #  Generate line numbers.
+      inline_theme: nil       #  A Rouge::CSSTheme used to highlight the output with inline styles
+                              #  instead of classes. Allows string inputs (separate mode with a dot):
+                              #  %w[colorful github monokai monokai.sublime thankful_eyes base16
+                              #     base16.dark base16.light base16.solarized base16.monokai]
+      wrap: true              #  Wrap the highlighted content in a container
+                              #  Defaults to <pre> or <div> if :line_numbers are enabled
+                              #  Use :pre_code for redcarpet style format, or false for no container
+
+Lexer options:
+
+      debug: false            #  Print a trace of the lex on stdout
+      parent: ''              #  Allows you to specify which language the template is inside
+
+CSS theme options:
+
+      scope: '.highlight'     #  CSS selector that styles are applied to
+                              #  E.g. Rouge::Themes::Monokai.mode(:sublime).render(scope: 'code')
+
 Rouge aims to be simple to extend, and to be a drop-in replacement for pygments, with the same quality of output.
 
-Also, Rouge ships with a `rougify` command which allows you to easily highlight files in your terminal: 
+Also, Rouge ships with a `rougify` command which allows you to easily highlight files in your terminal:
 
 ``` bash
 $ rougify foo.rb

--- a/lib/rouge/themes/monokai.rb
+++ b/lib/rouge/themes/monokai.rb
@@ -19,6 +19,79 @@ module Rouge
       palette :soft_yellow    => '#e6db74'
       palette :very_dark      => '#1e0010'
       palette :whitish        => '#f8f8f2'
+      palette :orange         => '#f6aa11'
+      palette :white          => '#ffffff'
+
+      extend HasModes
+
+      def self.sublime!
+        mode! :sublime
+      end
+
+      def self.make_sublime!
+        style Generic::Heading,                 :fg => :grey
+        style Literal::String::Regex,           :fg => :orange
+        style Generic::Output,                  :fg => :dark_grey
+        style Generic::Prompt,                  :fg => :emperor
+        style Generic::Strong,                  :bold => false
+        style Generic::Subheading,              :fg => :light_grey
+        style Name::Builtin,                    :fg => :orange
+        style Comment::Multiline,
+              Comment::Preproc,
+              Comment::Single,
+              Comment::Special,
+              Comment,                          :fg => :dimgrey
+        style Error,
+        Generic::Error,
+        Generic::Traceback,                     :fg => :carmine
+        style Generic::Deleted,
+              Generic::Inserted,
+              Generic::Emph,                    :fg => :dark
+        style Keyword::Constant,
+              Keyword::Declaration,
+              Keyword::Reserved,
+              Name::Constant,
+              Keyword::Type,                    :fg => :soft_cyan
+        style Literal::Number::Float,
+              Literal::Number::Hex,
+              Literal::Number::Integer::Long,
+              Literal::Number::Integer,
+              Literal::Number::Oct,
+              Literal::Number,
+              Literal::String::Char,
+              Literal::String::Escape,
+              Literal::String::Symbol,          :fg => :light_violet
+        style Literal::String::Doc,
+              Literal::String::Double,
+              Literal::String::Backtick,
+              Literal::String::Heredoc,
+              Literal::String::Interpol,
+              Literal::String::Other,
+              Literal::String::Single,
+              Literal::String,                  :fg => :soft_yellow
+        style Name::Attribute,
+              Name::Class,
+              Name::Decorator,
+              Name::Exception,
+              Name::Function,                   :fg => :bright_green
+        style Name::Variable::Class,
+              Name::Namespace,
+              Name::Label,
+              Name::Entity,
+              Name::Builtin::Pseudo,
+              Name::Variable::Global,
+              Name::Variable::Instance,
+              Name::Variable,
+              Text::Whitespace,
+              Text,
+              Name,                             :fg => :white
+        style Operator::Word,
+              Name::Tag,
+              Keyword,
+              Keyword::Namespace,
+              Keyword::Pseudo,
+              Operator,                         :fg => :bright_pink
+      end
 
       style Comment,
             Comment::Multiline,


### PR DESCRIPTION
Please make sure this patch is backwards compatible, also the documentation may be a bit off.
If it all works I will update the `middleman-syntax` readme with the new stuff too.

Update 2014/04/05: Updated and squashed commits to fix new specs which were failing (https://github.com/jayferd/rouge/commit/f8fcf193085e99c513f8167750bb4f33af9fa9a9). Added a hack to allow `css_class: false` instead of `css_class: nil` which I think is more elegant - I'll leave it to you to refactor that and the other `inline_theme` stuff.
