### PR TITLE
[Cpp]Fix float suffix, add binary, closes #577

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -57,9 +57,11 @@ module Rouge
 
       prepend :statements do
         rule /class\b/, Keyword, :classname
-        rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
-        rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float
+        rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lf]?)?)i, Num::Float
+        rule %r(0x(\h[.]\h?|[.]\h)(p[+-]?\d[lf]?))i, Num::Float
+        rule %r(#{dq}e[+-]?#{dq}[lf]?)i, Num::Float
         rule /0x\h('?\h)*[lu]*/i, Num::Hex
+        rule /0b[01]('?[01])*[lu]*/i, Num::Bin
         rule /0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule /#{dq}[lu]*/i, Num::Integer
         rule /\bnullptr\b/, Name::Builtin


### PR DESCRIPTION
Following cppreference:
 - float http://en.cppreference.com/w/cpp/language/floating_literal
 - integer http://en.cppreference.com/w/cpp/language/integer_literal

Adds support for:
 - binary integer literals (starting with `Ob`),
 - hexadecimal floating-point literal (C++17, never used them, not sure my
regex is perfect),
 - highlights `f,F` suffixes instead of `u,U` (not yet supported)
 - A float suffix is at most one character long.

Closes #577