### PR TITLE
[Fix #895] allow numbers within variable names

### DIFF
--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -69,7 +69,7 @@ module Rouge
         # highlighted specifically; thus use `Name::Function`.
         rule %r/\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
 
-        rule %r/[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
+        rule %r/[a-zA-Z.]([a-zA-Z0-9_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
           elsif KEYWORD_CONSTANTS.include? m[0]

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -60,8 +60,7 @@ module Rouge
         rule %r/%[^%]*?%/, Operator
 
         rule %r/0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
-        rule %r/[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
-          Num
+        rule %r/[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/, Num
 
         # Only recognize built-in functions when they are actually used as a
         # function call, i.e. followed by an opening parenthesis.
@@ -69,7 +68,8 @@ module Rouge
         # highlighted specifically; thus use `Name::Function`.
         rule %r/\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
 
-        rule %r/[a-zA-Z.]([a-zA-Z0-9_][\w.]*)?/ do |m|
+        rule %r/(?:(?:[[:alpha:]]|[.][._[:alpha:]])[._[:alnum:]]*)|[.]/ do |m|
+        # rule %r/[a-zA-Z.]([a-zA-Z0-9_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
           elsif KEYWORD_CONSTANTS.include? m[0]

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -69,7 +69,6 @@ module Rouge
         rule %r/\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
 
         rule %r/(?:(?:[[:alpha:]]|[.][._[:alpha:]])[._[:alnum:]]*)|[.]/ do |m|
-        # rule %r/[a-zA-Z.]([a-zA-Z0-9_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
           elsif KEYWORD_CONSTANTS.include? m[0]

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -5,6 +5,8 @@
 
 ## Valid names
 abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
+f2_bar
+F2_BAR
 .foo_ <- NULL
 ._foo <- NULL
 . <- NULL

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -5,8 +5,8 @@
 
 ## Valid names
 abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
-f2_bar
-F2_BAR
+f2_bar <- NULL
+F2_BAR <- NULL
 .foo_ <- NULL
 ._foo <- NULL
 . <- NULL


### PR DESCRIPTION
Attempt to address #895 
This is my first contribution to a Ruby project. Please provide feedback if anything else is needed.
@klmr given that you improved the R lexer, could you please double check that this looks reasonable? 
