### PR TITLE
Fix several errors and add an option.

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -26,6 +26,7 @@ module Rouge
         @css_class = " class=#{@css_class.inspect}" if @css_class
 
         @line_numbers = opts.fetch(:line_numbers, false)
+        @start_line = opts.fetch(:start_line, 1)
         @inline_theme = opts.fetch(:inline_theme, nil)
         @inline_theme = Theme.find(@inline_theme).new if @inline_theme.is_a? String
 
@@ -66,7 +67,8 @@ module Rouge
         end
 
         # generate a string of newline-separated line numbers for the gutter>
-        numbers = %<<pre class="lineno">#{(1..num_lines).to_a.join("\n")}</pre>>
+        numbers = %<<pre class="lineno">#{(@start_line..num_lines+@start_line-1)
+          .to_a.join("\n")}</pre>>
 
         yield "<div#@css_class>" if @wrap
         yield '<table style="border-spacing: 0"><tbody><tr>'


### PR DESCRIPTION
1e6c0c6 Fixes inline_theme issue where giving the theme name as a string
doesn't work.

1cb78de Fixes line numbers issue, where line numbers doesn't appear in the same
line in google chrome.

23f7900 Adds start_line option for the cases where one doesn't want to start
with line number 1.
