### PR TITLE
Add null to allowed JSON constants

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -179,7 +179,7 @@ module Rouge
         rule /(\{)(\s*)(\})/m do
           groups Punctuation, Text::Whitespace, Punctuation
         end
-        rule /(?:true|false)\b/, Keyword::Constant
+        rule /(?:true|false|null)\b/, Keyword::Constant
         rule /{/,  Punctuation, :object_key
         rule /\[/, Punctuation, :array
         rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float


### PR DESCRIPTION
JSON allows `null` as a value.  See: http://www.json.org/
