### PR TITLE
add lexer support for LoomScript

### DIFF
--- a/lib/rouge/demos/loomscript
+++ b/lib/rouge/demos/loomscript
@@ -1,0 +1,38 @@
+package
+{
+    import loom.Application;
+    import loom2d.display.StageScaleMode;
+    import loom2d.ui.SimpleLabel;
+
+    /**
+    The HelloWorld app renders a label with its name on it,
+    and traces 'hello' to the log.
+    */
+    public class HelloWorld extends Application
+    {
+
+        override public function run():void
+        {
+            stage.scaleMode = StageScaleMode.LETTERBOX;
+            centeredMessage(simpleLabel, this.getFullTypeName());
+
+            trace("hello");
+        }
+
+        // a convenience getter that generates a label and adds it to the stage
+        private function get simpleLabel():SimpleLabel
+        {
+            return stage.addChild(new SimpleLabel("assets/Curse-hd.fnt")) as SimpleLabel;
+        }
+
+        // a utility to set the label's text and then center it on the stage
+        private function centeredMessage(label:SimpleLabel, msg:String):void
+        {
+            label.text = msg;
+            label.center();
+            label.x = stage.stageWidth / 2;
+            label.y = (stage.stageHeight / 2) - (label.height / 2);
+        }
+
+    }
+}

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -14,6 +14,7 @@ module Rouge
       state :comments_and_whitespace do
         rule %r(\s+), Text
         rule %r(//.*?$), Comment::Single
+        rule %r(/\*\*.*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
 

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -75,34 +75,52 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          for in while do break return continue switch case default
-          if else throw try catch finally new delete typeof is
-          this with
-        )
-      end
+          break case continue default do else for each in if label
+          return super switch throw try catch finally while with
 
-      def self.declarations
-        @declarations ||= Set.new %w(var with function)
-      end
-
-      def self.reserved
-        @reserved ||= Set.new %w(
-          dynamic final internal native public protected private class const
-          override static package interface extends implements namespace
-          set get import include super flash_proxy object_proxy trace
+          delete is new typeof
         )
       end
 
       def self.constants
-        @constants ||= Set.new %w(true false null NaN Infinity undefined)
+        @constants ||= Set.new %w(
+          false Infinity NaN null this true undefined
+        )
+      end
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          class const extends function get implements
+          interface namespace package set var
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+          import include flash_proxy object_proxy
+        )
+      end
+
+      def self.types
+        @types ||= Set.new %w(
+          ArgumentError Array Boolean Class Date DefinitionError Error
+          EvalError Function int JSON Math Namespace Number Null Object QName
+          RangeError ReferenceError RegExp SecurityError String SyntaxError
+          TypeError uint void URIError Vector VerifyError XML XMLList
+        )
+      end
+
+      def self.attributes
+        @attributes ||= Set.new %w(
+          dynamic final internal native override
+          private protected public static
+        )
       end
 
       def self.builtins
-        @builtins ||= %w(
-          void Function Math Class
-          Object RegExp decodeURI
-          decodeURIComponent encodeURI encodeURIComponent
-          eval isFinite isNaN parseFloat parseInt this
+        @builtins ||= Set.new %w(
+          arguments decodeURI decodeURIComponent encodeURI encodeURIComponent
+          escape isFinite isNaN isXMLName parseFloat parseInt trace unescape
         )
       end
 
@@ -135,12 +153,16 @@ module Rouge
           elsif self.class.declarations.include? m[0]
             token Keyword::Declaration
             push :expr_start
+          elsif self.class.attributes.include? m[0]
+            token Name::Attribute
           elsif self.class.reserved.include? m[0]
             token Keyword::Reserved
           elsif self.class.constants.include? m[0]
             token Keyword::Constant
           elsif self.class.builtins.include? m[0]
             token Name::Builtin
+          elsif self.class.types.include? m[0]
+            token Keyword::Type
           else
             token Name::Other
           end

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -115,10 +115,11 @@ module Rouge
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===
                | !== )x,
           Operator, :expr_start
-        rule %r([:-<>+*%&|\^/!=]=?), Operator, :expr_start
+        rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start
         rule /[(\[,]/, Punctuation, :expr_start
         rule /;/, Punctuation, :statement
         rule /[)\].]/, Punctuation
+        rule /:/, Punctuation
 
         rule /[?]/ do
           token Punctuation

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'application/x-actionscript', 'text/x-actionscript'
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r(\s+), Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
@@ -25,9 +25,9 @@ module Rouge
           goto :regex
         end
 
-        rule /[{]/, Punctuation, :object
+        rule %r([{]), Punctuation, :object
 
-        rule //, Text, :pop!
+        rule %r(), Text, :pop!
       end
 
       state :regex do
@@ -38,38 +38,38 @@ module Rouge
 
         rule %r([^/]\n), Error, :pop!
 
-        rule /\n/, Error, :pop!
-        rule /\[\^/, Str::Escape, :regex_group
-        rule /\[/, Str::Escape, :regex_group
-        rule /\\./, Str::Escape
+        rule %r(\n), Error, :pop!
+        rule %r(\[\^), Str::Escape, :regex_group
+        rule %r(\[), Str::Escape, :regex_group
+        rule %r(\\.), Str::Escape
         rule %r{[(][?][:=<!]}, Str::Escape
-        rule /[{][\d,]+[}]/, Str::Escape
-        rule /[()?]/, Str::Escape
-        rule /./, Str::Regex
+        rule %r([{][\d,]+[}]), Str::Escape
+        rule %r([()?]), Str::Escape
+        rule %r(.), Str::Regex
       end
 
       state :regex_end do
-        rule /[gim]+/, Str::Regex, :pop!
+        rule %r([gim]+), Str::Regex, :pop!
         rule(//) { pop! }
       end
 
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule /\//, Str::Escape
+        rule %r(\/), Str::Escape
 
         rule %r([^/]\n) do
           token Error
           pop! 2
         end
 
-        rule /\]/, Str::Escape, :pop!
-        rule /\\./, Str::Escape
-        rule /./, Str::Regex
+        rule %r(\]), Str::Escape, :pop!
+        rule %r(\\.), Str::Escape
+        rule %r(.), Str::Regex
       end
 
       state :bad_regex do
-        rule /[^\n]+/, Error, :pop!
+        rule %r([^\n]+), Error, :pop!
       end
 
       def self.keywords
@@ -105,27 +105,27 @@ module Rouge
         )
       end
 
-      id = /[$a-zA-Z_][a-zA-Z0-9_]*/
+      id = %r([$a-zA-Z_][a-zA-Z0-9_]*)
 
       state :root do
-        rule /\A\s*#!.*?\n/m, Comment::Preproc, :statement
-        rule /\n/, Text, :statement
+        rule %r(\A\s*#!.*?\n)m, Comment::Preproc, :statement
+        rule %r(\n), Text, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | === | !== )x, Operator, :expr_start
         rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start
-        rule /[(\[,]/, Punctuation, :expr_start
-        rule /;/, Punctuation, :statement
-        rule /[)\].]/, Punctuation
-        rule /:/, Punctuation
+        rule %r{[(\[,]}, Punctuation, :expr_start
+        rule %r(;), Punctuation, :statement
+        rule %r{[)\].]}, Punctuation
+        rule %r(:), Punctuation
 
-        rule /[?]/ do
+        rule %r([?]) do
           token Punctuation
           push :ternary
           push :expr_start
         end
 
-        rule /[{}]/, Punctuation, :statement
+        rule %r([{}]), Punctuation, :statement
 
         rule id do |m|
           if self.class.keywords.include? m[0]
@@ -145,20 +145,20 @@ module Rouge
           end
         end
 
-        rule /\-?[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
-        rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /\-?[0-9]+/, Num::Integer
-        rule /"(\\\\|\\"|[^"])*"/, Str::Double
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
+        rule %r(\-?[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?), Num::Float
+        rule %r(0x[0-9a-fA-F]+), Num::Hex
+        rule %r(\-?[0-9]+), Num::Integer
+        rule %r("(\\\\|\\"|[^"])*"), Str::Double
+        rule %r('(\\\\|\\'|[^'])*'), Str::Single
       end
 
       # braced parts that aren't object literals
       state :statement do
-        rule /(#{id})(\s*)(:)/ do
+        rule %r((#{id})(\s*)(:)) do
           groups Name::Label, Text, Punctuation
         end
 
-        rule /[{}]/, Punctuation
+        rule %r([{}]), Punctuation
 
         mixin :expr_start
       end
@@ -166,23 +166,23 @@ module Rouge
       # object literals
       state :object do
         mixin :comments_and_whitespace
-        rule /[}]/ do
+        rule %r([}]) do
           token Punctuation
           goto :statement
         end
 
-        rule /(#{id})(\s*)(:)/ do
+        rule %r{(#{id})(\s*)(:)} do
           groups Name::Attribute, Text, Punctuation
           push :expr_start
         end
 
-        rule /:/, Punctuation
+        rule %r(:), Punctuation
         mixin :root
       end
 
       # ternary expressions, where <id>: is not a label!
       state :ternary do
-        rule /:/ do
+        rule %r(:) do
           token Punctuation
           goto :expr_start
         end

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -4,7 +4,7 @@ module Rouge
   module Lexers
     class Actionscript < RegexLexer
       title "ActionScript"
-      desc "ActionScript"
+      desc "ActionScript 3 (https://www.adobe.com/go/as3lr)"
 
       tag 'actionscript'
       aliases 'as', 'as3'

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -9,7 +9,7 @@ module Rouge
       tag 'actionscript'
       aliases 'as', 'as3'
       filenames '*.as'
-      mimetypes 'application/x-actionscript'
+      mimetypes 'application/x-actionscript', 'text/x-actionscript'
 
       state :comments_and_whitespace do
         rule /\s+/, Text
@@ -112,9 +112,7 @@ module Rouge
         rule /\n/, Text, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
-        rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===
-               | !== )x,
-          Operator, :expr_start
+        rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | === | !== )x, Operator, :expr_start
         rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start
         rule /[(\[,]/, Punctuation, :expr_start
         rule /;/, Punctuation, :statement

--- a/lib/rouge/lexers/loomscript.rb
+++ b/lib/rouge/lexers/loomscript.rb
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class LoomScript < Actionscript
+      title 'LoomScript'
+      desc "Scripting language for the Loom SDK, a native mobile app and game framework (https://github.com/LoomSDK/LoomSDK)"
+
+      tag 'loomscript'
+      aliases 'ls'
+      filenames '*.ls'
+      mimetypes 'application/loomscript', 'application/x-loomscript',
+                'text/loomscript', 'text/x-loomscript'
+
+      # LoomScript token reference (as of sprint34):
+      # https://github.com/LoomSDK/LoomSDK/blob/sprint34/loom/script/compiler/lsToken.cpp#L111
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          break case continue default delete do each else
+          for if in return switch while with yield
+
+          as is instanceof new typeof
+        )
+      end
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          class delegate enum function interface
+          namespace operator package struct var
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+          abstract const dynamic extends final get
+          implements import include internal native
+          override private protected public
+          set static super this
+
+          debugger export goto syncronized transient volatile
+        )
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(
+          false NaN null true undefined void
+        )
+      end
+
+      def self.builtins
+        # builtin functions
+        @builtins ||= %w(
+          isNaN parseFloat parseInt trace
+        )
+
+        # builtin types
+        @builtins ||= %w(
+          Assembly Boolean ByteArray Coroutine Date Dictionary File Function
+          GUID Null Number Object Path Process Socket String Type Vector Void
+
+          AbstractClassError ArgumentError Error
+          IllegalOperationError RangeError TypeError
+
+          XMLAttribute XMLComment XMLDeclaration XMLDocument
+          XMLElement XMLError XMLNode XMLPrinter XMLText
+        )
+
+        # builtin utilities
+        @builtins ||= %w(
+          Base64 CommandLine Console Debug GC IO JSON Math Metrics
+          NativeDelegate ObjectInspector Platform Profiler Random Telemetry VM
+
+          BaseApplication ConsoleApplication
+        )
+      end
+
+    end
+  end
+end

--- a/lib/rouge/lexers/loomscript.rb
+++ b/lib/rouge/lexers/loomscript.rb
@@ -2,6 +2,8 @@
 
 module Rouge
   module Lexers
+    load_lexer 'actionscript.rb'
+
     class LoomScript < Actionscript
       title 'LoomScript'
       desc "Scripting language for the Loom SDK, a native mobile app and game framework (https://github.com/LoomSDK/LoomSDK)"

--- a/lib/rouge/lexers/loomscript.rb
+++ b/lib/rouge/lexers/loomscript.rb
@@ -68,7 +68,7 @@ module Rouge
           BaseApplication ConsoleApplication
         )
 
-        @types ||= Set.new (base_types + utils)
+        @types ||= Set.new(base_types + utils)
       end
 
       def self.attributes

--- a/lib/rouge/lexers/loomscript.rb
+++ b/lib/rouge/lexers/loomscript.rb
@@ -18,46 +18,39 @@ module Rouge
       def self.keywords
         @keywords ||= Set.new %w(
           break case continue default delete do each else
-          for if in return switch while with yield
+          for each in if return super switch while with yield
 
           as is instanceof new typeof
         )
       end
 
+      def self.constants
+        @constants ||= Set.new %w(
+          false Infinity NaN null this true undefined
+        )
+      end
+
       def self.declarations
         @declarations ||= Set.new %w(
-          class delegate enum function interface
-          namespace operator package struct var
+          class const delegate enum extends function get implements
+          interface namespace operator package set struct var
         )
       end
 
       def self.reserved
         @reserved ||= Set.new %w(
-          abstract const dynamic extends final get
-          implements import include internal native
-          override private protected public
-          set static super this
+          import include
 
           debugger export goto syncronized transient volatile
         )
       end
 
-      def self.constants
-        @constants ||= Set.new %w(
-          false NaN null true undefined void
-        )
-      end
+      def self.types
+        base_types = %w(
+          int uint void
 
-      def self.builtins
-        # builtin functions
-        @builtins ||= %w(
-          isNaN parseFloat parseInt trace
-        )
-
-        # builtin types
-        @builtins ||= %w(
           Assembly Boolean ByteArray Coroutine Date Dictionary File Function
-          GUID Null Number Object Path Process Socket String Type Vector Void
+          GUID Null Number Object Path Process Socket String Type Vector
 
           AbstractClassError ArgumentError Error
           IllegalOperationError RangeError TypeError
@@ -66,12 +59,26 @@ module Rouge
           XMLElement XMLError XMLNode XMLPrinter XMLText
         )
 
-        # builtin utilities
-        @builtins ||= %w(
+        utils = %w(
           Base64 CommandLine Console Debug GC IO JSON Math Metrics
           NativeDelegate ObjectInspector Platform Profiler Random Telemetry VM
 
           BaseApplication ConsoleApplication
+        )
+
+        @types ||= Set.new (base_types + utils)
+      end
+
+      def self.attributes
+        @attributes ||= Set.new %w(
+          abstract dynamic final internal native
+          override private protected public static
+        )
+      end
+
+      def self.builtins
+        @builtins ||= Set.new %w(
+          isNaN parseFloat parseInt trace
         )
       end
 

--- a/spec/lexers/actionscript_spec.rb
+++ b/spec/lexers/actionscript_spec.rb
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Actionscript do
+  let(:subject) { Rouge::Lexers::Actionscript.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.as'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-actionscript'
+      assert_guess :mimetype => 'application/x-actionscript'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'comments' do
+    # Comment
+    # Comment.Doc
+    # Comment.Multiline
+    # Comment.Preproc
+    # Comment.Single
+    # Comment.Special
+
+      it 'identifies doc comments' do
+        tokens = subject.lex(
+        %q(/**
+            Doc comment
+           */)).to_a
+        assert_last_token_type(tokens, 'Comment.Doc')
+      end
+
+      it 'identifies multi-line comments' do
+        tokens = subject.lex(
+        %q(/*
+            Multi-line comment
+           */)).to_a
+        assert_last_token_type(tokens, 'Comment.Multiline')
+      end
+
+      it 'identifies single-line comments' do
+        tokens = subject.lex('// single-line comment').to_a
+        assert_last_token_type(tokens, 'Comment.Single')
+      end
+    end
+
+    describe 'keywords' do
+    # Keyword
+    # Keyword.Constant
+    # Keyword.Declaration
+    # Keyword.Namespace
+    # Keyword.Pseudo
+    # Keyword.Reserved
+    # Keyword.Type
+    # Keyword.Variable
+
+      it 'identifies basic keywords' do
+        tokens = subject.lex("if (_a typeof A) return;").to_a
+        assert_token_type_at(tokens, [0, 5, 10], 'Keyword')
+      end
+
+      it 'identifies constants' do
+        tokens = subject.lex("function f(b:Boolean = false, n:Number = NaN, o:Object = null):void").to_a
+        assert_token_type_at(tokens, [10, 19, 28], 'Keyword.Constant')
+      end
+
+      it 'identifies declarations' do
+        code = <<~EOF
+        public interface I {}
+        public class C {}
+        EOF
+        tokens = subject.lex(code).to_a
+        assert_token_type_at(tokens, [2, 10], 'Keyword.Declaration')
+      end
+
+      it 'identifies reserved words' do
+        tokens = subject.lex("import baz.bar.foo;").to_a
+        assert_first_token_type(tokens, 'Keyword.Reserved')
+      end
+
+      it 'identifies builtin types' do
+        tokens = subject.lex("function f(b:Boolean, v:Vector.<Object>):void { trace(b, v); }").to_a
+        assert_token_type_at(tokens, [6, 11, 14, 17], 'Keyword.Type')
+      end
+    end
+
+    describe 'names' do
+    # Name
+    # Name.Attribute
+    # Name.Builtin
+    # Name.Builtin.Pseudo
+    # Name.Class
+    # Name.Constant
+    # Name.Decorator
+    # Name.Entity
+    # Name.Exception
+    # Name.Function
+    # Name.Property
+    # Name.Label
+    # Name.Namespace
+    # Name.Other
+    # Name.Tag
+    # Name.Variable
+    # Name.Variable.Class
+    # Name.Variable.Global
+    # Name.Variable.Instance
+
+      it 'identifies attributes' do
+        tokens = subject.lex("public static const CONST:String = 'constant';").to_a
+        assert_token_type_at(tokens, [0, 2], 'Name.Attribute')
+      end
+
+      it 'identifies builtin names' do
+        tokens = subject.lex("if (!isNaN(parseInt(x))) { trace(x); }").to_a
+        assert_token_type_at(tokens, [4, 6, 13], 'Name.Builtin')
+      end
+
+      it 'identifies labels' do
+        code = <<~EOF
+        switch (Math.floor(Math.random()) * 3 + 1)
+        {
+            case 1 : trace('rock'); break;
+            case 2 : trace('paper'); break;
+            default: trace('scissors'); break;
+        }
+        EOF
+        tokens = subject.lex(code).to_a
+        assert_token_type_at(tokens, [51], 'Name.Label')
+
+        # code = <<~EOF
+        # outerLoop: for (var i:int = 0; i < 10; i++)
+        # {
+        #     for (var j:int = 0; j < 10; j++)
+        #     {
+        #         if ( (i == 8) && (j == 0)) break outerLoop;
+        #         trace(10 * i + j);
+        #     }
+        # }
+        # EOF
+        # tokens = subject.lex(code).to_a
+        # assert { tokens[0][0] == Token['Name.Label'] }
+      end
+    end
+
+    describe 'literals' do
+    # Literal
+    # Literal.Date
+    # Literal.String
+    # Literal.String.Backtick
+    # Literal.String.Char
+    # Literal.String.Doc
+    # Literal.String.Double
+    # Literal.String.Escape
+    # Literal.String.Heredoc
+    # Literal.String.Interpol
+    # Literal.String.Other
+    # Literal.String.Regex
+    # Literal.String.Single
+    # Literal.String.Symbol
+    # Literal.Number
+    # Literal.Number.Float
+    # Literal.Number.Hex
+    # Literal.Number.Integer
+    # Literal.Number.Integer.Long
+    # Literal.Number.Oct
+    # Literal.Number.Bin
+    # Literal.Number.Other
+
+      it 'identifies quoted strings' do
+        tokens = subject.lex(%q(var s2:String = "double-quotes with 'quotes' inside";)).to_a
+        assert_token_type_at(tokens, [8], 'Literal.String.Double')
+
+        tokens = subject.lex(%q(var s1:String = 'single-quotes with "quotes" inside';)).to_a
+        assert_token_type_at(tokens, [8], 'Literal.String.Single')
+      end
+
+      it 'identifies floating point numbers' do
+        tokens = subject.lex("var f:Number = 123.45;").to_a
+        assert_token_type_at(tokens, [8], 'Literal.Number.Float')
+      end
+
+      it 'identifies hexadecimal numbers' do
+        tokens = subject.lex("var h:Number = 0xaabbcc;").to_a
+        assert_token_type_at(tokens, [8], 'Literal.Number.Hex')
+      end
+
+      it 'identifies integers' do
+        tokens = subject.lex("var i:Number = 12345;").to_a
+        assert_token_type_at(tokens, [8], 'Literal.Number.Integer')
+      end
+    end
+
+
+    describe 'operators and punctuation' do
+    # Operator
+    # Operator.Word
+    # Punctuation
+    # Punctuation.Indicator
+
+      it 'identifies bitwise operators' do
+        tokens = subject.lex("var b = 1 << 3 >>> 1 & 0xff;").to_a
+        assert_token_type_at(tokens, [8, 12, 16], 'Operator')
+      end
+
+      it 'identifies logical operators' do
+        tokens = subject.lex("var b = (x >= 0) && (x < 1 || x == 1);").to_a
+        assert_token_type_at(tokens, [9, 14, 19, 23, 27], 'Operator')
+      end
+
+      it 'identifies math operators' do
+        tokens = subject.lex("var a = 5+4-3*2/1%5; a += 300; a -= 5; a *= 4; a /= 2; a %= 7;").to_a
+        assert_token_type_at(tokens, [4, 7, 9, 11, 13, 15, 21, 28, 35, 42, 49], 'Operator')
+      end
+
+      it 'identifies punctuation' do
+        tokens = subject.lex("var flip:Vector.<String> =  (Math.random() > 0.5) ? [a] : [z];").to_a
+        assert_token_type_at(tokens, [3, 5, 12, 14, 16, 21, 23, 25, 27, 29, 31, 33], 'Punctuation')
+      end
+    end
+
+  end
+end

--- a/spec/lexers/actionscript_spec.rb
+++ b/spec/lexers/actionscript_spec.rb
@@ -70,11 +70,9 @@ describe Rouge::Lexers::Actionscript do
       end
 
       it 'identifies declarations' do
-        code = <<~EOF
-        public interface I {}
-        public class C {}
-        EOF
-        tokens = subject.lex(code).to_a
+        tokens = subject.lex(
+        %q(public interface I {}
+        public class C {})).to_a
         assert_token_type_at(tokens, [2, 10], 'Keyword.Declaration')
       end
 
@@ -121,15 +119,13 @@ describe Rouge::Lexers::Actionscript do
       end
 
       it 'identifies labels' do
-        code = <<~EOF
-        switch (Math.floor(Math.random()) * 3 + 1)
+        tokens = subject.lex(
+        %q(switch (Math.floor(Math.random()) * 3 + 1)
         {
             case 1 : trace('rock'); break;
             case 2 : trace('paper'); break;
             default: trace('scissors'); break;
-        }
-        EOF
-        tokens = subject.lex(code).to_a
+        })).to_a
         assert_token_type_at(tokens, [51], 'Name.Label')
 
         # code = <<~EOF

--- a/spec/lexers/loomscript_spec.rb
+++ b/spec/lexers/loomscript_spec.rb
@@ -33,16 +33,14 @@ describe Rouge::Lexers::LoomScript do
       end
 
       it 'identifies declarations' do
-        code = <<~EOF
-        delegate ToCompute(s:String, o:Object):Number;
+        tokens = subject.lex(
+        %q(delegate ToCompute(s:String, o:Object):Number;
         public enum Enumeration {}
         struct P {
             public var x:Number = 0;
             public var y:Number = 0;
             public static operator function =(a:P, b:P):P {}
-        }
-        EOF
-        tokens = subject.lex(code).to_a
+        })).to_a
         assert_token_type_at(tokens, [18, 24, 32, 45, 60, 62], 'Keyword.Declaration')
       end
 

--- a/spec/lexers/loomscript_spec.rb
+++ b/spec/lexers/loomscript_spec.rb
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::LoomScript do
+  let(:subject) { Rouge::Lexers::LoomScript.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.ls'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/loomscript'
+      assert_guess :mimetype => 'application/loomscript'
+      assert_guess :mimetype => 'text/x-loomscript'
+      assert_guess :mimetype => 'application/x-loomscript'
+    end
+  end
+end

--- a/spec/lexers/loomscript_spec.rb
+++ b/spec/lexers/loomscript_spec.rb
@@ -17,4 +17,47 @@ describe Rouge::Lexers::LoomScript do
       assert_guess :mimetype => 'application/x-loomscript'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'keywords' do
+      it 'identifies basic keywords' do
+        tokens = subject.lex("if (_a instanceof A) return;").to_a
+        assert_token_type_at(tokens, [0, 5, 10], 'Keyword')
+      end
+
+      it 'identifies constants' do
+        tokens = subject.lex("function f(b:Boolean = false, n:Number = NaN, o:Object = null):void").to_a
+        assert_token_type_at(tokens, [10, 19, 28], 'Keyword.Constant')
+      end
+
+      it 'identifies declarations' do
+        code = <<~EOF
+        delegate ToCompute(s:String, o:Object):Number;
+        public enum Enumeration {}
+        struct P {
+            public var x:Number = 0;
+            public var y:Number = 0;
+            public static operator function =(a:P, b:P):P {}
+        }
+        EOF
+        tokens = subject.lex(code).to_a
+        assert_token_type_at(tokens, [18, 24, 32, 45, 60, 62], 'Keyword.Declaration')
+      end
+
+      it 'identifies builtin types' do
+        tokens = subject.lex("function f(b:Boolean, v:Vector.<Object>, d:Dictionary.<String, Number>):void { trace(b, v, d); }").to_a
+        assert_token_type_at(tokens, [6, 11, 14, 20, 23, 26, 29], 'Keyword.Type')
+      end
+    end
+
+    describe 'names' do
+      it 'identifies attributes' do
+        tokens = subject.lex("private static native var releaseBuild:Boolean;").to_a
+        assert_token_type_at(tokens, [0, 2, 4], 'Name.Attribute')
+      end
+    end
+
+  end
 end

--- a/spec/support/lexing.rb
+++ b/spec/support/lexing.rb
@@ -28,6 +28,20 @@ module Support
       assert { filter_by_token(tokname, text, lexer).any? }
     end
 
+    def assert_first_token_type(tokens, type)
+      assert { tokens.first[0] == Token[type] }
+    end
+
+    def assert_last_token_type(tokens, type)
+      assert { tokens.last[0] == Token[type] }
+    end
+
+    def assert_token_type_at(tokens, indices, type)
+      indices.each do |i|
+        assert { tokens[i][0] == Token[type] }
+      end
+    end
+
     def assert_no_errors(*a)
       deny_has_token('Error', *a)
     end

--- a/spec/visual/samples/actionscript
+++ b/spec/visual/samples/actionscript
@@ -1,12 +1,27 @@
+package rouge.test
+{
+  private function variousOps():void
+  {
+    var a = ((100 + 200 - 0) / 300) % 2;
+    var b = 100 * 30;
+    var d = true && (b > 301);
+    var e = 0x10 | 0x01;
+    var f = (false || d);
+
+    b++; b--;
+    a += 300; a -= 5; a *= 4; a /= 2; a %= 7;
+  }
+}
+
 package a.b.c
 {
   import flash.events.Event;
   import flash.events.EventDispatcher;
-  
+
   /**
    * @langversion 3.0
    */
-  
+
   public final class Dispatcher extends EventDispatcher implements IEventDispatcher
   {
 
@@ -24,7 +39,7 @@ package a.b.c
         return true;
       }
     }
-    
+
   }
 }
 
@@ -38,61 +53,61 @@ package com.jx.screenshot
 
   public class Screenshot
   {
-    
+
     public static const INCLUDE_BOUNDS:Boolean = true;
-    
+
     public static var dictionary:Object;
     public static var save:Save;
     public static var comparer:Comparer;
     public static var resizer:Resizer;
-    
+
     public function Screenshot()
     {
       throw new IllegalOperationError("Can't be instantiated.");
     }
-    
+
     public static function compare(fixtureName:String, component:DisplayObject, includeBounds:Boolean = false):Boolean
     {
       checkPreconditions();
       comparer = comparer || new NativeComparer(save);
       resizer = resizer || new Resizer();
-      
+
       var matrix:Matrix;
       var newWidth:uint = component.width;
       var newHeight:uint = component.height;
-      
+
       if (includeBounds) {
         var bounds:Rectangle = component.getBounds(component);
-        
+
         matrix = new Matrix();
         matrix.translate(-1 * bounds.x, -1 * bounds.y);
-        
+
         newWidth = bounds.width;
         newHeight = bounds.height;
       }
-      
+
       var screenshot:BitmapData = new BitmapData(newWidth, newHeight);
-        screenshot.draw(component, matrix);
+      screenshot.draw(component, matrix);
       var resizedScreenshot:BitmapData = resizer.resize(screenshot);
       var originalScreen:BitmapData = dictionary[fixtureName];
-      
+
       // for manual comparison
       save.save(fixtureName + "-actual", resizedScreenshot);
-      
+
       return comparer.compare(fixtureName, originalScreen, resizedScreenshot);
     }
-    
+
     private static function checkPreconditions():void
     {
       if (!dictionary) {
         throw new IllegalOperationError('You have to set the dictionary first.');
       }
-      
+
       if (!save) {
         throw new IllegalOperationError("You have to set the save first.");
       }
     }
-    
+
   }
 }
 
@@ -140,7 +155,7 @@ final public dynamic class Generator extends Proxy
       value = null;
       this.error = error;
     }
-      
+
     if (this.error) {
       throw this.error;
     }
@@ -164,7 +179,7 @@ final public class GeneratorResult
   }
 
   public function get done():Boolean
-  { 
+  {
     return _done;
   }
 

--- a/spec/visual/samples/loomscript
+++ b/spec/visual/samples/loomscript
@@ -55,8 +55,9 @@ package
         private function variousTypes(defaultValue:String = ''):void
         {
             var nil:Object = null;
-            var b1:Boolean = true;
-            var b2:Boolean = false;
+            var b1:Boolean = false;
+            var b2:Boolean = B instanceof C;
+            var b3:Boolean = A typeof I;
             var n1:Number = 0.123;
             var n2:Number = 12345;
             var n3:Number = 0xfed;

--- a/spec/visual/samples/loomscript
+++ b/spec/visual/samples/loomscript
@@ -1,0 +1,138 @@
+package
+{
+    import loom.Application;
+
+    public interface I {}
+    public class C {}
+    public class B extends C implements I {}
+    public final class A extends B {}
+
+    delegate ToCompute(s:String, o:Object):Number;
+
+    public enum Enumeration
+    {
+        foo,
+        baz,
+        cat,
+    }
+
+    struct P {
+        public var x:Number = 0;
+        public var y:Number = 0;
+        public static operator function =(a:P, b:P):P
+        {
+            a.x = b.x;
+            a.y = b.y;
+
+            return a;
+        }
+    }
+
+    // single-line comment
+
+    /*
+    Multi-line comment
+    */
+
+    /**
+    Doc comment
+    */
+    public class SyntaxExercise extends Application
+    {
+        public static var classVar:String = 'class variable';
+        public const CONST:String = 'constant';
+        private var _a:A = new A();
+        public var _d:ToCompute;
+
+        override public function run():void
+        {
+            trace("hello");
+        }
+
+        private function get a():A { return _a; }
+        private function set a(value:A):void { _a = value; }
+
+        private function variousTypes(defaultValue:String = ''):void
+        {
+            var nil:Object = null;
+            var b1:Boolean = true;
+            var b2:Boolean = false;
+            var n1:Number = 0.123;
+            var n2:Number = 12345;
+            var n3:Number = 0xfed;
+            var s1:String = 'single-quotes with "quotes" inside';
+            var s2:String = "double-quotes with 'quotes' inside";
+            var f1:Function = function (life:String, universe:Object, ...everything):Number { return 42; };
+            var v1:Vector.<Number> = [1, 2];
+            var d1:Dictionary.<String, Number> = { 'three': 3, 'four': 4 };
+
+            _d += f1;
+            _d -= f1;
+        }
+
+        private function variousOps():void
+        {
+            var a = ((100 + 200 - 0) / 300) % 2;
+            var b = 100 * 30;
+            var d = true && (b > 301);
+            var e = 0x10 | 0x01;
+            var f = (false || d);
+
+            b++; b--;
+            a += 300; a -= 5; a *= 4; a /= 2; a %= 7;
+
+            var castable1:Boolean = (a is B);
+            var castable2:Boolean = (a as B) != null;
+            var cast:String = B(a).toString();
+            var instanced:Boolean = (_a instanceof A);
+        }
+
+        private function variousFlow():void
+        {
+            var n:Number = Math.random();
+            if (n > 0.6)
+                trace('top 40!');
+            else if(n > 0.3)
+                trace('mid 30!');
+            else
+                trace('bottom 30');
+
+            var flip:String =  (Math.random() > 0.5) ? 'heads' : 'tails';
+
+            for (var i = 0; i < 100; i++)
+                trace(i);
+
+            var v:Vector.<String> = ['a', 'b', 'c'];
+            for each (var s:String in v)
+                trace(s);
+
+            var d:Dictionary.<String, Number> = { 'one': 1 };
+            for (var key1:String in d)
+                trace(key1);
+
+            for (var key2:Number in v)
+                trace(key2);
+
+            while (i > 0)
+            {
+                i--;
+                if (i == 13) continue;
+                trace(i);
+            }
+
+            do
+            {
+                i++;
+            }
+            while (i < 10);
+
+            switch (Math.floor(Math.random()) * 3 + 1)
+            {
+                case 1 : trace('rock'); break;
+                case 2 : trace('paper'); break;
+                default: trace('scissors'); break;
+            }
+        }
+
+    }
+}

--- a/spec/visual_spec.rb
+++ b/spec/visual_spec.rb
@@ -3,7 +3,7 @@
 puts <<-msg
 
 ============
-Run `rackup` and visit localhost:9292/:lexer_name to visually test a lexer.
+Run `rackup` and visit localhost:9292/lexer_name to visually test a lexer.
 ============
 
 msg


### PR DESCRIPTION
LoomScript is the scripting language used by the Loom SDK, a native mobile app and game framework (https://github.com/LoomSDK/LoomSDK). It is largely similar to ActionScript3, with additional C#-ish features.

This pull request refactors a punctuation rule for colons (`:`) in the ActionScript lexer to address a highlighting error that wasn't exercised in the example (e.g. `a -= b;`), then extends the as3 lexer to implement LoomScript highlighting.