### PR TITLE
Changed javascript lexer to handle ES6 regex flags

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -73,7 +73,7 @@ module Rouge
       end
 
       state :regex_end do
-        rule %r/[gim]+/, Str::Regex, :pop!
+        rule %r/[gimuy]+/, Str::Regex, :pop!
         rule(//) { pop! }
       end
 

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -268,3 +268,8 @@ for (const x of global.foo) {}
 
 var myBin   = 0b10;
 var myOct   = 0o67;
+
+// ES6 regexes
+
+let x = /abc/u;
+let x = /abc/y;


### PR DESCRIPTION
ES6 introduced a `u` and `y` flag for regular expressions in javascript. This fix makes sure rouge properly tokenizes these flags