### PR TITLE
HTML: Add dash to the allowed characters in tag names

### DIFF
--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -33,8 +33,8 @@ module Rouge
           push :tag
         end
 
-        rule %r(<\s*[a-zA-Z0-9:]+), Name::Tag, :tag # opening tags
-        rule %r(<\s*/\s*[a-zA-Z0-9:]+\s*>), Name::Tag # closing tags
+        rule %r(<\s*[a-zA-Z0-9:-]+), Name::Tag, :tag # opening tags
+        rule %r(<\s*/\s*[a-zA-Z0-9:-]+\s*>), Name::Tag # closing tags
       end
 
       state :comment do

--- a/spec/lexers/html_spec.rb
+++ b/spec/lexers/html_spec.rb
@@ -8,6 +8,17 @@ describe Rouge::Lexers::HTML do
     assert_no_errors '<script>x && x < y;</script>'
   end
 
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'element names' do
+      it 'allow dashes to support custom elements' do
+        assert_tokens_equal '<custom-element></custom-element>',
+                            ['Name.Tag', '<custom-element></custom-element>']
+      end
+    end
+  end
+
   describe 'guessing' do
     include Support::Guessing
 


### PR DESCRIPTION
In the Angular universe we use custom elements all over the place, but rouge currently thinks they're errors.

Dashes are allowed in custom elements in HTML5 per this article
http://www.html5rocks.com/en/tutorials/webcomponents/customelements/

I tried to look for something more 'spec-like' than that article but couldn't quite. But no modern browsers have problems with dashes in element names.
