### PR TITLE
Allow []()*. in html attribute names #725 

### DIFF
--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -82,9 +82,9 @@ module Rouge
       end
 
       state :tag do
-        rule %r/\s+/m, Text
-        rule %r/[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
-        rule %r/[a-zA-Z0-9_:-]+/, Name::Attribute
+        rule /\s+/m, Text
+        rule /[a-zA-Z0-9_:\[\]()*.-]+\s*=/m, Name::Attribute, :attr
+        rule /[a-zA-Z0-9_:#*-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!
       end
 

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -83,7 +83,7 @@ module Rouge
 
       state :tag do
         rule %r/\s+/m, Text
-        rule %r/[a-zA-Z0-9_:\[\]()*.-]+\s*=/m, Name::Attribute, :attr
+        rule %r/[a-zA-Z0-9_:\[\]()*.-]+\s*=\s*/m, Name::Attribute, :attr
         rule %r/[a-zA-Z0-9_:#*-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!
       end

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -82,9 +82,9 @@ module Rouge
       end
 
       state :tag do
-        rule /\s+/m, Text
-        rule /[a-zA-Z0-9_:\[\]()*.-]+\s*=/m, Name::Attribute, :attr
-        rule /[a-zA-Z0-9_:#*-]+/, Name::Attribute
+        rule %r/\s+/m, Text
+        rule %r/[a-zA-Z0-9_:\[\]()*.-]+\s*=/m, Name::Attribute, :attr
+        rule %r/[a-zA-Z0-9_:#*-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!
       end
 

--- a/spec/lexers/html_spec.rb
+++ b/spec/lexers/html_spec.rb
@@ -18,6 +18,44 @@ describe Rouge::Lexers::HTML do
                             ['Name.Tag', '<custom-element></custom-element>']
       end
     end
+    describe 'attribute names' do
+      it 'allow * to support Angular 2+ structural Directives' do
+        assert_tokens_equal '<custom-element *ng-structural-directive></custom-element>',
+                            ['Name.Tag', '<custom-element'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '*ng-structural-directive'],
+                            ['Name.Tag', '></custom-element>']
+      end
+    end
+    describe 'attribute names' do
+      it 'allow # to support Angular 2+ template reference variables' do
+        assert_tokens_equal '<custom-element #ref></custom-element>',
+                            ['Name.Tag', '<custom-element'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '#ref'],
+                            ['Name.Tag', '></custom-element>']
+      end
+    end
+    describe 'attribute names' do
+      it 'allow [] to support Angular 2+ data binding inputs' do
+        assert_tokens_equal '<custom-element [target]="expression"></custom-element>',
+                            ['Name.Tag', '<custom-element'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '[target]='],
+                            ['Literal.String', '"expression"'],
+                            ['Name.Tag', '></custom-element>']
+      end
+    end
+    describe 'attribute names' do
+      it 'allow () to support Angular 2+ data binding outputs' do
+        assert_tokens_equal '<custom-element (target)="expression"></custom-element>',
+                            ['Name.Tag', '<custom-element'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '(target)='],
+                            ['Literal.String', '"expression"'],
+                            ['Name.Tag', '></custom-element>']
+      end
+    end
   end
 
   describe 'guessing' do

--- a/spec/visual/samples/html
+++ b/spec/visual/samples/html
@@ -49,3 +49,8 @@
 <!-- no tags -->
 Hello tagless world!
 
+<!-- custom Angular 2-style tags -->
+<custom-element *ng-structural-directive></custom-element>
+<custom-element #ref></custom-element>
+<custom-element [target]="expression"></custom-element>
+<custom-element (target)="expression"></custom-element>


### PR DESCRIPTION
Fix issue #725 
Allow `[]()*.` in Attribute names with values.
Allow `#*` in Attribute names.