### PR TITLE
Rust code highlighting fixes

### DIFF
--- a/lib/rouge/demos/rust
+++ b/lib/rouge/demos/rust
@@ -1,12 +1,33 @@
-use core::*;
+#![allow(dead_code)]
+
+#[derive(Debug, Copy, Clone)]
+struct Vector {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+fn test_big_number() -> u64 { 
+    2_000_000 
+}
+
+fn test_documentation() {
+    unreachable!()
+}
 
 fn main() {
-    for ["Alice", "Bob", "Carol"].each |&name| {
-        do task::spawn {
-            let v = rand::Rng().shuffle([1, 2, 3]);
-            for v.each |&num| {
-                io::print(fmt!("%s says: '%d'\n", name, num))
-            }
+    let program = "+ + * - /";
+    let mut accumulator = 0;
+
+    for token in program.chars() {
+        match token {
+            '+' => accumulator += 1,
+            '-' => accumulator -= 1,
+            '*' => accumulator *= 2,
+            '/' => accumulator /= 2,
+            _ => { /* ignore everything else */ }
         }
     }
+
+    println!("The program \"{}\" calculates the value {}", program, accumulator);
 }

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -50,14 +50,14 @@ module Rouge
       id = /[a-z_]\w*/i
       hex = /[0-9a-f]/i
       escapes = %r(
-        \\ ([nrt'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
+        \\ ([nrt"'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
       )x
       size = /8|16|32|64/
 
       state :start_line do
         mixin :whitespace
         rule /\s+/, Text
-        rule /#\[/ do
+        rule /#!*\[/ do
           token Comment::Preproc; push :attribute
         end
         rule(//) { pop! }
@@ -86,7 +86,7 @@ module Rouge
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
         rule /[()\[\]{}|,:;]/, Punctuation
-        rule /[*!@~&+%^<>=-]/, Operator
+        rule /[*!#@~\/&+%^.<>=-]/, Operator
 
         rule /([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule /[.]\s*#{id}/, Name::Property
@@ -155,7 +155,7 @@ module Rouge
         flt = /f32|f64/
 
         rule %r(
-          [0-9]+
+          [0-9_]+
           (#{dot}  #{exp}? #{flt}?
           |#{dot}? #{exp}  #{flt}?
           |#{dot}? #{exp}? #{flt}
@@ -165,7 +165,7 @@ module Rouge
         rule %r(
           ( 0b[10_]+
           | 0x[0-9a-fA-F-]+
-          | [0-9]+
+          | [0-9_]+
           ) (u#{size}?|i#{size})?
         )x, Num::Integer
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -54,15 +54,6 @@ module Rouge
       )x
       size = /8|16|32|64/
 
-      state :start_line do
-        mixin :whitespace
-        rule /\s+/, Text
-        rule /#!*\[/ do
-          token Comment::Preproc; push :attribute
-        end
-        rule(//) { pop! }
-      end
-
       state :attribute do
         mixin :whitespace
         mixin :has_literals
@@ -78,11 +69,15 @@ module Rouge
       end
 
       state :root do
-        rule /\n/, Text, :start_line
+        rule /\n/, Text
         mixin :whitespace
         rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals
-
+        
+        rule /#!*\[/ do
+          token Comment::Preproc; push :attribute
+        end
+        
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
         rule /[()\[\]{}|,:;]/, Punctuation

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -53,6 +53,15 @@ module Rouge
         \\ ([nrt"'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
       )x
       size = /8|16|32|64/
+      
+      state :start_line do
+        mixin :whitespace
+        rule /\s+/, Text
+        rule /#\[/ do
+          token Comment::Preproc; push :attribute
+        end
+        rule(//) { pop! }
+      end
 
       state :attribute do
         mixin :whitespace
@@ -69,7 +78,7 @@ module Rouge
       end
 
       state :root do
-        rule /\n/, Text
+        rule /\n/, Text, :start_line
         mixin :whitespace
         rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals


### PR DESCRIPTION
Fixes incorrect highlighting of:
- String escapes
- Feature gates, attributes
- Underscores in numbers
