### PR TITLE
Improve Swift attribute formatting

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -80,7 +80,7 @@ module Rouge
         rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 
-        rule %r/@#{id}(\([^)]+\))?/, Keyword::Declaration
+        rule %r/@#{id}/, Keyword::Declaration
 
         rule %r/(private|internal)(\([ ]*)(\w+)([ ]*\))/ do |m|
           if m[3] == 'set'

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -401,6 +401,7 @@ typealias StringDictionary<T> = Dictionary<String, T>
 
 #sourceLocation(file: "foo", line: 42)
 
+@available(swift, obsoleted: 5.0.0, renamed: "foo2(file:line:)")
 func foo(_ file: StaticString = #file, line: UInt = #line) { }
 
 precedencegroup ComparisonPrecedence {


### PR DESCRIPTION
Swift @available attributes can go wrong:
![screen shot 2017-10-13 at 09 10 50](https://user-images.githubusercontent.com/26768470/31536476-a69ed636-aff6-11e7-8703-f57d664be4f5.png)
The rparen inside the quoted string is accidentally ending the @available( and messing up what follows.

I also feel that treating the entire thing as a single token looks poor because of the internal structure.  So this PR just allows 'normal' lexing of the part in parens giving e.g.:
![screen shot 2017-10-13 at 09 16 03](https://user-images.githubusercontent.com/26768470/31536585-24944eb8-aff7-11e7-9dca-b640541e8a8e.png)
and
![screen shot 2017-10-13 at 09 16 57](https://user-images.githubusercontent.com/26768470/31536649-4d7b934a-aff7-11e7-9d97-2b22a00323c7.png)
The majority of attributes do not have args and are unaffected.

(This is similar in approach to Apple's default format:
![screen shot 2017-10-13 at 09 18 46](https://user-images.githubusercontent.com/26768470/31536748-a45ad874-aff7-11e7-9550-9ff4ecfc6c9b.png))

This change also deals with whitespace + comments inside the attr args / between attr and paren.

If there is a reason why the entire thing should be lexed as a single token then I'd be happy to change this PR to fix just the rparen-matching issue!

// cc @radex who touched this last for any thoughts.