### PR TITLE
Docker tooling to manage build environment in order to simplify the "Setting up Ruby" ordeal.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.4.1
+COPY . /src
+WORKDIR /src
+RUN bundle install
+ENTRYPOINT ["rackup", "-o", "0.0.0.0"]
+CMD ["-p", "9292"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+ROUGE_PORT=-p "9292:9292"
+
+image:
+	docker build . -t \
+		rouge-dev
+
+shell:
+	docker run \
+		--rm -it -v "${PWD}:/src" -w /src \
+		--entrypoint /bin/bash \
+		rouge-dev
+
+test:
+	docker run \
+		--rm -it -v "${PWD}:/src" -w /src \
+		--entrypoint rake \
+		rouge-dev
+
+server:
+	docker run \
+		--rm -it -v "${PWD}:/src" -w /src \
+		${ROUGE_PORT} \
+		rouge-dev


### PR DESCRIPTION
Quite honestly, I don't expect this to get accepted but I've developed this "nasty" habit of creating docker sandboxes for almost all of the project work on in order to contain dependencies and project-related state. Working on different projects is much easier when the project's impact to the state of my host machine is contained. Less housekeeping troubles for me.

Getting started with a build environment is as easy as running `make image`, which builds the Docker image, and subsequently running `make server` or `make shell` depending on whether you want to run the server or drop into a bash shell in the build environment. The `make test` rule just runs the test :wink:. After you're done you can simply remove your containers and images and continue your merry life. Since your host machine doesn't have to go through the [installation of ry](https://github.com/jneen/rouge/wiki/Setting-up-Ruby), rbenv or rvm or whatever else the cool kids on the block are using you have little environment management going on and your host maintains its zen state.

> NOTE: The `make shell` could've just dropped into the already running server instance (if there is one), but starting a whole new instance just for the shell should be fine in most use cases. If you need to drop into the shell of the instance currently running the server consider something like `docker exec --it NAME_OF_IMAGE /bin/bash`.