### PR TITLE
Fix Prolog comment character

### DIFF
--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -13,7 +13,7 @@ module Rouge
 
       state :basic do
         rule /\s+/, Text
-        rule /^#.*/, Comment::Single
+        rule /^#!.*/, Comment::Single
         rule /%.*/, Comment::Single
         rule /\/\*/, Comment::Multiline, :nested_comment
 

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -11,9 +11,15 @@ module Rouge
       filenames '*.pro', '*.P', '*.prolog', '*.pl'
       mimetypes 'text/x-prolog'
 
+      start { push :bol }
+
+      state :bol do
+        rule /#.*/, Comment::Single
+        rule(//) { pop! }
+      end
+
       state :basic do
         rule /\s+/, Text
-        rule /^#!.*/, Comment::Single
         rule /%.*/, Comment::Single
         rule /\/\*/, Comment::Multiline, :nested_comment
 

--- a/spec/visual/samples/prolog
+++ b/spec/visual/samples/prolog
@@ -1,4 +1,6 @@
-# Atoms
+#!/bin/prolog
+
+% Atoms
 
 x
 blue
@@ -6,47 +8,47 @@ blue
 'some atom'
 camelCaseAtom
 
-# Numbers
+% Numbers
 
 1
 123123123123
 12312.1231
 0.1
 
-# Variables
+% Variables
 
 Hello
 How_are_you_doing
 _amazing
 Wow123
 
-# Compound terms
+% Compound terms
 
 truck_year('Mazda', 1986)
 'Person_Friends'(zelda,[tom,jim])
 
-# List
+% List
 
 []
 [1,2,3]
 [red,green,blue]
 
-# Strings
+% Strings
 
 "to be, or not to be"
 "東京都"
 
-# This example was taken from
-# http://en.wikipedia.org/wiki/Prolog#Turing_completeness
+% This example was taken from
+% http://en.wikipedia.org/wiki/Prolog#Turing_completeness
 turing(Tape0, Tape) :-
     perform(q0, [], Ls, Tape0, Rs),
     reverse(Ls, Ls1),
     append(Ls1, Rs, Tape).
 
 /*
-*
+ *
  * This is a multiline comment.
-*/
+ */
 
 % This is a single-line comment
 
@@ -69,7 +71,7 @@ action(right, Ls0, [Sym|Ls0], [Sym|Rs], Rs).
 left([], [], Rs0, [b|Rs0]).
 left([L|Ls], Ls, Rs, [L|Rs]).
 
-## Example from pygments
+%% Example from pygments
 
 partition([], _, [], []).
 partition([X|Xs], Pivot, Smalls, Bigs) :-
@@ -81,6 +83,6 @@ partition([X|Xs], Pivot, Smalls, Bigs) :-
     ).
 
 quicksort([])     --> [].
-quicksort([X|Xs]) --> 
+quicksort([X|Xs]) -->
     { partition(Xs, X, Smaller, Bigger) },
     quicksort(Smaller), [X], quicksort(Bigger).


### PR DESCRIPTION
A number of mature Prolog implementations ([SICStus](https://sicstus.sics.se/sicstus/docs/3.12.7/html/sicstus/Comments.html), [GNU](http://www.cs.utexas.edu/~cannata/cs345/Class%20Notes/12%20prolog_intro.pdf), [SWI](http://www.swi-prolog.org/pldoc/man?section=pldoc-comments)) use `%` as the line comment character. GitHub also highlights it that way.

```prolog
% percent
# hash
```