### PR TITLE
Add support for EPP templates (#901)

### DIFF
--- a/lib/rouge/demos/epp
+++ b/lib/rouge/demos/epp
@@ -1,0 +1,4 @@
+<%- |
+    Optional[String] $title,
+| -%>
+<title><%= $title %></title>

--- a/lib/rouge/lexers/epp.rb
+++ b/lib/rouge/lexers/epp.rb
@@ -25,24 +25,24 @@ module Rouge
       close = /%%>|(\|\s*)?(-%>|%>)/
 
       state :root do
-        rule /<%#/, Comment, :comment
+        rule %r/<%#/, Comment, :comment
 
         rule open, Comment::Preproc, :puppet
 
-        rule /.+?(?=#{open})|.+/m do
+        rule %r/.+?(?=#{open})|.+/m do
           delegate parent
         end
       end
 
       state :comment do
         rule close, Comment, :pop!
-        rule /.+?(?=#{close})|.+/m, Comment
+        rule %r/.+?(?=#{close})|.+/m, Comment
       end
 
       state :puppet do
         rule close, Comment::Preproc, :pop!
 
-        rule /.+?(?=#{close})|.+/m do
+        rule %r/.+?(?=#{close})|.+/m do
           delegate @puppet_lexer
         end
       end

--- a/lib/rouge/lexers/epp.rb
+++ b/lib/rouge/lexers/epp.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class EPP < TemplateLexer
+      title "EPP"
+      desc "Embedded Puppet template files"
+
+      tag 'epp'
+
+      filenames '*.epp'
+
+      def initialize(opts={})
+        @puppet_lexer = Puppet.new(opts)
+
+        super(opts)
+      end
+
+      start do
+        parent.reset!
+        @puppet_lexer.reset!
+      end
+
+      open  = /<%%|<%=|<%#|(<%-|<%)(\s*?\|)?/
+      close = /%%>|(\|\s*?)?(-%>|%>)/
+
+      state :root do
+        rule /<%#/, Comment, :comment
+
+        rule open, Comment::Preproc, :puppet
+
+        rule /.+?(?=#{open})|.+/m do
+          delegate parent
+        end
+      end
+
+      state :comment do
+        rule close, Comment, :pop!
+        rule /.+?(?=#{close})|.+/m, Comment
+      end
+
+      state :puppet do
+        rule close, Comment::Preproc, :pop!
+
+        rule /.+?(?=#{close})|.+/m do
+          delegate @puppet_lexer
+        end
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/epp.rb
+++ b/lib/rouge/lexers/epp.rb
@@ -21,8 +21,8 @@ module Rouge
         @puppet_lexer.reset!
       end
 
-      open  = /<%%|<%=|<%#|(<%-|<%)(\s*?\|)?/
-      close = /%%>|(\|\s*?)?(-%>|%>)/
+      open  = /<%%|<%=|<%#|(<%-|<%)(\s*\|)?/
+      close = /%%>|(\|\s*)?(-%>|%>)/
 
       state :root do
         rule /<%#/, Comment, :comment

--- a/lib/rouge/lexers/epp.rb
+++ b/lib/rouge/lexers/epp.rb
@@ -11,9 +11,9 @@ module Rouge
       filenames '*.epp'
 
       def initialize(opts={})
-        @puppet_lexer = Puppet.new(opts)
-
         super(opts)
+        @parent = lexer_option(:parent) { PlainText.new(opts) }
+        @puppet_lexer = Puppet.new(opts)
       end
 
       start do

--- a/spec/lexers/epp_spec.rb
+++ b/spec/lexers/epp_spec.rb
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::EPP do
+  let(:subject) { Rouge::Lexers::EPP.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.html.epp'
+    end
+  end
+end

--- a/spec/visual/samples/epp
+++ b/spec/visual/samples/epp
@@ -1,0 +1,24 @@
+<%- | Boolean $keys_enable,
+      String  $keys_file,
+      Array   $keys_trusted,
+      String  $keys_requestkey,
+      String  $keys_controlkey
+| -%>
+<%# Parameter tag ↑ -%>
+
+<%# Non-printing tag ↓ -%>
+<% if $keys_enable { -%>
+
+<%# Expression-printing tag ↓ -%>
+keys <%= $keys_file %>
+<% unless $keys_trusted =~ Array[Data,0,0] { -%>
+trustedkey <%= $keys_trusted.join(' ') %>
+<% } -%>
+<% if $keys_requestkey =~ String[1] { -%>
+requestkey <%= $keys_requestkey %>
+<% } -%>
+<% if $keys_controlkey =~ String[1] { -%>
+controlkey <%= $keys_controlkey %>
+<% } -%>
+
+<% } -%>


### PR DESCRIPTION
Based off of a lightly modified ERB lexer, just with the added parsing of parameter blocks.

I'm not entirely sure if it's best to just extend the open/close regexps, or to add a completely separate parameters state.

This fixes #901.