### PR TITLE
Swift Beta 6 + improvements

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -18,7 +18,7 @@ module Rouge
 
           as dynamicType is new super self Self Type __COLUMN__ __FILE__ __FUNCTION__ __LINE__
 
-          associativity didSet get infix inout left mutating none nonmutating operator override postfix precedence prefix right set unowned unowned(safe) unowned(unsafe) weak willSet
+          associativity didSet get infix inout left mutating none nonmutating operator override postfix precedence prefix right set unowned weak willSet
         )
       end
 
@@ -71,7 +71,7 @@ module Rouge
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 
-        rule /(?!\b(if|while|for|private|internal|@objc)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
+        rule /(?!\b(if|while|for|private|internal|unowned|@objc)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
           if m[0] =~ /^[[:upper:]]/
             token Name::Constant
           else
@@ -106,6 +106,14 @@ module Rouge
             token Keyword::Declaration
           else
             groups Keyword::Declaration, Keyword::Declaration, Error, Keyword::Declaration
+          end
+        end
+
+        rule /(unowned\([ ]*)(\w+)([ ]*\))/ do |m|
+          if m[2] == 'safe' || m[2] == 'unsafe'
+            token Keyword::Declaration
+          else
+            groups Keyword::Declaration, Error, Keyword::Declaration
           end
         end
 

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -21,7 +21,7 @@ halfOpenRangeLength(3, 8)
 
 func count(string:String) -> (vowels:Int, consonants:Int, others:Int) {
     var vowels = 0, consonants = 0, emoji = 0, whitespace = 0, others = 0
-    
+
     for character in string {
 
         switch String(character).lowercaseString {
@@ -100,11 +100,11 @@ func chooseSteperFunction(backward:Bool) -> (Int) -> Int {
     func stepForward(input:Int)->Int {
         return input + 1
     }
-    
+
     func stepBackward(input:Int)->Int {
         return input + 1
     }
-    
+
     return backward ? stepBackward : stepForward
 }
 let currentValue = 5
@@ -178,36 +178,40 @@ maybeFunction!()
 //MARK: Classes
 public class Person : NSObject {
     let firstName: String
-    
+
     private var lastName: String
-    
+
     private(set) var age: Int {
     didSet {
         println("Happy Birthday")
     }
     }
-    
+
+    internal(set) var doubleAge = 0.0
+    unowned(safe) var safeUnowned = nil
+    unowned(unsafe) var unsafeUnowned = nil
+
     lazy var phoneNumbers = [String]()
     @NSCopying var modificationDate: NSDate = NSDate()
-    
+
     required public init(name: String, age: Int) {
         self.name = name
         self.age = age
         super.init()
     }
-    
+
     internal var isAdmin: Bool { return false }
-    
+
     final func doSomething() {
         //TODO: Do something
     }
-    
+
     dynamic func somethingDynamic() { }
 }
 
 @objc(MYCustomView) class CustomView: NSView, SomeProtocol , OtherProtocol {
     @IBOutlet var button: AnyObject!
-    
+
     @IBAction func doSomething(sender: AnyObject) {
         //TODO: Do something
     }
@@ -220,7 +224,7 @@ public class Person : NSObject {
 }
 
 extension SomeClass {
-    
+
 }
 
 struct Stack<T, U>: Equatable {


### PR DESCRIPTION
- new `@availability(...)` attribute, as well as `unowned(safe)`, `unowned(unsafe)` are now rendered properly
- `default:` in switches is fixed
- the function/method name in optional calls (`foo?()`/`foo!()`) is highlighted properly
- coloring custom types properly in a few places
- refactoring

---

Besides the changes in the PR, I started thinking if we shouldn't just highlight all capitalized identifiers as `Name.Constant`. There's nothing, strictly speaking, stopping people from calling their class `foo` or their variable `Bar`, but the convention _strongly_ encourages UpperCamelCase for types (classes, structs, enums) and enum cases, and lowerCamelCase for variables and functions. You can't possibly distinguish the two with a lexer, so there's a chance of a false positive, but I think in 99% of the cases the convention would do a good job at it, and types would stand out better in highlighted code.

Am I thinking about this correctly or am I missing something? @jneen, @ole, thoughts?
