### PR TITLE
Whitelisting the ASCII-8BIT encoding

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -292,7 +292,7 @@ module Rouge
 
       # @private
       def assert_utf8!(str)
-        return if %w(US-ASCII UTF-8).include? str.encoding.name
+        return if %w(US-ASCII UTF-8 ASCII-8BIT).include? str.encoding.name
         raise EncodingError.new(
           "Bad encoding: #{str.encoding.names.join(',')}. " +
           "Please convert your string to UTF-8."


### PR DESCRIPTION
This is what regular ASCII seems to report itself as on OSX
