### PR TITLE
Improve single line comment formatting in files with CRLF

### DIFF
--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -13,7 +13,7 @@ module Rouge
 
       state :comments_and_whitespace do
         rule /\s+/, Text
-        rule %r(//.*?$), Comment::Single
+        rule %r(//[^\r\n]*), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
 

--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -43,7 +43,7 @@ module Rouge
 
       state :whitespace do
         rule /\s+/m, Text
-        rule %r(//.*?$), Comment::Single
+        rule %r(//[^\r\n]*), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end
 

--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -54,7 +54,7 @@ module Rouge
 
         # whitespace
         rule /[^\S\n]+/, Text
-        rule %r(//.*?$), Comment::Single
+        rule %r(//[^\r\n]*), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
         rule /@\w[\w\d.]*/, Name::Decorator
         rule /(class|interface|trait)\b/,  Keyword::Declaration, :class

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -33,7 +33,7 @@ module Rouge
       state :comments_and_whitespace do
         rule /\s+/, Text
         rule /<!--/, Comment # really...?
-        rule %r(//.*?$), Comment::Single
+        rule %r(//[^\r\n]*), Comment::Single
         rule %r(/[*]), Comment::Multiline, :multiline_comment
       end
 


### PR DESCRIPTION
I'm using Rouge through Jekyll to format some code snippets and I noticed that all my single line comments had an extra line after them in the formatted HTML. It looks like this is caused by the single line comment rule is some languages not handling windows line endings.