### PR TITLE
new lexer: octave

### DIFF
--- a/lib/rouge/demos/octave
+++ b/lib/rouge/demos/octave
@@ -1,0 +1,6 @@
+A = cat( 3, [1 2 3; 9 8 7; 4 6 5], [0 3 2; 8 8 4; 5 3 5], ...
+                 [6 4 7; 6 8 5; 5 4 3]);
+# The EIG function is applied to each of the horizontal 'slices' of A.
+for i = 1:3
+    eig(squeeze(A(i,:,:)))
+endfor

--- a/lib/rouge/lexers/octave.rb
+++ b/lib/rouge/lexers/octave.rb
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    load_lexer 'matlab.rb'
+
+    class Octave < Matlab
+      title "GNU Octave"
+      desc "Octave"
+      tag 'octave'
+      aliases 'm'
+      filenames '*.m'
+      mimetypes 'text/x-octave', 'application/x-octave'
+
+      def self.analyze_text(text)
+        return 0.4 if text.match(/^\s*% /) # % comments are a dead giveaway
+      end
+
+      def self.keywords
+        @keywords ||= %w(
+          do end_try_catch end_unwind_protect endfor endfunction endif
+          endparfor endswitch endwhile static until unwind_protect
+          unwind_protect_cleanup varargin varargout
+        )
+      end
+
+      state :root do
+        rule /\s+/m, Text # Whitespace
+        rule %r([{]%.*?%[}])m, Comment::Multiline
+        rule /[%#].*$/, Comment::Single
+        rule /([.][.][.])(.*?)$/ do
+          groups(Keyword, Comment)
+        end
+
+        rule /^(!)(.*?)(?=%|$)/ do |m|
+          token Keyword, m[1]
+          delegate Shell, m[2]
+        end
+
+
+        rule /[a-zA-Z][_a-zA-Z0-9]*/m do |m|
+          match = m[0]
+          if self.class.keywords.include? match
+            token Keyword
+          elsif self.class.builtins.include? match
+            token Name::Builtin
+          else
+            token Name
+          end
+        end
+
+        rule %r{[(){};:,\/\\\]\[]}, Punctuation
+
+        rule /~=|==|<<|>>|[-~+\/*%=<>&^|.@]/, Operator
+
+
+        rule /(\d+\.\d*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
+        rule /\d+e[+-]?[0-9]+/i, Num::Float
+        rule /\d+L/, Num::Integer::Long
+        rule /\d+/, Num::Integer
+
+        rule /'(?=(.*'))/, Str::Single, :string
+        rule /'/, Operator
+      end
+
+      state :string do
+        rule /[^']+/, Str::Single
+        rule /''/, Str::Escape
+        rule /'/, Str::Single, :pop!
+      end
+    end
+  end
+end

--- a/spec/lexers/octave_spec.rb
+++ b/spec/lexers/octave_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Octave do
+  let(:subject) { Rouge::Lexers::Octave.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.m', :source => '# comment'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-octave'
+      assert_guess :mimetype => 'application/x-octave'
+    end
+  end
+end

--- a/spec/visual/samples/matlab
+++ b/spec/visual/samples/matlab
@@ -25,9 +25,9 @@ disp('a comment symbol, %, in a string');
 function y=myfunc(x)
 y = exp(x);
 
- {%
+%{
 a block comment
- %}
+%}
 
 
 function myfunc(s)

--- a/spec/visual/samples/octave
+++ b/spec/visual/samples/octave
@@ -1,0 +1,49 @@
+function zz=sample(aa)
+%%%%%%%%%%%%%%%%%%
+% some comments
+%%%%%%%%%%%%%%%%%%
+
+x = 'a string';    % some 'ticks' in a comment
+y = 'a string with ''interal'' quotes';
+xx = "a string";
+yy = "a string with \"interal\" quotes";
+
+for i=1:20
+  disp(i);
+endfor
+
+for i=1:20
+  disp(i);
+end
+
+a = rand(30);
+b = rand(30);
+
+c = a .* b ./ a \ ... comment at end of line and continuation
+    (b .* a + b - a);
+
+c = a' * b';  % note: these ticks are for transpose, not quotes.
+
+disp('a comment symbol, %, in a string');
+disp("a comment symbol, %, in a string");
+
+
+!echo abc % this isn't a comment - it's passed to system command
+
+function y=myfunc(x)
+y = exp(x);
+end
+
+%{
+a block comment
+%}
+
+#{
+a block comment
+#}
+
+
+
+function myfunc(s)
+    a = 1;
+endfunction


### PR DESCRIPTION
Here some proposal for a GNU Octave lexer. My approach was to copy everything related to Matlab and make some inheritance like with "C" and "ObjectiveC".

The problem I am facing is that the GNU Octave language is a superset of the Matlab language, e.g. `for .. end` vs. `for ... endfor`, and so on. So the detection mechanism cannot decide whether a Matlab example is Matlab or Octave code, which isn't decidable by definition. How to resolve such issues, or simply ignore them?