### PR TITLE
Add support for GAL

### DIFF
--- a/lib/rouge/demos/gal
+++ b/lib/rouge/demos/gal
@@ -3,44 +3,20 @@ typedef data=0..$MAX-1;
 // A lossy buffer, with a single cell, that can hold a data.
 gal Buffer {
 	// MAX models an empty buffer
-	int value=$MAX;
-	
+	int value=$MAX;	
 	/** Allows to write to the buffer, if it is empty */
 	transition put (data $d) [value==$MAX] label "send"($d) {
 		value = $d;
-	}
-	/** allows to read the value held by the buffer */
-	transition get (data $d) [value==$d] label "receive"($d) {
-		value = $MAX;
-	}
-	/** This buffer is lossy, at any time (no label) the data can be lost. */
-	transition lose [value!=$MAX] {
-		value = $MAX;
-	}		
+	}	
 }
 composite Channel {
 	// the sender sends at most three messages
 	BoundedCounter sender($BOUND=3);
 	Buffer buff;
-	// to count the sum of all data values in actually received packets
-	BoundedCounter summer($BOUND=20);
-	// to count the number of received messages
-	BoundedCounter receiver;
-	
-	// our sender sends a random packet, and increments its send counter by one
 	synchronization sendData (data $d) {
 		sender."inc"(1);
 		buff."send"($d);
-	}
-	// at reception, we read the data from the buffer
-	synchronization receiveData (data $d) {
-		buff."receive"($d);		
-		// increment "summer" by the value in the packet
-		summer."inc"($d);
-		// increment received message counter by 1 : a constant value
-		receiver."inc"(1);
 	}	
 }
-
 main Channel;
 property noDead [ctl] : AG (EX true);

--- a/lib/rouge/demos/gal
+++ b/lib/rouge/demos/gal
@@ -1,0 +1,63 @@
+$MAX=3;
+typedef data=0..$MAX-1;
+
+// A lossy buffer, with a single cell, that can hold a data.
+gal Buffer {
+	// MAX models an empty buffer
+	int value=$MAX;
+	
+	/** Allows to write to the buffer, if it is empty */
+	transition put (data $d) [value==$MAX] label "send"($d) {
+		value = $d;
+	}
+	/** allows to read the value held by the buffer */
+	transition get (data $d) [value==$d] label "receive"($d) {
+		value = $MAX;
+	}
+	/** This buffer is lossy, at any time (no label) the data can be lost. */
+	transition lose [value!=$MAX] {
+		value = $MAX;
+	}		
+}
+// An example (buggy) counter ; can be incremented up to a bound.
+gal BoundedCounter($BOUND=5) {
+	int count=0;
+	
+	/** The quantity to increment by is passed through the label.	 */
+	transition inc (data $d) [count < $BOUND] label "inc"($d) {
+		count+=$d;
+	}
+	/** incrementing by one should increment by one. 
+	*   But it could also not increment because this counter is buggy. */
+	transition inc2 [count < $BOUND] label "inc"(1) {
+		count+=2;
+	}
+}
+
+composite Channel {
+	// the sender sends at most three messages
+	BoundedCounter sender($BOUND=3);
+	Buffer buff;
+	// to count the sum of all data values in actually received packets
+	BoundedCounter summer($BOUND=20);
+	// to count the number of received messages
+	BoundedCounter receiver;
+	
+	// our sender sends a random packet, and increments its send counter by one
+	synchronization sendData (data $d) {
+		sender."inc"(1);
+		buff."send"($d);
+	}
+	// at reception, we read the data from the buffer
+	synchronization receiveData (data $d) {
+		buff."receive"($d);		
+		// increment "summer" by the value in the packet
+		summer."inc"($d);
+		// increment received message counter by 1 : a constant value
+		receiver."inc"(1);
+	}	
+}
+
+main Channel;
+
+property noDead [ctl] : AG (EX true);

--- a/lib/rouge/demos/gal
+++ b/lib/rouge/demos/gal
@@ -1,6 +1,5 @@
 $MAX=3;
 typedef data=0..$MAX-1;
-
 // A lossy buffer, with a single cell, that can hold a data.
 gal Buffer {
 	// MAX models an empty buffer
@@ -19,21 +18,6 @@ gal Buffer {
 		value = $MAX;
 	}		
 }
-// An example (buggy) counter ; can be incremented up to a bound.
-gal BoundedCounter($BOUND=5) {
-	int count=0;
-	
-	/** The quantity to increment by is passed through the label.	 */
-	transition inc (data $d) [count < $BOUND] label "inc"($d) {
-		count+=$d;
-	}
-	/** incrementing by one should increment by one. 
-	*   But it could also not increment because this counter is buggy. */
-	transition inc2 [count < $BOUND] label "inc"(1) {
-		count+=2;
-	}
-}
-
 composite Channel {
 	// the sender sends at most three messages
 	BoundedCounter sender($BOUND=3);
@@ -59,5 +43,4 @@ composite Channel {
 }
 
 main Channel;
-
 property noDead [ctl] : AG (EX true);

--- a/lib/rouge/lexers/gal.rb
+++ b/lib/rouge/lexers/gal.rb
@@ -21,7 +21,7 @@ module Rouge
 	  TRANSIENT typedef hotbit
 	  transition synchronization label predicate
 	  for if else abort fixpoint
-	  self
+	  self main
 	  property bounds reachable invariant never ctl ltl
 	  AG AF AX EG EF EX A E U W M R X
 	  true false

--- a/lib/rouge/lexers/gal.rb
+++ b/lib/rouge/lexers/gal.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class GAL < C
+      tag 'gal'
+      filenames '*.gal'
+      mimetypes 'text/x-chdr', 'text/x-csrc'
+
+      title "GAL"
+      desc "The Guarded Action Language"
+
+      # optional comment or whitespace
+      ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
+      id = /[a-zA-Z_][a-zA-Z0-9_\.]*/
+      pid = /\$[a-zA-Z_][a-zA-Z0-9_]*/
+      
+      def self.keywords
+        @keywords ||= Set.new %w(
+          gal composite import interface extends 
+	  TRANSIENT typedef hotbit
+	  transition synchronization label predicate
+	  for if else abort fixpoint
+	  self
+	  property bounds reachable invariant never ctl ltl
+	  AG AF AX EG EF EX A E U W M R X
+	  true false
+        )
+      end
+
+      def self.keywords_type
+        @keywords_type ||= Set.new %w(
+          int array
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+	  AG AF AX EG EF EX A E U W M R X
+        )
+      end
+      
+      append :statements do 
+	rule pid do |m|
+	  name = m[0]
+	  token Name::Builtin
+	end
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/gal.rb
+++ b/lib/rouge/lexers/gal.rb
@@ -5,7 +5,6 @@ module Rouge
     class GAL < C
       tag 'gal'
       filenames '*.gal'
-      mimetypes 'text/x-chdr', 'text/x-csrc'
 
       title "GAL"
       desc "The Guarded Action Language"

--- a/spec/lexers/gal_spec.rb
+++ b/spec/lexers/gal_spec.rb
@@ -11,8 +11,5 @@ describe Rouge::Lexers::GAL do
       assert_guess :filename => 'FOO.GAL'
     end
 
-    it 'guesses by mimetype' do
-      assert_guess :mimetype => 'text/x-csrc'
-    end
   end
 end

--- a/spec/lexers/gal_spec.rb
+++ b/spec/lexers/gal_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::GAL do
+  let(:subject) { Rouge::Lexers::GAL.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.gal'
+      assert_guess :filename => 'FOO.GAL'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-csrc'
+    end
+  end
+end

--- a/spec/visual/samples/gal
+++ b/spec/visual/samples/gal
@@ -1,0 +1,229 @@
+$N=10;
+typedef index=0..$N-1;
+
+// A participant : can hold the token. Other behavior is not modeled.
+gal Participant($TOKEN=0) {
+	int hasToken=$TOKEN;
+	
+	transition get [hasToken==1] label "get" {
+		hasToken = 0;
+	}
+	transition put [hasToken==0] label "put" {
+		hasToken = 1;
+	}
+	transition reset [true] label "reset" {
+		hasToken = 0;
+	}		
+}
+composite Collaboration {
+	// the leader starts and ends cycles
+	Participant leader($TOKEN=1);
+	// A ring of participants
+	Participant [$N] ring;
+
+	// our leader gives the token to a random participant
+	synchronization start (index $i) {
+		ring[$i]."put";
+		leader."get";
+	}
+	
+	// There is a topological ring of participants
+	synchronization passToken (index $i) {
+		ring[$i]."get";
+		ring[($i+1)% $N]."put";		
+	}
+	
+	// The reset is a broadcast : the leader gets the token back forcefully
+	synchronization reset {
+		leader."put";
+		for ($i : index) {
+			ring[$i]."reset";
+		}
+	}
+	// the condition used is random/meaningless ;
+	// this example shows if/abort used to make complex synchronization
+	synchronization passFast (index $i, index $j) {
+		if ( $i!=$j && ( $i==0 || $j == $i + 2)) {
+			ring[$i]."get";
+			ring[$j]."put";
+		} else {
+			abort;
+		}		
+	} 
+	
+}
+
+main Collaboration;
+
+$MAX=3;
+typedef data=0..$MAX-1;
+
+// A lossy buffer, with a single cell, that can hold a data.
+gal Buffer {
+	// MAX models an empty buffer
+	int value=$MAX;
+	
+	/** Allows to write to the buffer, if it is empty */
+	transition put (data $d) [value==$MAX] label "send"($d) {
+		value = $d;
+	}
+	/** allows to read the value held by the buffer */
+	transition get (data $d) [value==$d] label "receive"($d) {
+		value = $MAX;
+	}
+	/** This buffer is lossy, at any time (no label) the data can be lost. */
+	transition lose [value!=$MAX] {
+		value = $MAX;
+	}		
+}
+// An example (buggy) counter ; can be incremented up to a bound.
+gal BoundedCounter($BOUND=5) {
+	int count=0;
+	
+	/** The quantity to increment by is passed through the label.	 */
+	transition inc (data $d) [count < $BOUND] label "inc"($d) {
+		count+=$d;
+	}
+	/** incrementing by one should increment by one. 
+	*   But it could also not increment because this counter is buggy. */
+	transition inc2 [count < $BOUND] label "inc"(1) {
+		count+=2;
+	}
+}
+
+composite Channel {
+	// the sender sends at most three messages
+	BoundedCounter sender($BOUND=3);
+	Buffer buff;
+	// to count the sum of all data values in actually received packets
+	BoundedCounter summer($BOUND=20);
+	// to count the number of received messages
+	BoundedCounter receiver;
+	
+	// our sender sends a random packet, and increments its send counter by one
+	synchronization sendData (data $d) {
+		sender."inc"(1);
+		buff."send"($d);
+	}
+	// at reception, we read the data from the buffer
+	synchronization receiveData (data $d) {
+		buff."receive"($d);		
+		// increment "summer" by the value in the packet
+		summer."inc"($d);
+		// increment received message counter by 1 : a constant value
+		receiver."inc"(1);
+	}	
+}
+
+main Channel;
+
+gal Philo {
+	int think = 1 ;
+	int waitL = 0 ;
+	int waitR = 0 ;
+	int hasL = 0 ;
+	int hasR = 0 ;
+	int eat = 0;
+	int fork = 1 ;
+
+	transition ask [think >= 1] {
+		think-= 1 ;
+		waitR+= 1 ;
+		waitL+= 1 ;
+	}
+	transition getL [waitL >= 1 && fork >=1] {		
+		fork-= 1 ;
+		waitL-= 1 ;
+		hasL+= 1 ;
+	}
+	transition giveFork [fork >= 1] label "takeFork" {
+		fork-=1;
+	}
+	transition returnFork [true] label "returnFork" {
+		fork+=1;
+	}	
+	transition getR [waitR >= 1] label "getRight" {
+		waitR -= 1 ;
+		hasR += 1 ;
+	}
+	transition eat [hasR >= 1 && hasL >= 1] {
+		eat += 1 ;
+		hasL-=1 ;
+		hasR-=1 ;
+	}	
+	transition release [eat >= 1] label "endEat" {
+		eat-=1;
+		fork+=1;
+		think+=1;
+	}
+}
+
+composite ThreePhilo {
+	Philo p0;
+	Philo p1;
+	Philo p2;
+		
+	synchronization get0 {
+		p0."getRight";
+		p1."takeFork"; 
+	}
+	synchronization end0 {
+		p0."endEat";
+		p1."returnFork"; 
+	}
+	synchronization get1 {
+		p1."getRight";
+		p2."takeFork"; 
+	}
+	synchronization end1 {
+		p1."endEat";
+		p2."returnFork"; 
+	}
+	synchronization get2 {
+		p2."getRight";
+		p0."takeFork"; 
+	}
+	synchronization end2 {
+		p2."endEat";
+		p0."returnFork"; 
+	}
+}
+
+main ThreePhilo ;
+
+// Test for absence of deadlocks
+property noDeadlocks [ctl] : AG(EX(true)) ;
+
+// p0 and p2 never eat simultaneously.
+property mutEx [ctl] : AG (! (p0:eat==1 && p2:eat==1));
+
+// Whenever philosopher 0 finishes eating, philosopher 1 **can** eat before philo 0 eats again.
+property turns [ctl] : 
+	AG (p0:eat==1 
+		-> (
+			A p0:eat==1 U 
+				p0:eat==0 && 
+				(E p0:eat==0 U p1:eat==1) 
+			)		
+	);
+
+
+// Whenever philosopher 0 finishes eating, he cannot eat again until philosopher 1 has eaten.
+property fair [ctl] : 
+	AG (p0:eat==1 
+		-> (
+			A p0:eat==1 U 
+				p0:eat==0 && 
+				(A p0:eat==0 U p1:eat==1) 
+			)		
+	);
+
+// Philo 0 will be the first to eat
+property firstEater [ctl] : 
+	A  (p1:eat==0 && p2:eat==0) U  p0:eat==1 ; 
+
+// Existence of a home state (a.k.a reset property)
+property home [ctl] :
+	AG ( EF (p0:eat==0 && p1:eat==0 && p2:eat==0 ));
+
+


### PR DESCRIPTION
The Guarded Action Language is a DSL for model-checking concurrent systems.
It is the pivot language used in the ITS-tools.

See homepage : https://lip6.github.io/ITSTools-web/gal.html
where rouge will be useful

This code is basically reusing (inheritance) the C lexer, with 
* different keywords
* additional rules for identifiers for $var which is not recognized in C

Thanks for building this tool.