### PR TITLE
Treat escaped sequences in strings as Str::Escape instead of Str.

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -54,15 +54,27 @@ module Rouge
       end
 
       state :splice_string do
-        rule /\\./, Str
+        rule /\\./, Str::Escape
         rule /{/, Punctuation, :nest
         rule /"|\n/, Str, :pop!
         rule /./, Str
       end
 
       state :splice_literal do
-        rule /""/, Str
+        rule /""/, Str::Escape
         rule /{/, Punctuation, :nest
+        rule /"/, Str, :pop!
+        rule /./, Str
+      end
+
+      state :string do
+        rule /\\./, Str::Escape
+        rule /["\n]/, Str, :pop!
+        rule /./, Str
+      end
+
+      state :literal_string do
+        rule /""/, Str::Escape
         rule /"/, Str, :pop!
         rule /./, Str
       end
@@ -73,13 +85,13 @@ module Rouge
         rule /^\s*\[.*?\]/, Name::Attribute
         rule /[$]\s*"/, Str, :splice_string
         rule /[$]@\s*"/, Str, :splice_literal
+        rule /@"/, Str, :literal_string
+        rule /"/, Str, :string
 
         rule /(<\[)\s*(#{id}:)?/, Keyword
         rule /\]>/, Keyword
 
         rule /[~!%^&*()+=|\[\]{}:;,.<>\/?-]/, Punctuation
-        rule /@"(""|[^"])*"/m, Str
-        rule /"(\\.|.)*?["\n]/, Str
         rule /'(\\.|.)'/, Str::Char
         rule /0x[0-9a-f]+[lu]?/i, Num
         rule %r(

--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -57,26 +57,26 @@ module Rouge
         rule /\\./, Str::Escape
         rule /{/, Punctuation, :nest
         rule /"|\n/, Str, :pop!
-        rule /./, Str
+        rule /[^"\{\\]\n+/, Str
       end
 
       state :splice_literal do
         rule /""/, Str::Escape
         rule /{/, Punctuation, :nest
         rule /"/, Str, :pop!
-        rule /./, Str
+        rule /[^"\{\\]+/, Str
       end
 
       state :string do
         rule /\\./, Str::Escape
         rule /["\n]/, Str, :pop!
-        rule /./, Str
+        rule /[^\\"\n]+/, Str
       end
 
       state :literal_string do
         rule /""/, Str::Escape
         rule /"/, Str, :pop!
-        rule /./, Str
+        rule /[^"]+/, Str
       end
 
       state :root do


### PR DESCRIPTION
(backslash-sequences in regular strings and double-double-quotes in literal strings)

As promised in the comments to #600.