### PR TITLE
Console lexer: use whitespace after prompt

### DIFF
--- a/lib/rouge/lexers/console.rb
+++ b/lib/rouge/lexers/console.rb
@@ -115,7 +115,7 @@ module Rouge
           # before we pass to the lang lexer so it can determine where
           # the "real" beginning of the line is
           $' =~ /\A\s*/
-          yield Text, $& unless $&.empty?
+          yield Text::Whitespace, $& unless $&.empty?
 
           lang_lexer.lex($', continue: true, &output)
         elsif comment_regex =~ input[0].strip


### PR DESCRIPTION
Changed the console lexer to use the whitespace token after the prompt instead of using a normal text token. This is useful to allow applying custom CSS to the whitespace (e.g. disabling selection).

Input:
~~~
~$ gpg2 
~~~

Original output:
~~~ html
<span class="gp">~$</span> gpg2 
~~~

New output:
~~~ html
<span class="gp">~$</span><span class="w"> </span>gpg2 
~~~
