### PR TITLE
Add Solidity (lexer and examples)

### DIFF
--- a/lib/rouge/demos/solidity
+++ b/lib/rouge/demos/solidity
@@ -1,0 +1,24 @@
+pragma solidity ~0.4.15;
+
+interface IMirror {
+    function reflect() external payable returns(bool /* ain't I pretty?.. */);
+}
+
+contract Mirror is IMirror {
+    event logMessage(address indexed sender, uint256 value, uint256 gas, bytes data);
+
+    function reflect() external payable returns(bool retval) {
+        assert(msg.sender != address(this));
+        require(msg.value != 0);
+
+        IMirror rorrim = IMirror(msg.sender);
+        retval = rorrim.reflect.value(msg.value).gas(msg.gas)();
+
+        logMessage(msg.sender, msg.value, msg.gas, msg.data);
+        return retval;
+    }
+
+    function () { // no funny stuff
+       revert();
+    }
+}

--- a/lib/rouge/demos/solidity
+++ b/lib/rouge/demos/solidity
@@ -7,17 +7,6 @@ interface IMirror {
 contract Mirror is IMirror {
     event logMessage(address indexed sender, uint256 value, uint256 gas, bytes data);
 
-    function reflect() external payable returns(bool retval) {
-        assert(msg.sender != address(this));
-        require(msg.value != 0);
-
-        IMirror rorrim = IMirror(msg.sender);
-        retval = rorrim.reflect.value(msg.value).gas(msg.gas)();
-
-        logMessage(msg.sender, msg.value, msg.gas, msg.data);
-        return retval;
-    }
-
     function () { // no funny stuff
        revert();
     }

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -31,7 +31,8 @@ module Rouge
       end
 
       def self.builtins
-        @builtins ||= Set.new %w(
+        return @builtins if @builtins
+        @builtins = Set.new %w(
           now
           true false
           assert require revert
@@ -56,7 +57,8 @@ module Rouge
       end
 
       def self.keywords_type
-        @keywords_type ||= Set.new %w(
+        return @keywords_type if @keywords_type
+        @keywords_type = Set.new %w(
           int uint bytes fixed ufixed address bool
         )
 

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Solidity < RegexLexer
+      tag 'solidity'
+      filenames '*.sol', '*.solidity'
+      mimetypes 'text/x-solidity'
+
+      title "Solidity"
+      desc "Solidity, an Ethereum smart contract programming language"
+
+      # optional comment or whitespace
+      ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
+      id = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+
+      def self.analyze_text(text)
+        return 1 if text.shebang? 'pragma solidity'
+      end
+
+      # TODO: seperate by "type"
+      def self.keywords
+        @keywords ||= Set.new %w(
+          anonymous as assembly break constant continue contract do delete
+          else enum event external for function hex if indexed interface
+          internal import is library mapping memory modifier new payable
+          public pragma private return returns storage struct throw
+          using var while
+        )
+      end
+
+      def self.builtins
+        @builtins ||= Set.new %w(
+          now
+          true false
+          assert require revert
+          selfdestruct suicide
+          this super balance transfer send call callcode delegatecall
+          addmod mulmod keccak256 sha256 sha3 ripemd160 ecrecover
+        )
+        # TODO: use (currently shadowed by catch-all in :statements)
+        block = %w(blockhash coinbase difficulty gaslimit number timestamp)
+        @builtins.merge( block.map { |i| "block.#{i}" } )
+        msg = %w(data gas sender sig value)
+        @builtins.merge( msg.map { |i| "msg.#{i}" } )
+        tx = %w(gasprice origin)
+        @builtins.merge( tx.map { |i| "tx.#{i}" } )
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(
+          wei finney szabo ether
+          seconds minutes hours days weeks years
+        )
+      end
+
+      def self.keywords_type
+        @keywords_type ||= Set.new %w(
+          int uint bytes fixed ufixed address bool
+        )
+
+        # bytes1 .. bytes32
+        @keywords_type.merge( (1..32).map { |i| "bytes#{i}" } )
+
+        # size helpers
+        sizesm = (0..256).step(8)
+        sizesn = (8..256).step(8)
+        sizesmxn = sizesm.map { |m| m }
+                     .product( sizesn.map { |n| n } )
+                     .select { |m,n| m+n <= 256 }
+        # [u]int8 .. [u]int256
+        @keywords_type.merge( sizesn.map { |n|  "int#{n}" } )
+        @keywords_type.merge( sizesn.map { |n| "uint#{n}" } )
+        # [u]fixed{MxN}
+        @keywords_type.merge(sizesmxn.map { |m,n|  "fixed#{m}x#{n}" })
+        @keywords_type.merge(sizesmxn.map { |m,n| "ufixed#{m}x#{n}" })
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+          abstract after case catch default final in inline let
+          match null of pure relocatable static switch try type
+          typeof view
+        )
+      end
+
+      start { push :bol }
+
+      state :expr_bol do
+        mixin :inline_whitespace
+
+        rule(//) { pop! }
+      end
+
+      # :expr_bol is the same as :bol but without labels, since
+      # labels can only appear at the beginning of a statement.
+      state :bol do
+        mixin :expr_bol
+      end
+
+      state :inline_whitespace do
+        rule /[ \t\r]+/, Text
+        rule /\\\n/, Text # line continuation
+        rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
+      end
+
+      state :whitespace do
+        rule /\n+/m, Text, :bol
+        rule %r(//(\\.|.)*?\n), Comment::Single, :bol
+        mixin :inline_whitespace
+      end
+
+      state :expr_whitespace do
+        rule /\n+/m, Text, :expr_bol
+        mixin :whitespace
+      end
+
+      state :statements do
+        mixin :whitespace
+        rule /(hex)?\"/, Str, :string_double
+        rule /(hex)?\'/, Str, :string_single
+        rule %r('(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
+        rule /0x[0-9a-f]+/i, Num::Hex
+        rule /\d+/i, Num::Integer
+        rule %r(\*/), Error
+        rule %r([~!%^&*+=\|?:<>/-]), Operator
+        rule /(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
+        rule /[()\[\],.]/, Punctuation
+        rule id do |m|
+          name = m[0]
+
+          if self.class.keywords.include? name
+            token Keyword
+          elsif self.class.builtins.include? name
+            token Name::Builtin
+          elsif self.class.constants.include? name
+            token Keyword::Constant
+          elsif self.class.keywords_type.include? name
+            token Keyword::Type
+          elsif self.class.reserved.include? name
+            token Keyword::Reserved
+          else
+            token Name
+          end
+        end
+      end
+
+      state :root do
+        mixin :expr_whitespace
+        rule(//) { push :statement }
+        # TODO: function declarations
+      end
+
+      state :statement do
+        rule /;/, Punctuation, :pop!
+        mixin :expr_whitespace
+        mixin :statements
+        rule /[{}]/, Punctuation
+      end
+
+      state :string_common do
+        rule /\\(u[a-fA-F0-9]{4}|x..|[^x])/, Str::Escape
+        rule /[^\\\"\'\n]+/, Str
+        rule /\\\n/, Str # line continuation
+        rule /\\/, Str # stray backslash
+      end
+
+      state :string_double do
+        mixin :string_common
+        rule /\"/, Str, :pop!
+        rule /\'/, Str
+      end
+
+      state :string_single do
+        mixin :string_common
+        rule /\'/, Str, :pop!
+        rule /\"/, Str
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -11,7 +11,7 @@ module Rouge
 
       # optional comment or whitespace
       ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
-      id = /[a-zA-Z_][a-zA-Z0-9_]*/
+      id = /[a-zA-Z$_][a-zA-Z0-9$_]*/
 
       def self.detect?(text)
         return true if text.start_with? 'pragma solidity'
@@ -62,7 +62,7 @@ module Rouge
       def self.keywords_type
         return @keywords_type if @keywords_type
         @keywords_type = Set.new %w(
-          int uint bytes fixed ufixed address bool
+          address bool bytes fixed int ufixed uint string
         )
 
         # bytes1 .. bytes32

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -96,8 +96,7 @@ module Rouge
       state :inline_whitespace do
         rule %r/[ \t\r]+/, Text
         rule %r/\\\n/, Text # line continuation
-        rule %r(/[*].*?[*]/)m, Comment::Multiline
-        rule %r(/\*.*(\*/){0})m, Comment::Multiline # open to EOF
+        rule %r(/\*), Comment::Multiline, :comment_multi
       end
 
       state :whitespace do
@@ -175,6 +174,13 @@ module Rouge
         rule %r/\'/, Str, :pop!
         rule %r/\"/, Str
       end
+
+       state :comment_multi do
+         rule %r(\*/), Comment::Multiline, :pop!
+         rule %r(/\*), Comment::Multiline, :comment_multi
+         rule %r([^*/]+), Comment::Multiline
+         rule %r([*/]), Comment::Multiline
+       end
     end
   end
 end

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -62,7 +62,7 @@ module Rouge
       def self.keywords_type
         return @keywords_type if @keywords_type
         @keywords_type = Set.new %w(
-          address bool bytes fixed int ufixed uint string
+          address bool bytes fixed int string ufixed uintb
         )
 
         # bytes1 .. bytes32

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -20,7 +20,7 @@ module Rouge
       # TODO: seperate by "type"
       def self.keywords
         @keywords ||= Set.new %w(
-          abstract anonymous as assembly break catch constant
+          abstract anonymous as assembly break catch calldata constant
           constructor continue contract do delete else emit enum event
           external fallback for function hex if indexed interface
           internal import is library mapping memory modifier new

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -22,11 +22,11 @@ module Rouge
       # TODO: seperate by "type"
       def self.keywords
         @keywords ||= Set.new %w(
-          anonymous as assembly break constant continue contract do delete
-          else enum event external for function hex if indexed interface
-          internal import is library mapping memory modifier new payable
-          public pragma private return returns storage struct throw
-          using var while
+          abstract anonymous as assembly break catch constant continue
+          contract do delete else enum event external for function hex
+          if indexed interface internal import is library mapping memory
+          modifier new payable public pure pragma private return returns
+          storage struct throw try type using var view while
         )
       end
 
@@ -81,9 +81,8 @@ module Rouge
 
       def self.reserved
         @reserved ||= Set.new %w(
-          abstract after case catch default final in inline let
-          match null of pure relocatable static switch try type
-          typeof view
+          after case default final in inline let match null of
+          relocatable static switch typeof
         )
       end
 

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -46,7 +46,7 @@ module Rouge
         )
 
         # TODO: use (currently shadowed by catch-all in :statements)
-        abi = %w(encode encodePacked encodeWithSelector encodeWithSignature)
+        abi = %w(decode encode encodePacked encodeWithSelector encodeWithSignature)
         @builtins.merge( abi.map { |i| "abi.#{i}" } )
         block = %w(coinbase difficulty gaslimit hash number timestamp)
         @builtins.merge( block.map { |i| "block.#{i}" } )

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -62,7 +62,7 @@ module Rouge
       def self.keywords_type
         return @keywords_type if @keywords_type
         @keywords_type = Set.new %w(
-          address bool bytes fixed int string ufixed uintb
+          address bool bytes fixed int string ufixed uint
         )
 
         # bytes1 .. bytes32

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -3,20 +3,18 @@
 module Rouge
   module Lexers
     class Solidity < RegexLexer
+      title "Solidity"
+      desc "Solidity, an Ethereum smart contract programming language"
       tag 'solidity'
       filenames '*.sol', '*.solidity'
       mimetypes 'text/x-solidity'
-
-      title "Solidity"
-      desc "Solidity, an Ethereum smart contract programming language"
 
       # optional comment or whitespace
       ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
       id = /[a-zA-Z_][a-zA-Z0-9_]*/
 
-
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'pragma solidity'
+      def self.detect?(text)
+        return true if text.start_with? 'pragma solidity'
       end
 
       # TODO: seperate by "type"

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -23,7 +23,7 @@ module Rouge
       def self.keywords
         @keywords ||= Set.new %w(
           abstract anonymous as assembly break catch constant constructor continue
-          contract do delete else emit enum event external for function hex
+          contract do delete else emit enum event external fallback for function hex
           if indexed interface internal import is library mapping memory
           modifier new payable public pure pragma private return returns
           storage struct throw try type using var view while
@@ -86,8 +86,10 @@ module Rouge
 
       def self.reserved
         @reserved ||= Set.new %w(
-          after case default final in inline let match null of
-          relocatable static switch typeof
+          alias after apply auto case copyof default define final
+          immutable implements in inline let macro match mutable null of
+          override partial promise receive reference relocatable sealed
+          sizeof static supports switch typedef typeof unchecked virtual
         )
       end
 
@@ -105,6 +107,7 @@ module Rouge
         mixin :expr_bol
       end
 
+      # TODO: natspec in comments
       state :inline_whitespace do
         rule /[ \t\r]+/, Text
         rule /\\\n/, Text # line continuation

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -64,20 +64,9 @@ module Rouge
       end
 
       def self.keywords_type
-        return @keywords_type if @keywords_type
-
-        @keywords_type = Set.new %w(
+        @keywords_type ||= Set.new %w(
           address bool byte bytes int string uint
         )
-
-        # bytes1 .. bytes32
-        @keywords_type.merge( (1..32).map { |i| "bytes#{i}" } )
-
-        # size helper
-        sizes = (8..256).step(8)
-        # [u]int8 .. [u]int256
-        @keywords_type.merge( sizes.map { |n|  "int#{n}" } )
-        @keywords_type.merge( sizes.map { |n| "uint#{n}" } )
       end
 
       def self.reserved
@@ -134,6 +123,8 @@ module Rouge
         rule %r/(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
         rule %r/[()\[\],.]/, Punctuation
         rule %r/u?fixed\d+x\d+/, Keyword::Reserved
+        rule %r/bytes\d+/, Keyword::Type
+        rule %r/u?int\d+/, Keyword::Type
         rule id do |m|
           name = m[0]
 

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -20,11 +20,13 @@ module Rouge
       # TODO: seperate by "type"
       def self.keywords
         @keywords ||= Set.new %w(
-          abstract anonymous as assembly break catch constant constructor continue
-          contract do delete else emit enum event external fallback for function hex
-          if indexed interface internal import is library mapping memory
-          modifier new payable public pure pragma private return returns
-          storage struct throw try type using var view while
+          abstract anonymous as assembly break catch constant
+          constructor continue contract do delete else emit enum event
+          external fallback for function hex if indexed interface
+          internal import is library mapping memory modifier new
+          override payable public pure pragma private receive return
+          returns storage struct throw try type using var view virtual
+          while
         )
       end
 
@@ -84,9 +86,8 @@ module Rouge
         @reserved ||= Set.new %w(
           alias after apply auto case copyof default define final fixed
           immutable implements in inline let macro match mutable null of
-          override partial promise receive reference relocatable sealed
-          sizeof static supports switch typedef typeof ufixed unchecked
-          virtual
+          partial promise reference relocatable sealed sizeof static
+          supports switch typedef typeof ufixed unchecked
         )
 
         # size helpers

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -11,7 +11,7 @@ module Rouge
 
       # optional comment or whitespace
       ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
-      id = /[a-zA-Z$_][a-zA-Z0-9$_]*/
+      id = /[a-zA-Z$_][\w$_]*/
 
       def self.detect?(text)
         return true if text.start_with? 'pragma solidity'

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -81,23 +81,12 @@ module Rouge
       end
 
       def self.reserved
-        return @reserved if @reserved
-
         @reserved ||= Set.new %w(
           alias after apply auto case copyof default define final fixed
           immutable implements in inline let macro match mutable null of
           partial promise reference relocatable sealed sizeof static
           supports switch typedef typeof ufixed unchecked
         )
-
-        # size helpers
-        sizesm = (8..256).step(8)
-        sizesn = (0..80)
-        sizesmxn = sizesm.map { |m| m }
-                     .product( sizesn.map { |n| n } )
-        # [u]fixed{MxN}
-        @reserved.merge(sizesmxn.map { |m,n|  "fixed#{m}x#{n}" })
-        @reserved.merge(sizesmxn.map { |m,n| "ufixed#{m}x#{n}" })
       end
 
       start { push :bol }
@@ -144,6 +133,7 @@ module Rouge
         rule %r([~!%^&*+=\|?:<>/-]), Operator
         rule %r/(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
         rule %r/[()\[\],.]/, Punctuation
+        rule %r/u?fixed\d*x\d*/, Keyword::Reserved
         rule id do |m|
           name = m[0]
 

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -96,7 +96,8 @@ module Rouge
       state :inline_whitespace do
         rule %r/[ \t\r]+/, Text
         rule %r/\\\n/, Text # line continuation
-        rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
+        rule %r(/[*].*?[*]/)m, Comment::Multiline
+        rule %r(/\*.*(\*/){0})m, Comment::Multiline # open to EOF
       end
 
       state :whitespace do

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -120,7 +120,6 @@ module Rouge
         rule %r/\d+([eE]\d+)?/i, Num::Integer
         rule %r(\*/), Error
         rule %r([~!%^&*+=\|?:<>/-]), Operator
-        rule %r/(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
         rule %r/[()\[\],.]/, Punctuation
         rule %r/u?fixed\d+x\d+/, Keyword::Reserved
         rule %r/bytes\d+/, Keyword::Type

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -91,11 +91,10 @@ module Rouge
         )
 
         # size helpers
-        sizesm = (0..256).step(8)
-        sizesn = (8..256).step(8)
+        sizesm = (8..256).step(8)
+        sizesn = (0..80)
         sizesmxn = sizesm.map { |m| m }
                      .product( sizesn.map { |n| n } )
-                     .select { |m,n| m+n <= 256 }
         # [u]fixed{MxN}
         @reserved.merge(sizesmxn.map { |m,n|  "fixed#{m}x#{n}" })
         @reserved.merge(sizesmxn.map { |m,n| "ufixed#{m}x#{n}" })

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -177,7 +177,6 @@ module Rouge
 
        state :comment_multi do
          rule %r(\*/), Comment::Multiline, :pop!
-         rule %r(/\*), Comment::Multiline, :comment_multi
          rule %r([^*/]+), Comment::Multiline
          rule %r([*/]), Comment::Multiline
        end

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -109,34 +109,34 @@ module Rouge
 
       # TODO: natspec in comments
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
-        rule /\\\n/, Text # line continuation
+        rule %r/[ \t\r]+/, Text
+        rule %r/\\\n/, Text # line continuation
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :bol
+        rule %r/\n+/m, Text, :bol
         rule %r(//(\\.|.)*?\n), Comment::Single, :bol
         mixin :inline_whitespace
       end
 
       state :expr_whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         mixin :whitespace
       end
 
       state :statements do
         mixin :whitespace
-        rule /(hex)?\"/, Str, :string_double
-        rule /(hex)?\'/, Str, :string_single
+        rule %r/(hex)?\"/, Str, :string_double
+        rule %r/(hex)?\'/, Str, :string_single
         rule %r('(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
-        rule /\d\d*\.\d+([eE]\d+)?/i, Num::Float
-        rule /0x[0-9a-f]+/i, Num::Hex
-        rule /\d+([eE]\d+)?/i, Num::Integer
+        rule %r/\d\d*\.\d+([eE]\d+)?/i, Num::Float
+        rule %r/0x[0-9a-f]+/i, Num::Hex
+        rule %r/\d+([eE]\d+)?/i, Num::Integer
         rule %r(\*/), Error
         rule %r([~!%^&*+=\|?:<>/-]), Operator
-        rule /(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
-        rule /[()\[\],.]/, Punctuation
+        rule %r/(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
+        rule %r/[()\[\],.]/, Punctuation
         rule id do |m|
           name = m[0]
 
@@ -163,29 +163,29 @@ module Rouge
       end
 
       state :statement do
-        rule /;/, Punctuation, :pop!
+        rule %r/;/, Punctuation, :pop!
         mixin :expr_whitespace
         mixin :statements
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
       end
 
       state :string_common do
-        rule /\\(u[a-fA-F0-9]{4}|x..|[^x])/, Str::Escape
-        rule /[^\\\"\'\n]+/, Str
-        rule /\\\n/, Str # line continuation
-        rule /\\/, Str # stray backslash
+        rule %r/\\(u[a-fA-F0-9]{4}|x..|[^x])/, Str::Escape
+        rule %r/[^\\\"\'\n]+/, Str
+        rule %r/\\\n/, Str # line continuation
+        rule %r/\\/, Str # stray backslash
       end
 
       state :string_double do
         mixin :string_common
-        rule /\"/, Str, :pop!
-        rule /\'/, Str
+        rule %r/\"/, Str, :pop!
+        rule %r/\'/, Str
       end
 
       state :string_single do
         mixin :string_common
-        rule /\'/, Str, :pop!
-        rule /\"/, Str
+        rule %r/\'/, Str, :pop!
+        rule %r/\"/, Str
       end
     end
   end

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -133,7 +133,7 @@ module Rouge
         rule %r([~!%^&*+=\|?:<>/-]), Operator
         rule %r/(?:block|msg|tx)\.[a-z]*\b/, Name::Builtin
         rule %r/[()\[\],.]/, Punctuation
-        rule %r/u?fixed\d*x\d*/, Keyword::Reserved
+        rule %r/u?fixed\d+x\d+/, Keyword::Reserved
         rule id do |m|
           name = m[0]
 

--- a/spec/lexers/solidity_spec.rb
+++ b/spec/lexers/solidity_spec.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Solidity do
+  let(:subject) { Rouge::Lexers::Solidity.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.sol'
+      assert_guess :filename => 'foo.solidity'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-solidity'
+    end
+
+    # it 'guesses by source' do
+    #   assert_guess :source => 'pragma solidity'
+    # end
+  end
+end

--- a/spec/lexers/solidity_spec.rb
+++ b/spec/lexers/solidity_spec.rb
@@ -15,8 +15,8 @@ describe Rouge::Lexers::Solidity do
       assert_guess :mimetype => 'text/x-solidity'
     end
 
-    # it 'guesses by source' do
-    #   assert_guess :source => 'pragma solidity'
-    # end
+    it 'guesses by source' do
+      assert_guess :source => 'pragma solidity'
+    end
   end
 end

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -1,0 +1,220 @@
+pragma solidity ^0.4.1;
+
+/**********************************************************************
+ *                             example.sol                            *
+ **********************************************************************/
+
+// Code in this contract is not meant to work (or be a good example).
+// It is meant to demonstrate good syntax highlighting by pygments,
+// even if otherwise hazardous.
+
+// Comments relevant to the lexer are single-line.
+/* Comments relevant to the code are multi-line. */
+
+library Assembly {
+    function junk(address _addr) returns (address _ret) {
+        assembly {
+            let tmp := 0
+
+            // nested code block
+            let mulmod_ := 0 { // evade collision with `mulmod`
+                let tmp:=sub(mulmod_,1) // `tmp` is not a label
+                mulmod_ := tmp
+            }
+            /* guess what mulmod_ is now... */
+        _loop: // JIC, dots are invalid in labels
+            let i := 0x10
+        loop:
+            // Escape sequences in comments are not parsed.
+            /* Not sure what's going on here, but it sure is funky!
+             \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ \o/ */
+            mulmod(_addr, mulmod_, 160)
+            
+            0x1 i sub // instructional style
+            i =: tmp /* tmp not used */
+            
+            jumpi(loop, not(iszero(i)))
+            
+            mstore(0x0, _addr)
+            return(0x0, 160)
+        }
+    }
+}
+
+contract Strings {
+    // `double` is not a keyword (yet)
+    string doublestr = "This\ is a string\nwith \"escapes\",\
+and it's multi-line. // no comment"; // comment ok // even nested :)
+    string singlestr = 'This\ is a string\nwith "escapes",\
+and it\'s multi-line. // no comment'; // same thing, single-quote
+    string hexstr = hex'537472696e67732e73656e6428746869732e62616c616e6365293b';
+
+    function(){}
+}
+
+contract Types is Strings {
+    using Assembly for Assembly.junk;
+    
+    // typesM (compiler doesn't choke on invalid)
+    int8 i8; // valid
+    int10 i10; // invalid
+    uint256 ui256; // valid
+    uint9001 ui9001; // invalid
+    bytes1 b1; //valid
+    bytes42 b42; // invalid: M out of range for `bytes`
+    
+    // typesMxN (compiler doesn't choke on invalid)
+    fixed0x8 f0x8; // valid
+    fixed8x0 f8x0; // invalid - N can't be 0
+    ufixed42x217 uf42x217; // invalid: M and N must be multiples of 8
+    fixed224x16 f224x16; // valid
+    ufixed256x256 uf256x256; // invalid: M+N > 256
+
+    // special cases (internally not types)
+    string str; // dynamic array (not a value-type)
+    bytes bs; // same as above
+    //var v = 5; // `var` is a keyword, not a type, and compiler chokes
+
+    address a = "0x1"; // lexer parses as string
+    struct AddressMap {
+        address origin;
+        address result;
+        address sender;
+        bool touched;
+    }
+    mapping (address => AddressMap) touchedMe;
+
+    function failOnNegative(int8 _arg)
+        private
+        constant
+        returns (uint256)
+    {
+        /* implicit type conversion from `int8` to `uint256` */
+        return _arg;
+    }
+
+    // some arithmetic operators + built-in names
+    function opportunisticSend(address k) private {
+        /* `touchedMe[k].result` et al are addresses, so
+           `send()` available */
+        touchedMe[k].origin.send(k**2 % 100 finney);
+        touchedMe[k].result.send(1 wei);
+        touchedMe[k].sender.send(mulmod(1 szabo, k, 42));
+    }
+
+    function() payable {
+        /* inferred type: address */
+        var k = msg.sender;
+        /* inferred type: `ufixed0x256` */
+        var v = 1/42;
+        /* can't be `var` - location specifier requires explicit type */
+        int storage negative = -1;
+
+        // valid syntax, unexpected result - not our problem
+        ui256 = failOnNegative(negative);
+        
+        // logic operators
+        if ((!touchedMe[msg.sender].touched &&
+             !touchedMe[tx.origin].touched) ||
+            ((~(msg.sender * v + a)) % 256 == 42)
+        ) {
+            address memory garbled = Assembly.junk(a + msg.sender);
+
+            /* create a new AddressMap struct in storage */
+            AddressMap storage tmp;
+
+            // TODO: highlight all known internal keywords?
+            tmp.origin = tx.origin;
+            tmp.result = garbled;
+            tmp.sender = msg.sender;
+            tmp.touched = true;
+
+            /* does this link-by-reference as expected?.. */
+            touchedMe[msg.sender] = tmp;
+            touchedMe[tx.origin] = tmp;
+        }
+        else {
+            /* weak guard against re-entry */
+            touchedMe[k].touched = false;
+            
+            opportunisticSend(k);
+            
+            delete touchedMe[k];
+            /* these probably do nothing... */
+            delete touchedMe[msg.sender];
+            delete touchedMe[tx.origin];
+        }
+    }
+}
+
+/**
+   \brief Examples of bad practices.
+
+   TODO: This special doxygen natspec notation is not parsed yet.
+
+   @author Noel Maersk
+ */
+/// TODO: Neither is this one.
+
+contract BadPractices {
+    address constant creator; /* `internal` by default */
+    address private owner; /* forbid inheritance */
+    bool mutex;
+
+    modifier critical {
+        if (mutex) throw;
+        mutex = true;
+        _;
+        mutex = false;
+    }
+    
+    /* constructor */
+    function BadPractices() {
+        creator = tx.origin;
+        owner = msg.sender;
+    }
+
+    /* Dangerous - function public (by default), and doesn't check
+       who's calling. */
+    function withdraw(uint _amount)
+        critical
+        returns (bool)
+    { /* `mutex` set via modifier */
+        if (msg.sender.call.value(_amount)())
+            throw; /* Throwing on failed call is dangerous.
+                      Consider returning false instead?.. */
+        return true;
+    } /* `mutex` reset via modifier */
+    
+    /* fallback */
+    function () payable {
+        /* `i` will be `uint8`, so this is an endless loop
+           that will consume all gas and eventually throw.
+         */
+        for (var i = 0; i < 257; i++) {
+            owner++;
+        }
+    }
+}
+
+/*
+// Open comment to EOF. Compiler chokes on this, but it's useful
+// for highlighting to show that there's an unmatched multi-line
+// comment open.
+
+contract MoreBadPractices is BadPractices {
+    uint balance;
+
+    // These would close the comment if the space was removed:
+    * /
+    \* /
+
+    / * no modifiers to check ownership * /
+    function () payable {
+        balance += msg.value;
+
+        / * vulnerable to re-entry * /
+        if (!msg.sender.send(this.balance / 10)) throw;
+        balance -= this.balance;
+    }
+}

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -14,7 +14,7 @@ pragma experimental SMTChecker;
 /* Comments relevant to the code are multi-line. */
 
 library Assembly {
-    public function junk(address _addr) private returns (address _ret) {
+    function junk(address _addr) private returns (address _ret) {
         assembly {
             let tmp := 0
 
@@ -51,7 +51,7 @@ and it's multi-line. // no comment"; // comment ok // even nested :)
 and it\'s multi-line. // no comment'; // same thing, single-quote
     string hexstr = hex'537472696e67732e73656e6428746869732e62616c616e6365293b';
 
-    fallback() external {}
+    fallback() external payable virtual {}
 
     receive() external payable {
         revert();
@@ -83,7 +83,7 @@ contract Types is Strings {
     string str; // dynamic array (not a value-type)
     bytes bs; // same as above
     //var v = 5; // `var` is a keyword, not a type, and compiler chokes
-    var unu$ed; // `var` is highlighted, though, and `$` is a valid char
+    uint unu$ed; // `var` is highlighted, though, and `$` is a valid char
 
     address a = "0x1"; // lexer parses as string
     struct AddressMap {
@@ -94,9 +94,9 @@ contract Types is Strings {
     }
     mapping (address => AddressMap) touchedMe;
 
-    public function failOnNegative(int8 _arg)
+    function failOnNegative(int8 _arg)
         private
-        constant
+        pure
         returns (uint256)
     {
         /* implicit type conversion from `int8` to `uint256` */
@@ -104,15 +104,15 @@ contract Types is Strings {
     }
 
     // some arithmetic operators + built-in names
-    public function opportunisticSend(address k) private {
+    function opportunisticSend(address k) private {
         /* `touchedMe[k].result` et al are addresses, so
            `send()` available */
-        touchedMe[k].origin.send(k**2 % 100 finney);
+        touchedMe[k].origin.send(uint256(k)**2 % 100 finney);
         touchedMe[k].result.send(1 wei);
         touchedMe[k].sender.send(mulmod(1 szabo, k, 42));
     }
 
-    fallback() external payable {
+    fallback() external payable override {
         /* inferred type: address */
         var k = msg.sender;
         /* inferred type: `ufixed0x256` */
@@ -178,13 +178,14 @@ contract BadPractices {
         mutex = false;
     }
     
-    constructor {
+    constructor() external {
         creator = tx.origin;
         owner = msg.sender;
     }
 
     /* Dangerous - function public, and doesn't check who's calling. */
-    public function withdraw(uint _amount)
+    function withdraw(uint _amount)
+        public
         critical
         returns (bool)
     { /* `mutex` set via modifier */
@@ -203,6 +204,8 @@ contract BadPractices {
             owner++;
         }
     }
+
+    /* receive()?.. nah, why bother */
 }
 
 /*

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -83,6 +83,7 @@ contract Types is Strings {
     string str; // dynamic array (not a value-type)
     bytes bs; // same as above
     //var v = 5; // `var` is a keyword, not a type, and compiler chokes
+    var unu$ed; // `var` is highlighted, though, and `$` is a valid char
 
     address a = "0x1"; // lexer parses as string
     struct AddressMap {

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -220,11 +220,11 @@ contract MoreBadPractices is BadPractices {
     * /
     \* /
 
-    / * no modifiers to check ownership * /
+    /* no modifiers to check ownership */
     fallback() external payable {
         balance += msg.value;
 
-        / * vulnerable to re-entry * /
+        /* vulnerable to re-entry */
         if (!msg.sender.send(this.balance / 10)) throw;
         balance -= this.balance;
     }

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -208,23 +208,34 @@ contract BadPractices {
     /* receive()?.. nah, why bother */
 }
 
-/*
-// Open comment to EOF. Compiler chokes on this, but it's useful
-// for highlighting to show that there's an unmatched multi-line
-// comment open.
-
+/* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /*
+// Open comment to EOF. Compiler chokes on this, but it's useful for
+// highlighting to show that there's an unmatched multi-line comment
+// open.
+//
+// On the other hand, a regular multi-line comment closure, including an
+// escaped variant as demonstrated shortly, should close the comment;
+// note that there are no nested multi-line comments.
+//
+// If the comment is still shown as "open", then a
+//
+//                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//                !!! MALICIOUS CODE SEGMENT !!!
+//                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// can be erroneously thought of as inactive, and left unread.
+// In fact, the compiler will produce executable code it, possibly
+// overriding the program above.
+//
+// It is imperative that syntax highlighters do parse it if either of
+// `* /` or `\* /` (with space removed) are present.
+//
+// Now, let's party! :) \* /
 contract MoreBadPractices is BadPractices {
     uint balance;
 
-    // These would close the comment if the space was removed:
-    * /
-    \* /
-
-    /* no modifiers to check ownership * /
-    fallback() external payable {
+    fallback() external payable override {
         balance += msg.value;
-
-        /* vulnerable to re-entry * /
         if (!msg.sender.send(this.balance / 10)) throw;
         balance -= this.balance;
     }

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -208,14 +208,10 @@ contract BadPractices {
     /* receive()?.. nah, why bother */
 }
 
-/* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /*
-// Open comment to EOF. Compiler chokes on this, but it's useful for
-// highlighting to show that there's an unmatched multi-line comment
-// open.
-//
-// On the other hand, a regular multi-line comment closure, including an
-// escaped variant as demonstrated shortly, should close the comment;
-// note that there are no nested multi-line comments.
+/* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /* /*
+// A regular multi-line comment closure, including an escaped variant as
+// demonstrated shortly, should close the comment; note that the lexer
+// should not be nesting multi-line comments.
 //
 // If the comment is still shown as "open", then a
 //
@@ -230,7 +226,8 @@ contract BadPractices {
 // It is imperative that syntax highlighters do parse it if either of
 // `* /` or `\* /` (with space removed) are present.
 //
-// Now, let's party! :) \* /
+// Now, let's party! :) \*/
+
 contract MoreBadPractices is BadPractices {
     uint balance;
 
@@ -239,4 +236,13 @@ contract MoreBadPractices is BadPractices {
         if (!msg.sender.send(this.balance / 10)) throw;
         balance -= this.balance;
     }
+}
+
+/*
+// Open comment to EOF. Compiler chokes on this, but it's useful for
+// highlighting to show that there's an unmatched multi-line comment
+// open.
+
+contract CommentToEndOfFile is MoreBadPractices {
+    fallback() external payable override {}
 }

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -1,18 +1,20 @@
-pragma solidity ^0.4.1;
+pragma solidity ^0.6.0;
+pragma ABIEncoderV2;
+pragma experimental SMTChecker;
 
 /**********************************************************************
  *                             example.sol                            *
  **********************************************************************/
 
 // Code in this contract is not meant to work (or be a good example).
-// It is meant to demonstrate good syntax highlighting by pygments,
+// It is meant to demonstrate good syntax highlighting by the lexer,
 // even if otherwise hazardous.
 
 // Comments relevant to the lexer are single-line.
 /* Comments relevant to the code are multi-line. */
 
 library Assembly {
-    function junk(address _addr) returns (address _ret) {
+    public function junk(address _addr) private returns (address _ret) {
         assembly {
             let tmp := 0
 
@@ -43,32 +45,39 @@ library Assembly {
 
 contract Strings {
     // `double` is not a keyword (yet)
-    string doublestr = "This\ is a string\nwith \"escapes\",\
+    string double = "This\ is a string\nwith \"escapes\",\
 and it's multi-line. // no comment"; // comment ok // even nested :)
-    string singlestr = 'This\ is a string\nwith "escapes",\
+    string single = 'This\ is a string\nwith "escapes",\
 and it\'s multi-line. // no comment'; // same thing, single-quote
     string hexstr = hex'537472696e67732e73656e6428746869732e62616c616e6365293b';
 
-    function(){}
+    fallback() external {}
+
+    receive() external payable {
+        revert();
+    }
 }
 
 contract Types is Strings {
-    using Assembly for Assembly.junk;
+    using Assembly for Assembly;
+
+    bytes stringsruntime = type(Strings).runtimeCode;
     
-    // typesM (compiler doesn't choke on invalid)
-    int8 i8; // valid
-    int10 i10; // invalid
-    uint256 ui256; // valid
-    uint9001 ui9001; // invalid
-    bytes1 b1; //valid
-    bytes42 b42; // invalid: M out of range for `bytes`
+    // typesM (compiler chokes on invalid)
+    int8 i8;           // valid
+    //int10 i10;       // invalid
+    uint256 ui256;     // valid
+    //uint9001 ui9001; // invalid
+    bytes1 b1;         //valid
+    //bytes42 b42;     // invalid - M out of range for `bytes`
     
-    // typesMxN (compiler doesn't choke on invalid)
-    fixed0x8 f0x8; // valid
-    fixed8x0 f8x0; // invalid - N can't be 0
-    ufixed42x217 uf42x217; // invalid: M and N must be multiples of 8
-    fixed224x16 f224x16; // valid
-    ufixed256x256 uf256x256; // invalid: M+N > 256
+    // typesMxN (compiler chokes on invalid)
+    fixed8x0 f8x0;           // valid
+    fixed8x1 f8x1;           // valid
+    fixed8x8 f8x8;           // valid
+    //fixed0x8 f0x8;         // invalid since MxN scheme changed
+    ufixed256x80 uf256x80;   // valid
+    //ufixed42x217 uf42x217; // invalid - M must be multiple of 8, N <= 80
 
     // special cases (internally not types)
     string str; // dynamic array (not a value-type)
@@ -84,7 +93,7 @@ contract Types is Strings {
     }
     mapping (address => AddressMap) touchedMe;
 
-    function failOnNegative(int8 _arg)
+    public function failOnNegative(int8 _arg)
         private
         constant
         returns (uint256)
@@ -94,7 +103,7 @@ contract Types is Strings {
     }
 
     // some arithmetic operators + built-in names
-    function opportunisticSend(address k) private {
+    public function opportunisticSend(address k) private {
         /* `touchedMe[k].result` et al are addresses, so
            `send()` available */
         touchedMe[k].origin.send(k**2 % 100 finney);
@@ -102,13 +111,13 @@ contract Types is Strings {
         touchedMe[k].sender.send(mulmod(1 szabo, k, 42));
     }
 
-    function() payable {
+    fallback() external payable {
         /* inferred type: address */
         var k = msg.sender;
         /* inferred type: `ufixed0x256` */
         var v = 1/42;
         /* can't be `var` - location specifier requires explicit type */
-        int storage negative = -1;
+        int negative = -1;
 
         // valid syntax, unexpected result - not our problem
         ui256 = failOnNegative(negative);
@@ -118,7 +127,7 @@ contract Types is Strings {
              !touchedMe[tx.origin].touched) ||
             ((~(msg.sender * v + a)) % 256 == 42)
         ) {
-            address memory garbled = Assembly.junk(a + msg.sender);
+            address garbled = Assembly.junk(a + msg.sender);
 
             /* create a new AddressMap struct in storage */
             AddressMap storage tmp;
@@ -162,32 +171,30 @@ contract BadPractices {
     bool mutex;
 
     modifier critical {
-        if (mutex) throw;
+        assert(!mutex);
         mutex = true;
         _;
         mutex = false;
     }
     
-    /* constructor */
-    function BadPractices() {
+    constructor {
         creator = tx.origin;
         owner = msg.sender;
     }
 
-    /* Dangerous - function public (by default), and doesn't check
-       who's calling. */
-    function withdraw(uint _amount)
+    /* Dangerous - function public, and doesn't check who's calling. */
+    public function withdraw(uint _amount)
         critical
         returns (bool)
     { /* `mutex` set via modifier */
-        if (msg.sender.call.value(_amount)())
-            throw; /* Throwing on failed call is dangerous.
-                      Consider returning false instead?.. */
+        /* Throwing on failed call may be dangerous. Consider
+           returning false instead?.. */
+        require(msg.sender.call.value(_amount)());
         return true;
     } /* `mutex` reset via modifier */
     
     /* fallback */
-    function () payable {
+    fallback() external payable {
         /* `i` will be `uint8`, so this is an endless loop
            that will consume all gas and eventually throw.
          */
@@ -210,7 +217,7 @@ contract MoreBadPractices is BadPractices {
     \* /
 
     / * no modifiers to check ownership * /
-    function () payable {
+    fallback() external payable {
         balance += msg.value;
 
         / * vulnerable to re-entry * /

--- a/spec/visual/samples/solidity
+++ b/spec/visual/samples/solidity
@@ -220,11 +220,11 @@ contract MoreBadPractices is BadPractices {
     * /
     \* /
 
-    /* no modifiers to check ownership */
+    /* no modifiers to check ownership * /
     fallback() external payable {
         balance += msg.value;
 
-        /* vulnerable to re-entry */
+        /* vulnerable to re-entry * /
         if (!msg.sender.send(this.balance / 10)) throw;
         balance -= this.balance;
     }


### PR DESCRIPTION
Adds a lexer for the Solidity language. It's based on Rouge's C lexer.

The longer example in `sample` is from my [Pygments lexer](https://gitlab.com/veox/pygments-lexer-solidity) package. The shorter one in `demos` was written specifically for Rouge.

Compared to the linked Pygments lexer, the one here has ~~more~~ less up-to-date keywords, ~~but~~ and doesn't have a distinct `assembly` state (yet). This is not a big issue: the low-level assembly keywords (e.g. `let`) _are_ listed (in `self.reserved`).

[Here's the demo file](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fdavidhq%2FSublimeEthereum%2Fblob%2Fmaster%2FSolidity.YAML-tmLanguage&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fveox%2Frouge%2Fblob%2F6b12eea50b217e2df08fa9c2470550dfc1e8103f%2Flib%2Frouge%2Fdemos%2Fsolidity&code=) on Lightshow, for comparison with a yet another highlighter (using [davidhq/SublimeEthereum](https://github.com/davidhq/SublimeEthereum/) grammar file).

I've squashed the development history into one commit; do tell if this is undesirable.

-----

Solidity is a high(?)-level language for the Ethereum Virtual Machine (EVM), a blockchain-based "decentralised computer".

More info: [`solc` compiler](https://github.com/ethereum/solidity), its [docs](https://solidity.readthedocs.io/en/develop/); [ethereum.org](https://ethereum.org/) landing page

This fixes #987.