### PR TITLE
added C preprocessor

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -205,6 +205,11 @@ module Rouge
         rule %r(/), Comment::Preproc
       end
 
+      state :preprocessor do
+        rule /#+\w*/, Comment::Preproc
+        mixin :inline_whitespace
+      end
+
       state :if_0 do
         # NB: no \b here, to cover #ifdef and #ifndef
         rule /^\s*#if/, Comment, :if_0


### PR DESCRIPTION
supports #include #define #ifdef #endif 

will not highlight the contents following #{statement}

highlights in Comment:Preproc