### PR TITLE
Add SuperCollider language support

### DIFF
--- a/lib/rouge/demos/supercollider
+++ b/lib/rouge/demos/supercollider
@@ -1,0 +1,11 @@
+// modulate a sine frequency and a noise amplitude with another sine
+// whose frequency depends on the horizontal mouse pointer position
+~myFunction = {
+        var x = SinOsc.ar(MouseX.kr(1, 100));
+        SinOsc.ar(300 * x + 800, 0, 0.1)
+        +
+        PinkNoise.ar(0.1 * x + 0.1)
+};
+
+~myFunction.play;
+"that's all, folks!".postln;

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -107,6 +107,13 @@ module Rouge
 
         Plist
       end
+
+      disambiguate '*.sc' do
+        next Python if matches?(/^#/)
+        next SuperCollider if matches?(/(?:^~|;$)/)
+
+        next Python
+      end
     end
   end
 end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "The Python programming language (python.org)"
       tag 'python'
       aliases 'py'
-      filenames '*.py', '*.pyw', '*.sc', 'SConstruct', 'SConscript', '*.tac'
+      filenames '*.py', '*.pyw', 'SConstruct', 'SConscript', '*.tac'
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "The Python programming language (python.org)"
       tag 'python'
       aliases 'py'
-      filenames '*.py', '*.pyw', 'SConstruct', 'SConscript', '*.tac'
+      filenames '*.py', '*.pyw', '*.sc', 'SConstruct', 'SConscript', '*.tac'
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -134,9 +134,9 @@ module Rouge
         # punctuation
         rule /[\{\}()\[\];,\.]/, Punctuation
 
-        # operators
+        # operators. treat # (array unpack) as an operator
         rule /[\+\-\*\/&\|%<>=]+/, Operator
-        rule /[\^:]/, Operator
+        rule /[\^:#]/, Operator
 
         # treat curry argument as a special operator
         rule /_/, Name::Builtin

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -105,7 +105,9 @@ module Rouge
 
         # class name
         rule /[A-Z]\w*/, Name::Class
-        rule /_\W+/, Name::Function
+
+        # primitive
+        rule /_\w+/, Name::Function
 
         # main identifiers section
         rule /[a-z]\w*/ do |m|
@@ -134,9 +136,10 @@ module Rouge
 
         # operators
         rule /[\+\-\*\/&\|%<>=]+/, Operator
+        rule /[\^:]/, Operator
 
-        # treat "return" as a special operator
-        rule /\^/, Keyword
+        # treat curry argument as a special operator
+        rule /_/, Name::Builtin
 
       end
     end

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class SuperCollider < RegexLexer
+      tag 'supercollider'
+      filenames '*.sc', '*.scd'
+
+      title "SuperCollider"
+      desc 'A cross-platform interpreted programming language for sound synthesis, algorithmic composition, and realtime performance'
+
+      keywords = Set.new %w(
+        case do for forBy loop if while
+        var arg classvar const super this
+      )
+
+      constants = Set.new %w(
+        true false nil inf thisThread
+        thisMethod thisFunction thisProcess
+        thisFunctionDef currentEnvironment
+        topEnvironment
+      )
+
+      start { push :bol }
+
+      # beginning of line
+      state :bol do
+        mixin :inline_whitespace
+
+        rule(//) { pop! }
+      end
+
+      state :inline_whitespace do
+        rule /\s+/m, Text
+        mixin :has_comments
+      end
+
+      state :whitespace do
+        rule /\n+/m, Text, :bol
+        rule %r(\/\/\.*?$), Comment::Single, :bol
+        mixin :inline_whitespace
+      end
+
+      state :has_comments do
+        rule %r(/[*]), Comment::Multiline, :nested_comment
+      end
+
+      state :nested_comment do
+        mixin :has_comments
+        rule %r([*]/), Comment::Multiline, :pop!
+        rule %r([^*/]+)m, Comment::Multiline
+        rule /./, Comment::Multiline
+      end
+
+      state :root do
+        mixin :whitespace
+
+        rule /$(\\.|.)/, Str::Char
+        rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
+        rule /\d+e[+-]?[0-9]+/i, Num::Float
+        rule /0x[0-9A-Fa-f]+/, Num::Hex
+        rule /0b[01]+/, Num::Bin
+        rule /\d+/, Num::Integer
+
+#        from IDE's highlighter
+#    Token::RadixFloat, "^\\b\\d+r[0-9a-zA-Z]*(\\.[0-9A-Z]*)?" );
+#    Token::Float, "^\\b((\\d+(\\.\\d+)?([eE][-+]?\\d+)?(pi)?)|pi)\\b" );
+#    Token::HexInt, "^\\b0(x|X)(\\d|[a-f]|[A-F])+" );
+#    Token::SymbolArg, "^\\b[A-Za-z_]\\w*\\:" );
+#    Token::Name, "^[a-z]\\w*" );
+#    Token::Class, "^\\b[A-Z]\\w*" );
+#    Token::Primitive, "^\\b_\\w+" );
+#    Token::Symbol, "^\\\\\\w*" );
+#    Token::Char, "^\\$\\\\?." );
+#    Token::EnvVar, "^~\\w+" );
+#    Token::SingleLineComment, "^//[^\r\n]*" );
+#    Token::MultiLineCommentStart, "^/\\*" );
+#    Token::Operator, "^[\\+-\\*/&\\|\\^%<>=]+" );
+
+      end
+    end
+  end
+end
+

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*- #
+# frozen_string_literal: true
 
 module Rouge
   module Lexers
@@ -61,11 +62,6 @@ module Rouge
       state :root do
         mixin :whitespace
 
-        ####################
-        ##### LITERALS #####
-        ####################
-
-        # hex number
         rule /[\-+]?0[xX]\h+/, Num::Hex
 
         # radix float
@@ -74,13 +70,10 @@ module Rouge
         # normal float
         rule /[\-+]?((\d+(\.\d+)?([eE][\-+]?\d+)?(pi)?)|pi)/, Num::Float
 
-        # integer
         rule /[\-+]?\d+/, Num::Integer
 
-        # character
         rule /\$(\\.|.)/, Str::Char
 
-        # strings
         rule /"([^\\"]|\\.)*"/, Str
 
         # symbols (single-quote notation)
@@ -89,21 +82,11 @@ module Rouge
         # symbols (backslash notation)
         rule /\\\w+/, Str::Other
 
-        ####################
-        ##### COMMENTS #####
-        ####################
-
-        # single-line comments
         rule /\/\/.*$/, Comment::Single
-
-        #######################
-        ##### IDENTIFIERS #####
-        #######################
 
         # symbol arg
         rule /[A-Za-z_]\w*:/, Name::Label
 
-        # class name
         rule /[A-Z]\w*/, Name::Class
 
         # primitive
@@ -125,13 +108,6 @@ module Rouge
         # environment variables
         rule /~\w+/, Name::Variable::Global
 
-        # symbol arg
-
-        #################
-        ##### OTHER #####
-        #################
-
-        # punctuation
         rule /[\{\}()\[\];,\.]/, Punctuation
 
         # operators. treat # (array unpack) as an operator

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -61,27 +61,82 @@ module Rouge
       state :root do
         mixin :whitespace
 
-        rule /$(\\.|.)/, Str::Char
-        rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
-        rule /\d+e[+-]?[0-9]+/i, Num::Float
-        rule /0x[0-9A-Fa-f]+/, Num::Hex
-        rule /0b[01]+/, Num::Bin
-        rule /\d+/, Num::Integer
+        ####################
+        ##### LITERALS #####
+        ####################
 
-#        from IDE's highlighter
-#    Token::RadixFloat, "^\\b\\d+r[0-9a-zA-Z]*(\\.[0-9A-Z]*)?" );
-#    Token::Float, "^\\b((\\d+(\\.\\d+)?([eE][-+]?\\d+)?(pi)?)|pi)\\b" );
-#    Token::HexInt, "^\\b0(x|X)(\\d|[a-f]|[A-F])+" );
-#    Token::SymbolArg, "^\\b[A-Za-z_]\\w*\\:" );
-#    Token::Name, "^[a-z]\\w*" );
-#    Token::Class, "^\\b[A-Z]\\w*" );
-#    Token::Primitive, "^\\b_\\w+" );
-#    Token::Symbol, "^\\\\\\w*" );
-#    Token::Char, "^\\$\\\\?." );
-#    Token::EnvVar, "^~\\w+" );
-#    Token::SingleLineComment, "^//[^\r\n]*" );
-#    Token::MultiLineCommentStart, "^/\\*" );
-#    Token::Operator, "^[\\+-\\*/&\\|\\^%<>=]+" );
+        # hex number
+        rule /[\-+]?0[xX]\h+/, Num::Hex
+
+        # radix float
+        rule /[\-+]?\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, Num::Float
+
+        # normal float
+        rule /[\-+]?((\d+(\.\d+)?([eE][\-+]?\d+)?(pi)?)|pi)/, Num::Float
+
+        # integer
+        rule /[\-+]?\d+/, Num::Integer
+
+        # character
+        rule /\$(\\.|.)/, Str::Char
+
+        # strings
+        rule /"([^\\"]|\\.)*"/, Str
+
+        # symbols (single-quote notation)
+        rule /'([^\\']|\\.)*'/, Str::Other
+
+        # symbols (backslash notation)
+        rule /\\\w+/, Str::Other
+
+        ####################
+        ##### COMMENTS #####
+        ####################
+
+        # single-line comments
+        rule /\/\/.*$/, Comment::Single
+
+        #######################
+        ##### IDENTIFIERS #####
+        #######################
+
+        # symbol arg
+        rule /[A-Za-z_]\w*:/, Name::Label
+
+        # class name
+        rule /[A-Z]\w*/, Name::Class
+        rule /_\W+/, Name::Function
+
+        # main identifiers section
+        rule /[a-z]\w*/ do |m|
+          if keywords.include? m[0]
+            token Keyword
+          elsif constants.include? m[0]
+            token Keyword::Constant
+          elsif reserved.include? m[0]
+            token Keyword::Reserved
+          else
+            token Name
+          end
+        end
+
+        # environment variables
+        rule /~\w+/, Name::Variable::Global
+
+        # symbol arg
+
+        #################
+        ##### OTHER #####
+        #################
+
+        # punctuation
+        rule /[\{\}()\[\];,\.]/, Punctuation
+
+        # operators
+        rule /[\+\-\*\/&\|%<>=]+/, Operator
+
+        # treat "return" as a special operator
+        rule /\^/, Keyword
 
       end
     end

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -10,8 +10,14 @@ module Rouge
       desc 'A cross-platform interpreted programming language for sound synthesis, algorithmic composition, and realtime performance'
 
       keywords = Set.new %w(
-        case do for forBy loop if while
         var arg classvar const super this
+      )
+
+      # these aren't technically keywords, but we treat
+      # them as such because it makes things clearer 99%
+      # of the time
+      reserved = Set.new %w(
+        case do for forBy loop if while new newCopyArgs
       )
 
       constants = Set.new %w(

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -50,6 +50,7 @@ module Rouge
         rule %r(/[*]), Comment::Multiline, :nested_comment
         rule %r([*]/), Comment::Multiline, :pop!
         rule %r([^*/]+)m, Comment::Multiline
+        rule /./, Comment::Multiline
       end
 
       state :root do
@@ -107,7 +108,7 @@ module Rouge
         rule /[\^:#]/, Operator
 
         # treat curry argument as a special operator
-        rule /_/, Name::Builtin
+        rule /\b_\b/, Name::Builtin
       end
     end
   end

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -10,23 +10,29 @@ module Rouge
       title "SuperCollider"
       desc 'A cross-platform interpreted programming language for sound synthesis, algorithmic composition, and realtime performance'
 
-      keywords = Set.new %w(
-        var arg classvar const super this
-      )
+      def self.keywords
+        @keywords ||= Set.new %w(
+          var arg classvar const super this
+        )
+      end
 
       # these aren't technically keywords, but we treat
       # them as such because it makes things clearer 99%
       # of the time
-      reserved = Set.new %w(
-        case do for forBy loop if while new newCopyArgs
-      )
+      def self.reserved
+        @reserved ||= Set.new %w(
+          case do for forBy loop if while new newCopyArgs
+        )
+      end
 
-      constants = Set.new %w(
-        true false nil inf thisThread
-        thisMethod thisFunction thisProcess
-        thisFunctionDef currentEnvironment
-        topEnvironment
-      )
+      def self.constants
+        @constants ||= Set.new %w(
+          true false nil inf thisThread
+          thisMethod thisFunction thisProcess
+          thisFunctionDef currentEnvironment
+          topEnvironment
+        )
+      end
 
       start { push :bol }
 
@@ -94,11 +100,11 @@ module Rouge
 
         # main identifiers section
         rule /[a-z]\w*/ do |m|
-          if keywords.include? m[0]
+          if self.class.keywords.include? m[0]
             token Keyword
-          elsif constants.include? m[0]
+          elsif self.class.constants.include? m[0]
             token Keyword::Constant
-          elsif reserved.include? m[0]
+          elsif self.class.reserved.include? m[0]
             token Keyword::Reserved
           else
             token Name

--- a/spec/lexers/python_spec.rb
+++ b/spec/lexers/python_spec.rb
@@ -10,6 +10,10 @@ describe Rouge::Lexers::Python do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.py'
       assert_guess :filename => 'foo.pyw'
+      assert_guess :filename => '*.sc', :source => '# A comment'
+      assert_guess :filename => 'SConstruct'
+      assert_guess :filename => 'SConscript'
+      assert_guess :filename => 'foo.tac'
     end
 
     it 'guesses by mimetype' do

--- a/spec/lexers/supercollider_spec.rb
+++ b/spec/lexers/supercollider_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::SuperCollider do
+  let(:subject) { Rouge::Lexers::SuperCollider.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.scd'
+      assert_guess :filename => 'foo.sc'
+    end
+  end
+end

--- a/spec/lexers/supercollider_spec.rb
+++ b/spec/lexers/supercollider_spec.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*- #
+# frozen_string_literal: true
 
 describe Rouge::Lexers::SuperCollider do
   let(:subject) { Rouge::Lexers::SuperCollider.new }

--- a/spec/lexers/supercollider_spec.rb
+++ b/spec/lexers/supercollider_spec.rb
@@ -9,7 +9,8 @@ describe Rouge::Lexers::SuperCollider do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.scd'
-      assert_guess :filename => 'foo.sc'
+      assert_guess :filename => 'foo.sc', :source => '~x = 3'
+      assert_guess :filename => 'foo.sc', :source => '0;'
     end
   end
 end

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -1,3 +1,15 @@
+// modulate a sine frequency and a noise amplitude with another sine
+// whose frequency depends on the horizontal mouse pointer position
+~myFunction = {
+        var x = SinOsc.ar(MouseX.kr(1, 100));
+        SinOsc.ar(300 * x + 800, 0, 0.1)
+        +
+        PinkNoise.ar(0.1 * x + 0.1)
+};
+
+~myFunction.play;
+"that's all, folks!".postln;
+
 /* Test Class */
 Collection {
 	*newFrom { | aCollection |
@@ -62,6 +74,13 @@ Collection {
     postln("Bye!");
 };
 
+// function calls with symbol arguments:
+s.boot(startAliveThread: false, recover: true);
+Array.geom(size: 5, start: 1, grow: 8);
+[ 1, 8, 64, 512, 4096 ].collect { arg n;
+	n.squared
+};
+
 // some numbers
 // integers
 0;
@@ -83,9 +102,7 @@ Collection {
 1e-5;
 0.5e-5;
 10r2034.5;
-36r2358.abcdz;
 36r2358.ABCDZ;
--36r2358.abcdz;
 -36r2358.ABCDZ;
 15pi;
 15 pi;
@@ -98,6 +115,13 @@ Collection {
 "\"quoted\"";
 "\ttabbed\t";
 "\\\ttabbed with backslashes\t\\";
+
+// symbols
+\abc
+\a1
+\a_symbol
+'a symbol'
+'a cl3v3r\'_symb0l"'
 
 // characters
 $a;

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -94,6 +94,9 @@ Array.geom(size: 5, start: 1, grow: 8);
 	n.squared
 };
 
+// array unpacking
+#a, b, c = [1, 4, 9];
+
 // some numbers
 // integers
 0;

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -61,8 +61,8 @@ Collection {
 		^obj
 	}
 
-  // from Array
-  mirror2 {
+	// from Array
+	mirror2 {
 		_ArrayMirror2
 		^this.primitiveFailed
 	}

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -1,0 +1,111 @@
+/* Test Class */
+Collection {
+	*newFrom { | aCollection |
+		var newCollection = this.new(aCollection.size);
+		aCollection.do {| item | newCollection.add(item) };
+		^newCollection
+	}
+	*with { | ... args |
+		var newColl;
+		// answer a collection of my class of the given arguments
+		// the class Array has a simpler implementation
+		newColl = this.new(args.size);
+		newColl.addAll(args);
+		^newColl
+	}
+	*fill { | size, function |
+		var obj;
+		if(size.isSequenceableCollection) { ^this.fillND(size, function) };
+		obj = this.new(size);
+		size.do { | i |
+			obj.add(function.value(i));
+		};
+		^obj
+	}
+	*fill2D { | rows, cols, function |
+		var obj = this.new(rows);
+		rows.do { |row|
+			var obj2 = this.new(cols);
+			cols.do { |col|
+				obj2 = obj2.add(function.value(row, col))
+			};
+			obj = obj.add(obj2);
+		};
+		^obj
+	}
+	*fill3D { | planes, rows, cols, function |
+		var obj = this.new(planes);
+		planes.do { |plane|
+			var obj2 = this.new(rows);
+			rows.do { |row|
+				var obj3 = this.new(cols);
+				cols.do { |col|
+					obj3 = obj3.add(function.value(plane, row, col))
+				};
+				obj2 = obj2.add(obj3);
+			};
+			obj = obj.add(obj2);
+		};
+		^obj
+	}
+}
+
+/* This is a multiline comment 
+ /* With nesting! */
+   End of multiline comment */
+
+~environmentVariable = { 3.do(_.postln) };
+
+~environmentVariable.value();
+
+~myFunction = { arg size, offset, freq;
+    postln("Bye!");
+};
+
+// some numbers
+// integers
+0;
+10;
+33;
+-235;
+0x15;
+0x159abcdef;
+0x159ABCDEF;
+2r01;
+8r711;
+36rabczyblkgh;
+36rAZ19GH;
+
+// floats
+0.0;
+0.0e5;
+1e5;
+1e-5;
+0.5e-5;
+10r2034.5;
+36r2358.abcdz;
+36r2358.ABCDZ;
+-36r2358.abcdz;
+-36r2358.ABCDZ;
+15pi;
+15 pi;
+-10 pi;
+-10pi;
+-1.5e7pi;
+
+// strings
+"abcdefg hijklmnop";
+"\"quoted\"";
+"\ttabbed\t";
+"\\\ttabbed with backslashes\t\\";
+
+// characters
+$a;
+$ ;
+$b;
+$0;
+$$;
+$\t;
+$\0;
+$\&;
+$\\;

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -60,6 +60,19 @@ Collection {
 		};
 		^obj
 	}
+
+  // from Array
+  mirror2 {
+		_ArrayMirror2
+		^this.primitiveFailed
+	}
+}
+
+// class inheritance
+MyClass : Object {
+	classvar <>decorations;
+	var <>igloos;
+	const magicNumber = 3;
 }
 
 /* This is a multiline comment 
@@ -71,7 +84,7 @@ Collection {
 ~environmentVariable.value();
 
 ~myFunction = { arg size, offset, freq;
-    postln("Bye!");
+	postln("Bye!");
 };
 
 // function calls with symbol arguments:

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -133,11 +133,11 @@ Array.geom(size: 5, start: 1, grow: 8);
 "\\\ttabbed with backslashes\t\\";
 
 // symbols
-\abc
-\a1
-\a_symbol
-'a symbol'
-'a cl3v3r\'_symb0l"'
+\abc;
+\a1;
+\a_symbol;
+'a symbol';
+'a cl3v3r\'_symb0l"';
 
 // characters
 $a;

--- a/spec/visual/samples/supercollider
+++ b/spec/visual/samples/supercollider
@@ -149,3 +149,18 @@ $\t;
 $\0;
 $\&;
 $\\;
+
+// curry argument vs underscore in name
+[1, 2, 3].do(_.postln);
+[1, 2, 3].collect(_ + _);
+variable_name.function_name(Class_Name);
+
+// comments
+/* abc */ notComment;
+/* /* */ comment */ notComment;
+/* /* * */ comment */ notComment;
+/* /*/ comment */ comment */ notComment;
+/* /**/ comment */ notComment;
+// /*
+notComment;
+// */


### PR DESCRIPTION
This adds support for the [SuperCollider language](supercollider.github.io).

The visual sample contains a near-complete rundown of general language cases, including corner cases that I've found as a maintainer of the language's own backend lexer. The highlighting is mostly adapted from the project's IDE's [lexing regexes](https://github.com/supercollider/supercollider/blob/master/editors/sc-ide/core/sc_lexer.cpp), which I've found to be the most solid set among all the lexers out there for the language.

Let me know if I missed anything. Thanks!