### PR TITLE
add \b separator tail of Keyword::Type rule

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -42,7 +42,7 @@ module Rouge
         rule /@#{id}/, Name::Decorator
         rule /(?:#{keywords.join('|')})\b/, Keyword
         rule /(?:#{declarations.join('|')})\b/, Keyword::Declaration
-        rule /(?:#{types.join('|')})/, Keyword::Type
+        rule /(?:#{types.join('|')})\b/, Keyword::Type
         rule /package\b/, Keyword::Namespace
         rule /(?:true|false|null)\b/, Keyword::Constant
         rule /(?:class|interface)\b/, Keyword::Declaration, :class


### PR DESCRIPTION
When using java lexer, some words which start with type name are highlighted partially.
For example

| Input | Ouput | Expected |
| --- | --- | --- |
| intent | <strong>int</strong>ent | intent |
| longest | <strong>long</strong>est | longest |

This pull request will fix this.
