### PR TITLE
Add JSL Lexer

### DIFF
--- a/lib/rouge/demos/jsl
+++ b/lib/rouge/demos/jsl
@@ -1,0 +1,3 @@
+// Create Distribution of Big Class
+dt = open( "$sample_data\big class.jmp" );
+dt << Distribution( Column( :age ), Histograms Only( 1 ) );

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*- #
+# frozen_string_literal: true
 
 module Rouge
   module Lexers

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -24,12 +24,23 @@ module Rouge
 
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
-        rule %r/"\\\[.*?\]\\"/m, Str::Double  # escaped string
-        rule %r/"(?:\\!"|[^"])*"/m, Str::Double
+
+        rule %r/(")(\\\[)(.*?)(\]\\)(")/m do
+          groups Str::Double, Str::Escape, Str::Double, Str::Escape, Str::Double  # escaped string
+        end
+        rule %r/"/, Str::Double, :dq
+
         rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
         rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
         rule %r/\n/, Text
         rule %r/./, Text
+      end
+
+      state :dq do
+        rule %r/\\![btrnNf0\\"]/, Str::Escape
+        rule %r/\\/, Str::Double
+        rule %r/"/, Str::Double, :pop!
+        rule %r/[^\\"]*/m, Str::Double
       end
     end
   end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -11,6 +11,7 @@ module Rouge
       filenames '*.jsl'
 
       state :root do
+        rule %r/\s+/m, Text::Whitespace
 
         # messages
         rule %r/(<<)(.*?)(\(|;)/ do |m|
@@ -32,7 +33,7 @@ module Rouge
 
         rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
         rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
-        rule %r/\n/, Text
+        
         rule %r/./, Text
       end
 

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -13,7 +13,7 @@ module Rouge
       state :root do
 
         # messages
-        rule /(<<)(.*?)(\(|;])/ do |m|
+        rule /(<<)(.*?)(\(|;)/ do |m|
           token Operator, m[1]
           token Name::Function, m[2]
           token Operator, m[3]

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -24,8 +24,8 @@ module Rouge
 
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
-        rule %r/"\\\[.*?\]\\"/m, Str              # escaped string
-        rule %r/"(\\!"|[^"])*"/m, Str
+        rule %r/"\\\[.*?\]\\"/m, Str::Double  # escaped string
+        rule %r/"(\\!"|[^"])*"/m, Str::Double
         rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
         rule %r/\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)(e[+-]?[0-9]+)?i?\b/i, Num
         rule %r/\n/, Text

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -28,10 +28,10 @@ module Rouge
         rule %r(/\*.*?\*/)m, Comment::Multiline
         rule /"\\\[.*?\]\\"/m, Str              # escaped string
         rule /"(\\!"|[^"])*"/m, Str
-        rule /[~^*!%&\[\](){}<>\|+=:,.\/?-]/, Operator
-        rule /[0-9]+?/, Num::Integer
+        rule /[*!%&\[\](){}<>\|+=:\/-]/, Operator
+        rule /\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)(e[+-]?[0-9]+)?i?\b/i, Num
         rule /\n/, Text
-        rule /./, Text;
+        rule /./, Text
       end
     end
   end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -8,7 +8,6 @@ module Rouge
 
       tag 'jsl'
       filenames '*.jsl'
-      mimetypes 'text/x-jsl'
 
       state :root do
 

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class JSL < RegexLexer
+      title "JSL"
+      desc "The JMP Scripting Language (JSL) (jmp.com)"
+
+      tag 'jsl'
+      filenames '*.jsl'
+      mimetypes 'text/x-jsl'
+
+      state :root do
+
+        # messages
+        rule /(<<)(.*?)(\(|;])/ do |m|
+          token Operator, m[1]
+          token Name::Function, m[2]
+          token Operator, m[3]
+        end
+
+        # covers built-in and custom functions
+        rule /([a-z][a-z._\s]*)(\()/i do |m|
+          token Keyword, m[1]
+          token Operator, m[2]
+        end
+
+        rule %r(//.*?$), Comment::Single
+        rule %r(/\*.*?\*/)m, Comment::Multiline
+        rule /"\\\[.*?\]\\"/m, Str              # escaped string
+        rule /"(\\!"|[^"])*"/m, Str
+        rule /[~^*!%&\[\](){}<>\|+=:,.\/?-]/, Operator
+        rule /[0-9]+?/, Num::Integer
+        rule /./, Text;
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -13,26 +13,26 @@ module Rouge
       state :root do
 
         # messages
-        rule /(<<)(.*?)(\(|;)/ do |m|
+        rule %r/(<<)(.*?)(\(|;)/ do |m|
           token Operator, m[1]
           token Name::Function, m[2]
           token Operator, m[3]
         end
 
         # covers built-in and custom functions
-        rule /([a-z][a-z._\s]*)(\()/i do |m|
+        rule %r/([a-z][a-z._\s]*)(\()/i do |m|
           token Keyword, m[1]
           token Operator, m[2]
         end
 
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
-        rule /"\\\[.*?\]\\"/m, Str              # escaped string
-        rule /"(\\!"|[^"])*"/m, Str
-        rule /[*!%&\[\](){}<>\|+=:\/-]/, Operator
-        rule /\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)(e[+-]?[0-9]+)?i?\b/i, Num
-        rule /\n/, Text
-        rule /./, Text
+        rule %r/"\\\[.*?\]\\"/m, Str              # escaped string
+        rule %r/"(\\!"|[^"])*"/m, Str
+        rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
+        rule %r/\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)(e[+-]?[0-9]+)?i?\b/i, Num
+        rule %r/\n/, Text
+        rule %r/./, Text
       end
     end
   end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -14,15 +14,12 @@ module Rouge
 
         # messages
         rule %r/(<<)(.*?)(\(|;)/ do |m|
-          token Operator, m[1]
-          token Name::Function, m[2]
-          token Operator, m[3]
+          groups Operator, Name::Function, Operator
         end
 
         # covers built-in and custom functions
         rule %r/([a-z][a-z._\s]*)(\()/i do |m|
-          token Keyword, m[1]
-          token Operator, m[2]
+          groups Keyword, Operator
         end
 
         rule %r(//.*?$), Comment::Single

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -31,6 +31,7 @@ module Rouge
         rule /"(\\!"|[^"])*"/m, Str
         rule /[~^*!%&\[\](){}<>\|+=:,.\/?-]/, Operator
         rule /[0-9]+?/, Num::Integer
+        rule /\n/, Text
         rule /./, Text;
       end
     end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -25,9 +25,9 @@ module Rouge
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
         rule %r/"\\\[.*?\]\\"/m, Str::Double  # escaped string
-        rule %r/"(\\!"|[^"])*"/m, Str::Double
+        rule %r/"(?:\\!"|[^"])*"/m, Str::Double
         rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
-        rule %r/\b[+-]?([0-9]+(\.[0-9]+)?|\.[0-9]+|\.)(e[+-]?[0-9]+)?i?\b/i, Num
+        rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
         rule %r/\n/, Text
         rule %r/./, Text
       end

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -28,9 +28,12 @@ module Rouge
 
         rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
 
+        rule %r/\d{2}(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\d{2}(\d{2})?(:\d{2}:\d{2}(:\d{2}(\.\d*)?)?)?/i, Literal::Date
+
         rule %r/::[a-z_][\w\s'%.\\]*/i, Name::Variable
         rule %r/:\w+/, Name
         rule %r/[a-z_][\w\s'%.\\]*/i, Name::Variable
+        rule %r/"(?:\\!"|[^"])*?"n/m, Name::Variable
 
         rule %r/(")(\\\[)(.*?)(\]\\)(")/m do
           groups Str::Double, Str::Escape, Str::Double, Str::Escape, Str::Double  # escaped string

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -13,28 +13,32 @@ module Rouge
       state :root do
         rule %r/\s+/m, Text::Whitespace
 
+        rule %r(//.*?$), Comment::Single
+        rule %r(/\*.*?\*/)m, Comment::Multiline
+
         # messages
         rule %r/(<<)(.*?)(\(|;)/ do |m|
-          groups Operator, Name::Function, Operator
+          groups Operator, Name::Function, Punctuation
         end
 
         # covers built-in and custom functions
-        rule %r/([a-z][a-z._\s]*)(\()/i do |m|
-          groups Keyword, Operator
+        rule %r/([a-z_][\w\s'%.\\]*)(\()/i do |m|
+          groups Keyword, Punctuation
         end
 
-        rule %r(//.*?$), Comment::Single
-        rule %r(/\*.*?\*/)m, Comment::Multiline
+        rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
+
+        rule %r/::[a-z_][\w\s'%.\\]*/i, Name::Variable
+        rule %r/:\w+/, Name
+        rule %r/[a-z_][\w\s'%.\\]*/i, Name::Variable
 
         rule %r/(")(\\\[)(.*?)(\]\\)(")/m do
           groups Str::Double, Str::Escape, Str::Double, Str::Escape, Str::Double  # escaped string
         end
         rule %r/"/, Str::Double, :dq
 
-        rule %r/[*!%&\[\](){}<>\|+=:\/-]/, Operator
-        rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
-        
-        rule %r/./, Text
+        rule %r/[-+*\/!%&<>\|=:]/, Operator
+        rule %r/[\[\](){},;]/, Punctuation
       end
 
       state :dq do

--- a/spec/lexers/jsl_spec.rb
+++ b/spec/lexers/jsl_spec.rb
@@ -9,9 +9,6 @@ describe Rouge::Lexers::JSL do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.jsl'
     end
-
-    it 'guesses by mimetype' do
-      assert_guess :mimetype => 'text/x-jsl'
-    end
+    
   end
 end

--- a/spec/lexers/jsl_spec.rb
+++ b/spec/lexers/jsl_spec.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*- #
+# frozen_string_literal: true
 
 describe Rouge::Lexers::JSL do
   let(:subject) { Rouge::Lexers::JSL.new }

--- a/spec/lexers/jsl_spec.rb
+++ b/spec/lexers/jsl_spec.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::JSL do
+  let(:subject) { Rouge::Lexers::JSL.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.jsl'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-jsl'
+    end
+  end
+end

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -1,0 +1,18 @@
+// Single Line Comment
+dt = open( "$sample_data\big class.jmp" );
+dt << Distribution( Column( :age ), Histograms Only( 1 ) );
+/*
+    Multi-line comment
+*/
+
+escapeQuote = "This is a \!"
+quotation mark";
+escapeStr = "\[This is """""""
+an escaped string]\"
+
+list = List( 1, 3, 5 );
+alsoAList = {7,9,11};
+
+New Window( "Rouge Test",
+    Text Box( "Syntax highlighting is great!" )
+);

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -5,6 +5,7 @@ dt << Distribution( Column( :age ), Histograms Only( 1 ) );
     Multi-line comment
 */
 
+escapeSequence = "This is an \!b escaped sequence";
 escapeQuote = "This is a \!"
 quotation mark";
 escapeStr = "\[This is """""""

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -13,6 +13,9 @@ an escaped string]\"
 list = List( 1, 3, 5 );
 alsoAList = {7,9,11};
 
+scientificNotation = 5e9;
+decimal = 1.234;
+
 New Window( "Rouge Test",
     Text Box( "Syntax highlighting is great!" )
 );

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -12,9 +12,12 @@ escapeStr = "\[This is """"""" an escaped string]\"
 list = List( 1, 3, 5 );
 alsoAList = {7,9,11};
 a name with spaces = 5;
+"a-name!with\!"special\characters"n = 5;
 
 scientificNotation = 5e9;
 decimal = 1.234;
+date = 01jan00;
+dateTime = 12dec1999:12:30:00.45;
 
 New Window( "Rouge Test",
     Text Box( "Syntax highlighting is great!" )

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -6,13 +6,12 @@ dt << Distribution( Column( :age ), Histograms Only( 1 ) );
 */
 
 escapeSequence = "This is an \!b escaped sequence";
-escapeQuote = "This is a \!"
-quotation mark";
-escapeStr = "\[This is """""""
-an escaped string]\"
+escapeQuote = "This is a \!" quotation mark";
+escapeStr = "\[This is """"""" an escaped string]\"
 
 list = List( 1, 3, 5 );
 alsoAList = {7,9,11};
+a name with spaces = 5;
 
 scientificNotation = 5e9;
 decimal = 1.234;


### PR DESCRIPTION
This PR adds support for JSL, the scripting language used in [JMP](www.jmp.com) software.