### PR TITLE
Ruby: Add support for method calls with trailing dots

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -196,8 +196,8 @@ module Rouge
         mixin :has_heredocs
 
         rule /[A-Z][a-zA-Z0-9_]+/, Name::Constant, :method_call
-        rule /(\.|::)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
-          groups Punctuation, Name::Function
+        rule /(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
+          groups Punctuation, Text, Name::Function
           push :expr_start
         end
 

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -1,6 +1,57 @@
 describe Rouge::Lexers::Ruby do
   let(:subject) { Rouge::Lexers::Ruby.new }
 
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'method calling' do
+      describe 'leading dot' do
+        it 'handles whitespace between the receiver and the method' do
+          assert_tokens_equal "foo\n  .bar()",
+            ['Name', 'foo'],
+            ['Text', "\n  "],
+            ['Punctuation', '.'],
+            ['Name.Function', 'bar'],
+            ['Punctuation', '()']
+        end
+
+        it 'handles whitespace between the receiver and multiple chained methods' do
+          assert_tokens_equal "foo\n  .bar()\n  .baz",
+            ['Name', 'foo'],
+            ['Text', "\n  "],
+            ['Punctuation', '.'],
+            ['Name.Function', 'bar'],
+            ['Punctuation', '()'],
+            ['Text', "\n  "],
+            ['Punctuation', '.'],
+            ['Name.Function', 'baz']
+        end
+      end
+
+      describe 'trailing dot' do
+        it 'handles whitespace between the receiver and the method' do
+          assert_tokens_equal "foo.\n  bar()",
+            ['Name', 'foo'],
+            ['Punctuation', '.'],
+            ['Text', "\n  "],
+            ['Name.Function', 'bar'],
+            ['Punctuation', '()']
+        end
+
+        it 'handles whitespace between the receiver and multiple chained methods' do
+          assert_tokens_equal "foo.\n  bar().\n  baz",
+            ['Name', 'foo'],
+            ['Punctuation', '.'],
+            ['Text', "\n  "],
+            ['Name.Function', 'bar'],
+            ['Punctuation', '().'],
+            ['Text', "\n  "],
+            ['Name.Function', 'baz']
+        end
+      end
+    end
+  end
+
   describe 'guessing' do
     include Support::Guessing
 

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -10,6 +10,28 @@ link_to 'new', new_article_path, class: 'btn'
 a ? b:c
 
 ########
+# method calls
+########
+
+foo.bar
+foo.bar.baz
+foo.bar(123).baz()
+
+foo.
+  bar
+
+foo
+  .bar()
+  .baz
+
+foo.
+  bar
+
+foo.
+  bar().
+  baz
+
+########
 # function definitions
 ########
 


### PR DESCRIPTION
Fixes #152

I'm curious about the way you use the visual tests. Do you have some tool to make sure you won't break anything somewhere unrelated? I used ImageMagick to create a diff between the before and after screenshots but that's kind of a slow process.
