### PR TITLE
use require_relative instead of load_lexer based on Kernel.load

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,4 @@ group :development do
 
   # for visual tests
   gem 'sinatra'
-  gem 'shotgun'
 end

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -6,11 +6,6 @@ require 'pathname'
 # The containing module for Rouge
 module Rouge
   class << self
-    def reload!
-      Object.send :remove_const, :Rouge
-      load __FILE__
-    end
-
     # Highlight some text with a given lexer and formatter.
     #
     # @example
@@ -30,53 +25,35 @@ module Rouge
 
       formatter.format(lexer.lex(text), &b)
     end
+
+    # @private
+    def load_components(root, glob)
+      root_path = Pathname.new(root)
+      Dir.glob(root_path.join(glob)).each do |f|
+        relative_path = Pathname.new(f).relative_path_from(root_path).to_s
+        require_relative(relative_path)
+      end
+    end
   end
 end
 
-load_dir = Pathname.new(__FILE__).dirname
-load load_dir.join('rouge/version.rb')
+require_relative('rouge/version.rb')
 
-load load_dir.join('rouge/util.rb')
+require_relative('rouge/util.rb')
 
-load load_dir.join('rouge/text_analyzer.rb')
-load load_dir.join('rouge/token.rb')
+require_relative('rouge/text_analyzer.rb')
+require_relative('rouge/token.rb')
 
-load load_dir.join('rouge/lexer.rb')
-load load_dir.join('rouge/regex_lexer.rb')
-load load_dir.join('rouge/template_lexer.rb')
+require_relative('rouge/lexer.rb')
+require_relative('rouge/regex_lexer.rb')
+require_relative('rouge/template_lexer.rb')
+Rouge.load_components(__dir__, 'rouge/lexers/*.rb')
 
-lexers_dir = load_dir.join('rouge/lexers')
-Dir.glob(lexers_dir.join('*.rb')).each do |f|
-  Rouge::Lexers.load_lexer(Pathname.new(f).relative_path_from(lexers_dir).to_s)
-end
+require_relative('rouge/guesser.rb')
+Rouge.load_components(__dir__, 'rouge/guessers/*.rb')
 
-load load_dir.join('rouge/guesser.rb')
-load load_dir.join('rouge/guessers/util.rb')
-load load_dir.join('rouge/guessers/glob_mapping.rb')
-load load_dir.join('rouge/guessers/modeline.rb')
-load load_dir.join('rouge/guessers/filename.rb')
-load load_dir.join('rouge/guessers/mimetype.rb')
-load load_dir.join('rouge/guessers/source.rb')
-load load_dir.join('rouge/guessers/disambiguation.rb')
+require_relative('rouge/formatter.rb')
+Rouge.load_components(__dir__, 'rouge/formatters/*.rb')
 
-load load_dir.join('rouge/formatter.rb')
-load load_dir.join('rouge/formatters/html.rb')
-load load_dir.join('rouge/formatters/html_table.rb')
-load load_dir.join('rouge/formatters/html_pygments.rb')
-load load_dir.join('rouge/formatters/html_legacy.rb')
-load load_dir.join('rouge/formatters/html_linewise.rb')
-load load_dir.join('rouge/formatters/html_inline.rb')
-load load_dir.join('rouge/formatters/terminal256.rb')
-load load_dir.join('rouge/formatters/null.rb')
-
-load load_dir.join('rouge/theme.rb')
-load load_dir.join('rouge/themes/thankful_eyes.rb')
-load load_dir.join('rouge/themes/colorful.rb')
-load load_dir.join('rouge/themes/base16.rb')
-load load_dir.join('rouge/themes/github.rb')
-load load_dir.join('rouge/themes/igor_pro.rb')
-load load_dir.join('rouge/themes/monokai.rb')
-load load_dir.join('rouge/themes/molokai.rb')
-load load_dir.join('rouge/themes/monokai_sublime.rb')
-load load_dir.join('rouge/themes/gruvbox.rb')
-load load_dir.join('rouge/themes/tulip.rb')
+require_relative('rouge/theme.rb')
+Rouge.load_components(__dir__, 'rouge/themes/*.rb')

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -29,7 +29,7 @@ module Rouge
     # @private
     def load_components(root, glob)
       root_path = Pathname.new(root)
-      Dir.glob(root_path.join(glob)).each do |f|
+      Dir.glob(root_path.join(glob)).sort.each do |f|
         relative_path = Pathname.new(f).relative_path_from(root_path).to_s
         require_relative(relative_path)
       end

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -1,3 +1,5 @@
+require_relative './util'
+
 module Rouge
   module Guessers
     class Disambiguation < Guesser

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -1,3 +1,5 @@
+require_relative './util'
+
 module Rouge
   module Guessers
     # This class allows for custom behavior

--- a/lib/rouge/guessers/modeline.rb
+++ b/lib/rouge/guessers/modeline.rb
@@ -1,3 +1,5 @@
+require_relative './util'
+
 module Rouge
   module Guessers
     class Modeline < Guesser
@@ -35,7 +37,7 @@ module Rouge
 
         matches = MODELINES.map { |re| re.match(search_space) }.compact
         return lexers unless matches.any?
-        
+
         match_set = Set.new(matches.map { |m| m[1] })
         lexers.select { |l| match_set.include?(l.tag) || l.aliases.any? { |a| match_set.include?(a) } }
       end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -1,3 +1,5 @@
+require_relative './util'
+
 module Rouge
   module Guessers
     class Source < Guesser

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -446,16 +446,4 @@ module Rouge
       false
     end
   end
-
-  module Lexers
-    @_loaded_lexers = {}
-
-    def self.load_lexer(relpath)
-      return if @_loaded_lexers.key?(relpath)
-      @_loaded_lexers[relpath] = true
-
-      root = Pathname.new(__FILE__).dirname.join('lexers')
-      load root.join(relpath)
-    end
-  end
 end

--- a/lib/rouge/lexers/apiblueprint.rb
+++ b/lib/rouge/lexers/apiblueprint.rb
@@ -1,6 +1,6 @@
 module Rouge
   module Lexers
-    load_lexer 'markdown.rb'
+    require_relative 'markdown.rb'
 
     class APIBlueprint < Markdown
       title 'API Blueprint'

--- a/lib/rouge/lexers/biml.rb
+++ b/lib/rouge/lexers/biml.rb
@@ -1,6 +1,6 @@
 module Rouge
   module Lexers
-    load_lexer 'xml.rb'
+    require_relative 'xml.rb'
 
     class BIML < XML
       title "BIML"

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'c.rb'
+    require_relative 'c.rb'
 
     class Cpp < C
       title "C++"

--- a/lib/rouge/lexers/digdag.rb
+++ b/lib/rouge/lexers/digdag.rb
@@ -1,7 +1,7 @@
 require 'set'
 module Rouge
   module Lexers
-    load_lexer 'yaml.rb'
+    require_relative 'yaml.rb'
 
     class Digdag < YAML
       title 'digdag'

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -18,7 +18,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('gherkin/keywords.rb')
+        require_relative('./gherkin/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/glsl.rb
+++ b/lib/rouge/lexers/glsl.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'c.rb'
+    require_relative 'c.rb'
 
     # This file defines the GLSL language lexer to the Rouge
     # syntax highlighter.

--- a/lib/rouge/lexers/gradle.rb
+++ b/lib/rouge/lexers/gradle.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'groovy.rb'
+    require_relative 'groovy.rb'
 
     class Gradle < Groovy
       title "Gradle"

--- a/lib/rouge/lexers/irb.rb
+++ b/lib/rouge/lexers/irb.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'console.rb'
+    require_relative 'console.rb'
 
     class IRBLexer < ConsoleLexer
       tag 'irb'
@@ -30,7 +30,7 @@ module Rouge
       end
     end
 
-    load_lexer 'ruby.rb'
+    require_relative 'ruby.rb'
     class IRBOutputLexer < Ruby
       tag 'irb_output'
 

--- a/lib/rouge/lexers/json_doc.rb
+++ b/lib/rouge/lexers/json_doc.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'json.rb'
+    require_relative 'json.rb'
 
     class JSONDOC < JSON
       desc "JavaScript Object Notation with extenstions for documentation"

--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -1,6 +1,6 @@
 module Rouge
   module Lexers
-    load_lexer 'javascript.rb'
+    require_relative 'javascript.rb'
 
     class JSX < Javascript
       title 'JSX'

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -24,7 +24,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('lua/builtins.rb')
+        require_relative('./lua/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -11,14 +11,14 @@ module Rouge
       mimetypes 'text/x-matlab', 'application/x-matlab'
 
       def self.keywords
-        @keywords = Set.new %w(
+        @keywords ||= Set.new %w(
           break case catch classdef continue else elseif end for function
           global if otherwise parfor persistent return spmd switch try while
         )
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('matlab/builtins.rb')
+        require_relative('./matlab/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/moonscript.rb
+++ b/lib/rouge/lexers/moonscript.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'lua.rb'
+    require_relative 'lua.rb'
 
     class Moonscript < RegexLexer
       title "MoonScript"

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'c.rb'
+    require_relative 'c.rb'
 
     class ObjectiveC < C
       tag 'objective_c'

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -28,7 +28,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('php/builtins.rb')
+        require_relative('./php/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'shell.rb'
+    require_relative 'shell.rb'
 
     class Powershell < Shell
       title 'powershell'

--- a/lib/rouge/lexers/qml.rb
+++ b/lib/rouge/lexers/qml.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'javascript.rb'
+    require_relative 'javascript.rb'
 
     class Qml < Javascript
       title "QML"

--- a/lib/rouge/lexers/sass.rb
+++ b/lib/rouge/lexers/sass.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'sass/common.rb'
+    require_relative 'sass/common.rb'
 
     class Sass < SassCommon
       include Indentation

--- a/lib/rouge/lexers/scss.rb
+++ b/lib/rouge/lexers/scss.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'sass/common.rb'
+    require_relative 'sass/common.rb'
 
     class Scss < SassCommon
       title "SCSS"

--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -2,8 +2,8 @@
 
 module Rouge
   module Lexers
-    load_lexer 'jsx.rb'
-    load_lexer 'typescript/common.rb'
+    require_relative 'jsx.rb'
+    require_relative 'typescript/common.rb'
 
     class TSX < JSX
       include TypescriptCommon

--- a/lib/rouge/lexers/twig.rb
+++ b/lib/rouge/lexers/twig.rb
@@ -2,7 +2,7 @@
 
 module Rouge
   module Lexers
-    load_lexer 'jinja.rb'
+    require_relative 'jinja.rb'
 
     class Twig < Jinja
       title "Twig"

--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -2,8 +2,8 @@
 
 module Rouge
   module Lexers
-    load_lexer 'javascript.rb'
-    load_lexer 'typescript/common.rb'
+    require_relative 'javascript.rb'
+    require_relative 'typescript/common.rb'
 
     class Typescript < Javascript
       include TypescriptCommon

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'text/x-vim'
 
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('viml/keywords.rb')
+        require_relative('./viml/keywords.rb')
         self.keywords
       end
 

--- a/lib/rouge/lexers/vue.rb
+++ b/lib/rouge/lexers/vue.rb
@@ -1,6 +1,6 @@
 module Rouge
   module Lexers
-    load_lexer 'html.rb'
+    require_relative 'html.rb'
 
     class Vue < HTML
       desc 'Vue.js single-file components'

--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -8,22 +8,17 @@ Bundler.require(:default, :development)
 require 'pathname'
 
 class VisualTestApp < Sinatra::Application
-  BASE = Pathname.new(__FILE__).dirname
+  BASE = Pathname.new(__dir__)
   SAMPLES = BASE.join('samples')
   ROOT = BASE.parent.parent
 
-  ROUGE_LIB = ROOT.join('lib/rouge.rb')
-
   DEMOS = ROOT.join('lib/rouge/demos')
-
-  def reload_source!
-    Object.send :remove_const, :Rouge
-    load ROUGE_LIB
-  end
 
   def query_string
     env['rack.request.query_string']
   end
+
+  use Rack::Reloader
 
   configure do
     set :root, BASE
@@ -31,8 +26,6 @@ class VisualTestApp < Sinatra::Application
   end
 
   before do
-    reload_source!
-
     Rouge::Lexer.enable_debug!
 
     theme_class = Rouge::Theme.find(params[:theme] || 'thankful_eyes')


### PR DESCRIPTION
Just use the built-in `require_relative` instead of custom loading methods.