### PR TITLE
Add CSS class to pre tag instead of code tag

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -46,7 +46,7 @@ module Rouge
 
     private
       def stream_untableized(tokens, &b)
-        yield "<pre><code#@css_class>" if @wrap
+        yield "<pre#@css_class><code>" if @wrap
         tokens.each{ |tok, val| span(tok, val, &b) }
         yield "</code></pre>\n" if @wrap
       end

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -7,7 +7,7 @@ describe Rouge::Formatters::HTML do
 
   it 'formats a simple token stream' do
     out = subject.format([[Token['Name'], 'foo']])
-    assert { out == %(<pre><code class="highlight"><span class="n">foo</span></code></pre>\n) }
+    assert { out == %(<pre class="highlight"><code><span class="n">foo</span></code></pre>\n) }
   end
 
   describe 'skipping the wrapper' do

--- a/spec/plugins/redcarpet_spec.rb
+++ b/spec/plugins/redcarpet_spec.rb
@@ -26,8 +26,8 @@ foo=1
 ```
     mkd
 
-    assert { result.include?(%<<code class="highlight shell">>) }
-    assert { result.include?(%<<code class="highlight javascript">>) }
+    assert { result.include?(%(<pre class="highlight shell"><code>)) }
+    assert { result.include?(%(<pre class="highlight javascript"><code>)) }
   end
 
   it 'guesses' do
@@ -37,7 +37,7 @@ foo=1
 ```
     mkd
 
-    assert { result.include?(%<<code class="highlight xml">>) }
+    assert { result.include?(%(<pre class="highlight xml"><code>)) }
   end
 
   it 'passes options' do
@@ -48,7 +48,7 @@ foo=1
     mkd
 
     # TODO: test that an option is actually there
-    assert { result.include?(%<<code class="highlight shell">>) }
+    assert { result.include?(%(<pre class="highlight shell"><code>)) }
   end
 
   it 'works when no language is provided' do
@@ -58,6 +58,6 @@ foo=1
 $stdin.each { |l| $stdout.puts l.reverse }
 ```
     mkd
-    assert { result.include?(%(<code class="highlight ruby">)) }
+    assert { result.include?(%(<pre class="highlight ruby"><code>)) }
   end
 end


### PR DESCRIPTION
Background colours have been broken since `v1.4.0`, as noted here: https://github.com/jneen/rouge/pull/141#issuecomment-45667410

This is because the highlight CSS class is added to the `code` tag, which is an inline element. Adding the class to the surrounding `pre` tag makes the background display correctly, since it's a block element.
