### PR TITLE
Sort available lexers by its tag

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -323,7 +323,7 @@ module Rouge
       def run
         puts "== Available Lexers =="
 
-        Lexer.all.each do |lexer|
+        Lexer.all.sort_by(&:tag).each do |lexer|
           desc = "#{lexer.desc}"
           if lexer.aliases.any?
             desc << " [aliases: #{lexer.aliases.join(',')}]"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -53,7 +53,7 @@ describe Rouge::CLI do
       it 'lists available lexers' do
         out, err = capture_io { subject.run }
 
-        expected_tags = Rouge::Lexer.all.map(&:tag)
+        expected_tags = Rouge::Lexer.all.map(&:tag).sort
         actual_tags = out.scan(/^(.*?):/).flatten
 
         assert_equal expected_tags, actual_tags, "err: #{err.inspect}"


### PR DESCRIPTION
When running `roughify list` I thought it might be useful to sort available lexers by its tag helping my eyes to find my favorite language :)
## Before

``` bash
$ rougify | head -10
== Available Lexers ==
haml: The Haml templating system for Ruby (haml.info) [aliases: HAML]

elixir: Elixir language (elixir-lang.org)

prolog: The Prolog programming language (http://en.wikipedia.org/wiki/Prolog) [aliases: prolog]

smalltalk: The Smalltalk programming language [aliases: st,squeak]

make: Makefile syntax [aliases: makefile,mf,gnumake,bsdmake]
```
## After

``` bash
$ rougify | head -10
== Available Lexers ==
c: The C programming language

clojure: The Clojure programming language (clojure.org) [aliases: clj,cljs]

coffeescript: The Coffeescript programming language (coffeescript.org) [aliases: coffee,coffee-script]

common_lisp: The Common Lisp variant of Lisp (common-lisp.net) [aliases: cl,common-lisp]

conf: A generic lexer for configuration files [aliases: config,configuration]
```

WDYT?

I'm happy to squash both commits.
