### PR TITLE
Add a first support to EEX (Embedded Elixir)

### DIFF
--- a/lib/rouge/demos/eex
+++ b/lib/rouge/demos/eex
@@ -1,0 +1,1 @@
+<title><%= @title %></title>

--- a/lib/rouge/lexers/eex.rb
+++ b/lib/rouge/lexers/eex.rb
@@ -25,24 +25,24 @@ module Rouge
       close = /%%>|%>/
 
       state :root do
-        rule /<%#/, Comment, :comment
+        rule %r/<%#/, Comment, :comment
 
         rule open, Comment::Preproc, :elixir
 
-        rule /.+?(?=#{open})|.+/m do
+        rule %r/.+?(?=#{open})|.+/m do
           delegate parent
         end
       end
 
       state :comment do
         rule close, Comment, :pop!
-        rule /./, Comment
+        rule %r/./, Comment
       end
 
       state :elixir do
         rule close, Comment::Preproc, :pop!
 
-        rule /.+?(?=#{close})|.+/m do
+        rule %r/.+?(?=#{close})|.+/m do
           delegate @elixir_lexer
         end
       end

--- a/lib/rouge/lexers/eex.rb
+++ b/lib/rouge/lexers/eex.rb
@@ -29,20 +29,20 @@ module Rouge
 
         rule open, Comment::Preproc, :elixir
 
-        rule %r/.+?(?=#{open})|.+/m do
+        rule %r/.+?(?=#{open})|.+/mo do
           delegate parent
         end
       end
 
       state :comment do
         rule close, Comment, :pop!
-        rule %r/./, Comment
+        rule %r/.+?(?=#{close})|.+/mo, Comment
       end
 
       state :elixir do
         rule close, Comment::Preproc, :pop!
 
-        rule %r/.+?(?=#{close})|.+/m do
+        rule %r/.+?(?=#{close})|.+/mo do
           delegate @elixir_lexer
         end
       end

--- a/lib/rouge/lexers/eex.rb
+++ b/lib/rouge/lexers/eex.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class EEX < TemplateLexer
+      title "EEX"
+      desc "Embedded Elixir"
+
+      tag 'eex'
+
+      filenames '*.eex'
+
+      def initialize(opts={})
+        @elixir_lexer = Elixir.new(opts)
+
+        super(opts)
+      end
+
+      start do
+        parent.reset!
+        @elixir_lexer.reset!
+      end
+
+      open  = /<%%|<%=|<%#|<%/
+      close = /%%>|%>/
+
+      state :root do
+        rule /<%#/, Comment, :comment
+
+        rule open, Comment::Preproc, :elixir
+
+        rule /.+?(?=#{open})|.+/m do
+          delegate parent
+        end
+      end
+
+      state :comment do
+        rule close, Comment, :pop!
+        rule /./, Comment
+      end
+
+      state :elixir do
+        rule close, Comment::Preproc, :pop!
+
+        rule /.+?(?=#{close})|.+/m do
+          delegate @elixir_lexer
+        end
+      end
+    end
+  end
+end

--- a/spec/lexers/eex_spec.rb
+++ b/spec/lexers/eex_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::EEX do
+  let(:subject) { Rouge::Lexers::EEX.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.eex'
+      assert_guess :filename => 'foo.html.eex'
+    end
+  end
+end

--- a/spec/visual/samples/eex
+++ b/spec/visual/samples/eex
@@ -1,0 +1,45 @@
+<h3>List</h3>
+<%= if Enum.empty?(@list) do %>
+<p>not found.</p>
+<% else %>
+<table>
+  <tbody>
+    <%= for {item, i} <- Enum.with_index(list) do %>
+    <tr bgcolor="<%= if Integer.mod(i, 2) == 0, do: "#FFCCCC", else: "#CCCCFF" %>">
+      <td><%= item %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+<% end %>
+
+<%# comment %>
+
+<% header_tag = 'h1' %>
+
+<<%= header_tag %>>
+  it's a header!
+</<%= header_tag %>>
+
+<%#
+  two line
+  comment
+%>
+
+<script>
+  var foo = 1;
+  var bar = <%= bar %>;
+  var baz = {
+    a: 1,
+    b: 2
+  };
+</script>
+<style>
+.foo {
+  line-height: <%= @line_height %>
+}
+</style>
+<p>
+  Some another text
+</p>
+thumbsup 0


### PR DESCRIPTION
Hi,

this PR attempts to add an initial support to [EEX (Embedded Elixir)](https://hexdocs.pm/eex/EEx.html).

Really close to (and based on) the ERB class with a change of `rule /.+(?=#{close})|.+/m, Comment` to `rule /./, Comment` to handle one line comments (`<%# ... %>`).

This fixes #412