### PR TITLE
improve `lexers/shell.rb`

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -9,14 +9,12 @@ module Rouge
 
       tag 'shell'
       aliases 'bash', 'zsh', 'ksh', 'sh'
-      filenames '*.sh', '*.bash', '*.zsh', '*.ksh',
-                '.bashrc', '.zshrc', '.kshrc', '.profile',
-                'APKBUILD',
-                'PKGBUILD',
-                '*.ebuild', '*.eclass',
-                '*.exheres-0', '*.exlib'
+      filenames '*.sh', '*.bash', '*.zsh', '*.ksh', '.bashrc', '.zshrc',
+                '.kshrc', '.profile', 'APKBUILD', 'PKGBUILD', '*.ebuild',
+                '*.eclass', '*.exheres-0', '*.exlib'
 
-      mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh', 'text/x-shellscript'
+      mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh',
+                'text/x-shellscript'
 
       def self.detect?(text)
         return true if text.shebang?(/(ba|z|k)?sh/)

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -12,7 +12,8 @@ module Rouge
       filenames '*.sh', '*.bash', '*.zsh', '*.ksh',
                 '.bashrc', '.zshrc', '.kshrc', '.profile',
                 'APKBUILD',
-                'PKGBUILD'
+                'PKGBUILD',
+                '*.ebuild', '*.eclass'
 
       mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh', 'text/x-shellscript'
 

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -10,7 +10,9 @@ module Rouge
       tag 'shell'
       aliases 'bash', 'zsh', 'ksh', 'sh'
       filenames '*.sh', '*.bash', '*.zsh', '*.ksh',
-                '.bashrc', '.zshrc', '.kshrc', '.profile', 'APKBUILD', 'PKGBUILD'
+                '.bashrc', '.zshrc', '.kshrc', '.profile',
+                'APKBUILD',
+                'PKGBUILD'
 
       mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh', 'text/x-shellscript'
 

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -12,7 +12,7 @@ module Rouge
       filenames '*.sh', '*.bash', '*.zsh', '*.ksh',
                 '.bashrc', '.zshrc', '.kshrc', '.profile', 'APKBUILD', 'PKGBUILD'
 
-      mimetypes 'application/x-sh', 'application/x-shellscript'
+      mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh', 'text/x-shellscript'
 
       def self.detect?(text)
         return true if text.shebang?(/(ba|z|k)?sh/)

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -13,7 +13,8 @@ module Rouge
                 '.bashrc', '.zshrc', '.kshrc', '.profile',
                 'APKBUILD',
                 'PKGBUILD',
-                '*.ebuild', '*.eclass'
+                '*.ebuild', '*.eclass',
+                '*.exheres-0', '*.exlib'
 
       mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh', 'text/x-shellscript'
 

--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -43,6 +43,10 @@ describe Rouge::Lexers::Shell do
       assert_guess :filename => 'foo.bash'
       assert_guess :filename => 'APKBUILD'
       assert_guess :filename => 'PKGBUILD'
+      assert_guess :filename => 'foo.ebuild'
+      assert_guess :filename => 'foo.eclass'
+      assert_guess :filename => 'foo.exheres-0'
+      assert_guess :filename => 'foo.exlib'
       deny_guess   :filename => 'foo'
     end
 

--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -47,7 +47,10 @@ describe Rouge::Lexers::Shell do
     end
 
     it 'guesses by mimetype' do
+      assert_guess :mimetype => 'application/x-sh'
       assert_guess :mimetype => 'application/x-shellscript'
+      assert_guess :mimetype => 'text/x-sh'
+      assert_guess :mimetype => 'text/x-shellscript'
     end
 
     it 'guesses by source' do


### PR DESCRIPTION
This patches adds support for Gentoo and Exherbo package build recipes. It also sets proper mime-type to shell files.