### PR TITLE
Add Velocity template support.

### DIFF
--- a/lib/rouge/demos/velocity
+++ b/lib/rouge/demos/velocity
@@ -1,0 +1,28 @@
+
+#*
+ There is multi-line comment.
+ see this text because the Velocity Templating Engine will ignore it.
+*#
+<h3>List</h3>
+## This is a single line comment.
+#if( $allProducts )
+<p>not found.</p>
+#else
+
+<table>
+  <tbody>
+    #foreach( $product in $allProducts )
+    <tr id="product-$product.Id" data-url="#SURL("$!product.Slug")">
+      <td>$product.Title</td>
+    </tr>
+    #end
+  </tbody>
+</table>
+#end
+#set( $monkey.Say = ["Not", $my, "fault", 10, false, null] ) ## ArrayList
+${mudSlinger}
+${customer.Address}
+${purchase.getTotal(true)}
+$title.set( "Homage to Catalonia" )
+
+

--- a/lib/rouge/lexers/velocity.rb
+++ b/lib/rouge/lexers/velocity.rb
@@ -3,13 +3,13 @@
 module Rouge
   module Lexers
     class Velocity < TemplateLexer
-      title "Velocity"
-      desc "Generic `Velocity <http://velocity.apache.org/>`_ template lexer."
+      title 'Velocity'
+      desc 'Generic `Velocity <http://velocity.apache.org/>`_ template lexer.'
       tag 'velocity'
       filenames '*.vm', '*.velocity', '*.fhtml'
       mimetypes 'text/html+velocity'
 
-      IDENTIFIER = '[a-zA-Z_]\w*'
+      IDENTIFIER = IDENTIFIER = /[a-zA-Z_]\w*/
 
       def self.analyze_text(text)
         rv = 0.0

--- a/lib/rouge/lexers/velocity.rb
+++ b/lib/rouge/lexers/velocity.rb
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Velocity < TemplateLexer
+      title "Velocity"
+      desc "Generic `Velocity <http://velocity.apache.org/>`_ template lexer."
+      tag 'velocity'
+      filenames '*.vm', '*.velocity', '*.fhtml'
+      mimetypes 'text/html+velocity'
+
+      IDENTIFIER = '[a-zA-Z_]\w*'
+
+      def self.analyze_text(text)
+        rv = 0.0
+        if text =~ /#\{?macro\}?\(.*?\).*?#\{?end\}?/
+          rv += 0.25
+        end
+
+        if text =~ /#\{?if\}?\(.+?\).*?#\{?end\}?/
+          rv += 0.15
+        end
+
+        if text =~ /#\{?foreach\}?\(.+?\).*?#\{?end\}?/
+          rv += 0.15
+        end
+
+        if text =~ /\$\{?[a-zA-Z_]\w*(\([^)]*\))?(\.\w+(\([^)]*\))?)*\}?/
+          rv += 0.01
+        end
+
+        rv
+      end
+
+      state :root do
+        rule /[^{#$]+/, Other
+
+        rule /(#)(\*.*?\*)(#)/m do
+          groups Comment::Preproc, Comment, Comment::Preproc
+        end
+
+        rule /(##)(.*?$)/ do
+          groups Comment::Preproc, Comment
+        end
+
+        rule /(#\{?)(#{IDENTIFIER})(\}?)(\s?\()/m do
+          groups Punctuation, Name::Function, Punctuation, Punctuation do
+            goto :directiveparams
+          end
+        end
+
+        rule /(#\{?)(#{IDENTIFIER})(\}|\b)/m do
+          groups Punctuation, Name::Function, Punctuation
+        end
+
+        rule /\$\{?/, Punctuation, :variable
+      end
+
+      state :variable do
+        rule /#{IDENTIFIER}/, Name::Variable
+        rule /\(/, Punctuation, :funcparams
+        rule /(\.)(#{IDENTIFIER})/ do
+          groups Punctuation, Name::Variable do
+            goto :push
+          end
+        end
+        rule /\}/, Punctuation, :pop!
+        rule /./, Str::Char, :pop!
+      end
+
+      state :directiveparams do
+        rule /(&&|\|\||==?|!=?|[-<>+*%&|^\/])|\b(eq|ne|gt|lt|ge|le|not|in)\b/, Operator
+        rule /\[/, Operator, :rangeoperator
+        rule /\b#{IDENTIFIER}\b/, Name::Function
+        mixin :funcparams
+      end
+
+      state :rangeoperator do
+        rule /\.\./, Operator
+        mixin :funcparams
+        rule /\]/, Operator, :pop!
+      end
+
+      state :funcparams do
+        rule /\$\{?/, Punctuation, :variable
+        rule /\s+/, Text
+        rule /,/, Punctuation
+        rule /"(\\\\|\\"|[^"])*"/, Str::Double
+        rule /'(\\\\|\\'|[^'])*'/, Str::Single
+        rule /0[xX][0-9a-fA-F]+[Ll]?/, Literal::Number
+        rule /\b[0-9]+\b/, Literal::Number
+        rule /(true|false|null)\b/, Keyword::Constant
+        rule /\(/, Punctuation, :push
+        rule /\)/, Punctuation, :push
+        rule /\[/, Punctuation, :push
+        rule /\]/, Punctuation, :push
+        rule /\}/, Punctuation, :pop!
+      end
+
+    end
+  end
+end

--- a/spec/lexers/velocity_spec.rb
+++ b/spec/lexers/velocity_spec.rb
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Velocity do
+  let(:subject) { Rouge::Lexers::Velocity.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.velocity'
+      assert_guess :filename => 'foo.vm'
+      assert_guess :filename => 'foo.fhtml'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/html+velocity'
+    end
+  end
+end

--- a/spec/visual/samples/velocity
+++ b/spec/visual/samples/velocity
@@ -1,0 +1,28 @@
+
+#*
+ There is multi-line comment.
+ see this text because the Velocity Templating Engine will ignore it.
+*#
+<h3>List</h3>
+## This is a single line comment.
+#if( $allProducts )
+<p>not found.</p>
+#else
+
+<table>
+  <tbody>
+    #foreach( $product in $allProducts )
+    <tr id="product-$product.Id" data-url="#SURL("$!product.Slug")">
+      <td>$product.Title</td>
+    </tr>
+    #end
+  </tbody>
+</table>
+#end
+#set( $monkey.Say = ["Not", $my, "fault", 10, false, null] ) ## ArrayList
+${mudSlinger}
+${customer.Address}
+${purchase.getTotal(true)}
+$title.set( "Homage to Catalonia" )
+
+


### PR DESCRIPTION
https://bitbucket.org/birkenfeld/pygments-main/src/f114940f5aeb4775eef157e7089f462b49bdc127/pygments/lexers/templates.py?at=default&fileviewer=file-view-default

We need highlight [Velocity](https://velocity.apache.org) templates on GitLab web page, because we have a lot of developers use that.
