### PR TITLE
Implement a null formatter

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -43,6 +43,7 @@ Dir.glob(load_dir.join('rouge/lexers/*.rb')).each { |f| load f }
 load load_dir.join('rouge/formatter.rb')
 load load_dir.join('rouge/formatters/html.rb')
 load load_dir.join('rouge/formatters/terminal256.rb')
+load load_dir.join('rouge/formatters/null.rb')
 
 load load_dir.join('rouge/theme.rb')
 load load_dir.join('rouge/themes/thankful_eyes.rb')

--- a/lib/rouge/formatters/null.rb
+++ b/lib/rouge/formatters/null.rb
@@ -1,0 +1,15 @@
+module Rouge
+  module Formatters
+    # A formatter which renders nothing.
+    class Null < Formatter
+      tag 'null'
+
+      def initialize(*)
+      end
+
+      def stream(tokens, &b)
+        tokens.to_a
+      end
+    end
+  end
+end

--- a/spec/formatters/null_spec.rb
+++ b/spec/formatters/null_spec.rb
@@ -1,0 +1,18 @@
+describe Rouge::Formatters::Null do
+  let(:subject) { Rouge::Formatters::Null.new }
+
+  it 'renders nothing' do
+    result = subject.format([[Token['Text'], 'foo']])
+
+    assert { result == '' }
+  end
+
+  it 'consumes tokens' do
+    consumed = false
+    tokens = Enumerator.new { consumed = true }
+
+    subject.format(tokens)
+
+    assert consumed
+  end
+end


### PR DESCRIPTION
While profiling `rouge` I noticed that the default formatter "distracts" the profiler too much, so I implemented a null formatter which just consumes the tokens.
