### PR TITLE
Add a Raku/Perl 6 lexer

### DIFF
--- a/lib/rouge/demos/perl6
+++ b/lib/rouge/demos/perl6
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl6
+
+grammar Parser {
+    rule  TOP  { I <love> <lang> }
+    token love { '♥' | love }
+    token lang { < Perl Rust Go Python Ruby > }
+}
+
+say Parser.parse: 'I ♥ Perl';
+say Parser.parse: 'I love Rust';
+
+start { sleep 1.5; print "hi" }
+await Supply.from-list(<A B C D E F>).throttle: 2, {
+    sleep 0.5;
+    .print
+}
+
+my @primes = ^∞ .grep: *.is-prime;
+say "1001ˢᵗ prime is @primes[1000]";
+
+.say for '50TB.file.txt'.IO.words;
+

--- a/lib/rouge/lexers/perl6.rb
+++ b/lib/rouge/lexers/perl6.rb
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+module Rouge
+  module Lexers
+    class Perl6 < Perl
+      title "Perl 6"
+      desc "The Perl 6 programming language (perl6.org)"
+
+      tag "perl6"
+      aliases 'pl6'
+
+      filenames '*.pl6', '*.pm6'
+      mimetypes 'text/x-perl6', 'application/x-perl6'
+
+      def self.analyze_text(text)
+        return 1 if text.shebang? 'perl6'
+        return 0.4 if text.include? 'use v6'
+      end
+
+      hyper_operators = %w(« » << >>)
+
+      operator_words = %w(
+        div xx x mod also leg cmp before after eq ne le lt not gt eqv
+        ff fff min max not so and andthen or xor orelse extra lcm gcd o
+      )
+
+      pre_declares = %w(multi proto only)
+
+      declares = %w(
+        macro sub submethod method category module class role package
+        enum grammar slang subset
+      )
+
+      rules = %w(regex rule token)
+
+      includes = %w(use require\ unit)
+
+      conditionals = %w(if else eslif unless with orwith without)
+
+      scopes = %w(let my our state temp has constant)
+
+      loops = %w(for loop repeat while until gather given)
+
+      flow_controls = %w(
+        take do when net last redo return contend maybe defer start
+        default exit make continue break goto leave async lift
+      )
+
+      phasers = %w(
+        BEGIN CHECK INIT START FIRST ENTER LEAVE KEEP UNDO NEXT LAST
+         PRE POST END CATCH CONTROL TEMP
+      )
+
+      exceptions = %w(die fail try warn)
+
+      pragmas = %w(oo fatal)
+
+      type_constraints = %w(
+        does as but trusts of returns handles where augment supersede
+      )
+
+      type_properties = %w(
+        signature context also shape prec irs ofs ors export deep binary
+        unary reparsed rw parsed cached readonly defequiv will ref copy
+        inline tighter looser equiv assoc required
+      )
+
+      low_types = %w(
+        int int1 int2 int4 int8 int16 int32 int64
+        rat rat1 rat2 rat4 rat8 rat16 rat32 rat64
+        buf buf1 buf2 buf4 buf8 buf16 buf32 buf64
+        uint uint1 uint2 uint4 uint8 uint16 uint32 uint64
+        utf8 utf16 utf32 bit bool bag set mix num complex
+      )
+
+      high_types = %w(
+        Object Any Junctiopn Whatever Capture Match Signature Proxy
+        Matcher Package Module Class Grammar Scalar Array Hasy KeyHash
+        KeySet KeyBag Pair List Seq Range Set Bag Baghash Mapping Void
+        Undef Failure Exception Code Block Routine Sub Macro Method
+        Submethod Regex Str Blob Char Map Byte Parcel CodePoint
+        Grapheme StrPos StrLen Version Num Complex Bit True False Order
+        Same Less More Increasing Decreasing Ordered Callable AnyChar
+        Positional Associateive Ordering KeyExtractor Comparator
+        OrderingPair IO KitchenSink Role Int Bool Rat Buf UInt
+        Abstraction Numeric Real Nil Mu
+      )
+
+      prepend :root do
+        rule /#.*?$/, Comment::Single
+        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/m, Comment::Multiline
+
+        rule /(?:#{pre_declares.join('|')})\b/, Keyword::Declaration
+        rule /(?:#{declares.join('|')})\b/, Keyword::Declaration
+        rule /(?:#{rules.join('|')})\b/, Keyword::Type
+        rule /(?:#{includes.join('|')})\b/, Keyword::Namespace
+        rule /(?:#{conditionals.join('|')})\b/, Keyword
+        rule /(?:#{scopes.join('|')})\b/, Keyword::Namespace
+        rule /(?:#{loops.join('|')})\b/, Keyword
+        rule /(?:#{flow_controls.join('|')})\b/, Keyword
+        rule /(?:#{phasers.join('|')})\b/, Keyword::Constant
+        rule /(?:#{exceptions.join('|')})\b/, Keyword
+        rule /(?:#{pragmas.join('|')})\b/, Keyword
+        rule /(?:#{type_constraints.join('|')})\b/, Keyword::Declaration
+        rule /(?:#{type_properties.join('|')})\b/, Keyword::Declaration
+        rule /(?:#{low_types.join('|')})\b/, Keyword::Type
+        rule /(?:#{high_types.join('|')})\b/, Keyword::Type
+
+        rule /(?:#{hyper_operators.join('|')})\b/, Operator
+        rule /(?:#{operator_words.join('|')})\b/, Operator::Word
+
+        rule /∞/, Keyword::Constant
+        rule /\$\<|»\.|∈/, Operator
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/perl6.rb
+++ b/lib/rouge/lexers/perl6.rb
@@ -12,7 +12,7 @@ module Rouge
       filenames '*.pl6', '*.pm6'
       mimetypes 'text/x-perl6', 'application/x-perl6'
 
-      def self.analyze_text(text)
+      def self.detect?(text)
         return 1 if text.shebang? 'perl6'
         return 0.4 if text.include? 'use v6'
       end

--- a/lib/rouge/lexers/perl6.rb
+++ b/lib/rouge/lexers/perl6.rb
@@ -2,6 +2,8 @@
 
 module Rouge
   module Lexers
+    load_lexer 'perl.rb'
+
     class Perl6 < Perl
       title "Perl 6"
       desc "The Perl 6 programming language (perl6.org)"

--- a/spec/lexers/perl6_spec.rb
+++ b/spec/lexers/perl6_spec.rb
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Perl6 do
+  let(:subject) { Rouge::Lexers::Perl6.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.pl6'
+      assert_guess :filename => 'foo.pm6'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-perl6'
+      assert_guess :mimetype => 'application/x-perl6'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => '#!/usr/local/env perl6'
+    end
+  end
+end

--- a/spec/lexers/perl6_spec.rb
+++ b/spec/lexers/perl6_spec.rb
@@ -17,7 +17,7 @@ describe Rouge::Lexers::Perl6 do
     end
 
     it 'guesses by source' do
-      assert_guess :source => '#!/usr/local/env perl6'
+      assert_guess :source => '#!/usr/bin/env perl6'
     end
   end
 end

--- a/spec/visual/samples/perl6
+++ b/spec/visual/samples/perl6
@@ -1,0 +1,129 @@
+#! /usr/bin/env perl6
+
+#### regex_delimiters
+
+sub substitutionOperator
+{
+}
+
+use v6;
+
+# common delimiters
+print "a: ";
+my $a = "foo";
+print $a, " - ";
+$a ~~ s/foo/bar/;
+say $a;
+
+print "b: ";
+my $b = "foo";
+print $b, " - ";
+$b ~~ s!foo!bar!;
+say $b;
+
+print "c: ";
+my $c = "foo";
+print $c, " - ";
+$c ~~ s@foo@bar@;
+say $c;
+
+print "d: ";
+my $d = "foo";
+print $d, " - ";
+$d ~~ s\foo\bar\;
+say $d;
+
+say '';
+
+# balanced delimiters with whitespace
+print "i: ";
+my $i = "foo";
+print $i, " - ";
+$i ~~ s{foo} = 'bar';
+say $i;
+
+print "j: ";
+my $j = "foo";
+print $j, " - ";
+$j ~~ s<foo> =          'bar';
+say $j;
+
+print "k: ";
+my $k = "foo";
+print $k, " - ";
+$k ~~
+        s(foo)
+        =
+        'bar';
+say $k;
+
+say '';
+
+##### perl6_misc #####
+
+use v6;
+
+for 1 .. 5 {
+    my $fh = open :r, '/proc/sys/kernel/random/entropy_avail' or die;
+    $fh.get.say;
+    $fh.close;
+    sleep 100_000;
+}
+
+grammar Parser {
+    rule  TOP  { I <love> <lang> }
+    token love { '♥' | love }
+    token lang { < Perl Rust Go Python Ruby > }
+}
+
+say Parser.parse: 'I ♥ Perl';
+say Parser.parse: 'I love Rust';
+
+start { sleep 1.5; print "hi" }
+await Supply.from-list(<A B C D E F>).throttle: 2, {
+    sleep 0.5;
+    .print
+}
+
+my @primes = ^∞ .grep: *.is-prime;
+say "1001ˢᵗ prime is @primes[1000]";
+
+.say for '50TB.file.txt'.IO.words;
+
+my @a = <a b c>;
+my @b = @a».ord;
+sub foo(Str:D $c){ $c.ord * 2 };
+say @a».&foo;
+say @a».&{ .ord };
+
+class CarefulClass { method take-care {} }
+my CarefulClass @objs;
+my @results = @objs».take-care();
+ 
+my @slops;        # May Contain Nuts 
+@slops».?this-method-may-not-exist();
+
+sub weird(@elems, :$direction = 'forward') {
+    my %direction = (
+        forward  => sub { take $_ for @elems },
+        backward => sub { take $_ for @elems.reverse },
+        random   => sub { take $_ for @elems.pick(*) },
+    );
+    return gather %direction{$direction}();
+}
+ 
+say weird(<a b c>, :direction<backward> );          # OUTPUT: «(c b a)␤» 
+
+=head1 Single Quote Breaker
+
+That's all folks
+
+=cut
+
+=end pod
+
+sub foo {
+    "after the POD with the single quote, it's all still good"
+}
+
+


### PR DESCRIPTION
This is an initial work deriving from current Rouge::Lexer::Perl, and
using keyword data from https://docs.perl6.org and
https://github.com/perl6/perl6-mode.

In all likelihood though, this might just derive directly from
Rouge::Lexer::RegexLexer instead and implement its own states soon in
subsequent commits, considering there's a lot of syntax changes.

This would close #390