### PR TITLE
Swift: Beta 4, 5 changes and highlighting improvements

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -95,11 +95,13 @@ module Rouge
         rule id do |m|
           if self.class.keywords.include? m[0]
             token Keyword
-          elsif %w(private internal).include? m[0]
-            token Keyword::Declaration
-            push :access_control_setting
           elsif self.class.declarations.include? m[0]
             token Keyword::Declaration
+            if %w(private internal).include? m[0]
+              push :access_control_setting
+            elsif %w(protocol class extension).include? m[0]
+              push :type_definition
+            end
           elsif self.class.types.include? m[0]
             token Keyword::Type
           elsif self.class.constants.include? m[0]
@@ -151,7 +153,7 @@ module Rouge
         mixin :root
       end
 
-      state :class do
+      state :type_definition do
         mixin :whitespace
         rule id, Name::Class, :pop!
       end

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -212,3 +212,7 @@ public class Person : NSObject {
     func random() -> Self
     optional func seed(seed: Int)
 }
+
+extension SomeClass {
+    
+}


### PR DESCRIPTION
Hi! I picked up where @ole left off in #167 and:
- fixed the problem with `private(set)`/`internal(set)` not being highlighted properly
- updated the list of attributes and declaration modifiers for Beta 5
- added coloring of classes/protocols in @objc(Class) attributes and in class, protocol and extension declarations

Note that I don't _really_ know what I'm doing, but after playing around with the visual samples, it looks good to me!
