### PR TITLE
Objective-C: Add support for @import

### DIFF
--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -14,7 +14,7 @@ module Rouge
         @at_keywords ||= %w(
           selector private protected public encode synchronized try
           throw catch finally end property synthesize dynamic optional
-          interface implementation
+          interface implementation import
         )
       end
 

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -39,6 +39,8 @@ for (key in dictionary) {
 }
 
 // MyClass.h
+@import Foundation;
+
 @interface MyClass : NSObject
 {
     NSString *value;


### PR DESCRIPTION
Apple added the @import keyword to Objective-C in 2013 as part of the
introduction of modules.
