### PR TITLE
Add apache keywords file to gemspec

### DIFF
--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   desc
   s.homepage = "http://github.com/jneen/rouge"
   s.rubyforge_project = "rouge"
-  s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'bin/rougify', 'lib/rouge/demos/*']
+  s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.license = 'MIT (see LICENSE file)'
 end


### PR DESCRIPTION
The file lexers/apache/keywords.yml was missing from the built gem and nothing worked in 1.7.5 :) Fixed this for now, so I can work on #201.
