### PR TITLE
Fix issue #860: `sed` addresses that use custom delimiter.

### DIFF
--- a/lib/rouge/lexers/sed.rb
+++ b/lib/rouge/lexers/sed.rb
@@ -141,7 +141,7 @@ module Rouge
         end
 
         # alternate regex rage delimiters
-        rule %r((\\)(.)(\\.|.)*?(\2)) do |m|
+        rule %r((\\)(.)((?:\\.|.)*?)(\2)) do |m|
           token addr_tok, m[1] + m[2]
           delegate regex, m[3]
           token addr_tok, m[4]

--- a/spec/lexers/sed_spec.rb
+++ b/spec/lexers/sed_spec.rb
@@ -19,4 +19,16 @@ describe Rouge::Lexers::Sed do
       assert_guess :source => '#!/usr/bin/sed'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'parses regex addresses with custom delimiter (issue #860)' do
+      assert_tokens_equal '\#foobar#n',
+        ['Keyword.Namespace', '\#'],
+        ['Literal.String.Regex', 'foobar'],
+        ['Keyword.Namespace', '#'],
+        ['Keyword', 'n']
+    end
+  end
 end

--- a/spec/lexers/sed_spec.rb
+++ b/spec/lexers/sed_spec.rb
@@ -23,7 +23,7 @@ describe Rouge::Lexers::Sed do
   describe 'lexing' do
     include Support::Lexing
 
-    it 'parses regex addresses with custom delimiter (issue #860)' do
+    it 'parses regex addresses with custom delimiter' do
       assert_tokens_equal '\#foobar#n',
         ['Keyword.Namespace', '\#'],
         ['Literal.String.Regex', 'foobar'],


### PR DESCRIPTION
This fixes #860.