### PR TITLE
Standard ML specs, plus keyword bug fix and a few small fixes

### DIFF
--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -41,9 +41,7 @@ module Rouge
         rule /[(\[{]/, Punctuation, :main
         rule /[)\]}]/, Punctuation, :pop!
 
-        rule /\b(let|if|local)\b(?!')/, Keyword::Reserved do
-          push; push
-        end
+        rule /\b(let|if|local)\b(?!')/, Keyword::Reserved, :push
 
         rule /\b(struct|sig|while)\b(?!')/ do
           token Keyword::Reserved

--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -78,7 +78,7 @@ module Rouge
       end
 
       state :core do
-        rule /[()\[\]{},;_]|[.][.][.]/, Punctuation
+        rule /[()\[\]{},;\+\*]|[.][.][.]/, Punctuation
         rule /#"/, Str::Char, :char
         rule /"/, Str::Double, :string
         rule /~?0x[0-9a-fA-F]+/, Num::Hex

--- a/spec/lexers/sml_spec.rb
+++ b/spec/lexers/sml_spec.rb
@@ -1,23 +1,113 @@
-# # -*- coding: utf-8 -*- #
+# -*- coding: utf-8 -*- #
 
-# describe Rouge::Lexers::Sml do
-#   let(:subject) { Rouge::Lexers::Sml.new }
-# 
-#   describe 'guessing' do
-#     include Support::Guessing
-# 
-#     it 'guesses by filename' do
-#       assert_guess :filename => 'foo.???'
-#     end
-# 
-#     it 'guesses by mimetype' do
-#       assert_guess :mimetype => 'text/x-sml'
-#       assert_guess :mimetype => 'application/x-sml'
-#     end
-# 
-#     it 'guesses by source' do
-#       assert_guess :source => '????'
-#     end
-#   end
-# end
-# 
+describe Rouge::Lexers::SML do
+  let(:subject) { Rouge::Lexers::SML.new }
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'handles let..in..end' do
+      assert_tokens_equal "let\n  val x = 3;\nin\n  3 + 3\nend;",
+        ["Keyword.Reserved", "let"],
+        ["Text", "\n  "],
+        ["Keyword.Reserved", "val"],
+        ["Text", " "],
+        ["Name.Variable", "x"],
+        ["Text", " "],
+        ["Punctuation", "="],
+        ["Text", " "],
+        ["Literal.Number.Integer", "3"],
+        ["Punctuation", ";"],
+        ["Text", "\n"],
+        ["Keyword.Reserved", "in"],
+        ["Text", "\n  "],
+        ["Literal.Number.Integer", "3"],
+        ["Text", " "],
+        ["Punctuation", "+"],
+        ["Text", " "],
+        ["Literal.Number.Integer", "3"],
+        ["Text", "\n"],
+        ["Keyword.Reserved", "end"],
+        ["Punctuation", ";"]
+    end
+
+    it 'handles local..in..end' do
+      assert_tokens_equal "local\n  val x = 3;\nin\n  val y = x + x\nend;",
+        ["Keyword.Reserved", "local"],
+        ["Text", "\n  "],
+        ["Keyword.Reserved", "val"],
+        ["Text", " "],
+        ["Name.Variable", "x"],
+        ["Text", " "],
+        ["Punctuation", "="],
+        ["Text", " "],
+        ["Literal.Number.Integer", "3"],
+        ["Punctuation", ";"],
+        ["Text", "\n"],
+        ["Keyword.Reserved", "in"],
+        ["Text", "\n  "],
+        ["Keyword.Reserved", "val"],
+        ["Text", " "],
+        ["Name.Variable", "y"],
+        ["Text", " "],
+        ["Punctuation", "="],
+        ["Text", " "],
+        ["Name", "x"],
+        ["Text", " "],
+        ["Punctuation", "+"],
+        ["Text", " "],
+        ["Name", "x"],
+        ["Text", "\n"],
+        ["Keyword.Reserved", "end"],
+        ["Punctuation", ";"]
+    end
+
+    it "handles pattern matching" do
+      assert_tokens_equal "val square =\n  fn 1 => 1\n | _ => _ * _;",
+        ["Keyword.Reserved", "val"],
+        ["Text", " "],
+        ["Name.Variable", "square"],
+        ["Text", " "],
+        ["Punctuation", "="],
+        ["Text", "\n  "],
+        ["Keyword.Reserved", "fn"],
+        ["Text", " "],
+        ["Literal.Number.Integer", "1"],
+        ["Text", " "],
+        ["Punctuation", "=>"],
+        ["Text", " "],
+        ["Literal.Number.Integer", "1"],
+        ["Text", "\n "],
+        ["Punctuation", "|"],
+        ["Text", " "],
+        ["Name", "_"],
+        ["Text", " "],
+        ["Punctuation", "=>"],
+        ["Text", " "],
+        ["Name", "_"],
+        ["Text", " "],
+        ["Punctuation", "*"],
+        ["Text", " "],
+        ["Name", "_"],
+        ["Punctuation", ";"]
+    end
+  end
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      # Not testing '*.ml', since it's more commonly
+      # used for OCaml source files.
+      assert_guess :filename => 'foo.sml'
+      assert_guess :filename => 'foo.sig'
+      assert_guess :filename => 'foo.fun'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-standardml'
+      assert_guess :mimetype => 'application/x-standardml'
+    end
+  end
+end
+


### PR DESCRIPTION
I noticed that certain keywords in Standard ML (`sml`) syntax would be omitted, particularly when using `let...in...end` and `local...in...end`. While fixing this I went ahead and added some simple specs for SML since there weren't any. I also removed `_` from the punctuation rule, since it's usually used as a variable name (and for snake-cased variables), and added `*` and `+` to the punctuation list.

Happy to rebase, add specs, etc. Just let me know :)