### PR TITLE
Fix visual spec layout

### DIFF
--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -3,7 +3,6 @@
 require 'rubygems'
 require 'bundler'
 Bundler.require :development
-require 'rouge'
 
 # stdlib
 require 'pathname'

--- a/spec/visual/templates/index.erb
+++ b/spec/visual/templates/index.erb
@@ -8,4 +8,5 @@
 <% @samples.each do |sample| %>
   <h2><a href="/<%= sample.tag %>"><%= sample.tag %></a></h2>
   <%= Rouge.highlight(sample.demo, sample, @formatter) %>
+  <br />
 <% end %>

--- a/spec/visual/templates/layout.erb
+++ b/spec/visual/templates/layout.erb
@@ -5,9 +5,11 @@
 
   <style type="text/css">
     <%= @theme.render %>
-    <%= @theme.render_base('pre') %>
+    <%= @theme.render_base('body') %>
+    <%= @theme.render_base('a') %>
 
-    pre { font-family: 'Ubuntu Mono', 'Monaco', monospace; }
+    pre, code { font-family: 'Source Code Pro', 'Menlo', 'Ubuntu Mono', 'Monaco', monospace; }
+    a { text-decoration: none }
 
   </style>
 </head>


### PR DESCRIPTION
Fixes the visual spec layout (the one you get when you run rackup) so it doesn't look like utter shite.
