### PR TITLE
Remove errors in samples

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -64,7 +64,7 @@ module Rouge
         rule /""/, Str
         rule /{/, Punctuation, :nest
         rule /"/, Str, :pop!
-        rule /./, Str
+        rule /./m, Str
       end
 
       state :root do

--- a/lib/rouge/lexers/elm.rb
+++ b/lib/rouge/lexers/elm.rb
@@ -79,9 +79,8 @@ module Rouge
 
       # Multiple line string with tripple double quotes, e.g. """ multi """
       state :multiline_string do
-        rule /\s*"""/, Str, :pop!
-        rule /.*/, Str
-        rule /\s*/, Str
+        rule /"""/, Str, :pop!
+        rule /(.*?)(?=""")/m, Str
       end
 
     end

--- a/lib/rouge/lexers/igorpro.rb
+++ b/lib/rouge/lexers/igorpro.rb
@@ -580,9 +580,9 @@ module Rouge
         rule /[=]/, Punctuation, :assignment
         rule object, Name::Variable
         rule /[\[\]]/, Punctuation # optional variables in functions
-        rule /[,]/, Punctuation, :parse_variables
+        rule /[,]/, Punctuation
         rule /\)/, Punctuation, :pop! # end of function
-        rule %r([/][a-z]+)i, Keyword::Pseudo, :parse_variables
+        rule %r([/][a-z]+)i, Keyword::Pseudo
         rule(//) { pop! }
       end
 
@@ -655,8 +655,7 @@ module Rouge
           # doxygen comments
           groups Comment, Comment::Special
         end
-        rule /[^\r\n]/, Comment
-        rule(//) { pop! }
+        rule /(.*?)(?=(\n|\r))/, Comment, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/jsonnet.rb
+++ b/lib/rouge/lexers/jsonnet.rb
@@ -144,7 +144,7 @@ module Rouge
       state :string_block do
         mixin :string
         rule /\|\|\|/, Str, :pop!
-        rule /.*/, Str
+        rule /(.*?)(?=\|\|\|)/m, Str
       end
     end
   end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -237,7 +237,7 @@ module Rouge
       end
 
       state :whitespace do
-        rule /[ \t]+/, Text::Whitespace
+        rule /[\s\t\n]+/, Text::Whitespace
       end
 
       state :comment do
@@ -246,7 +246,7 @@ module Rouge
           reset_stack
         end
 
-        rule /./, Comment
+        rule /./m, Comment
       end
 
       state :raw do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -21,7 +21,7 @@ module Rouge
 
       state :multiline_comment do
         rule /\*\//, Comment, :pop!
-        rule /./, Comment
+        rule /(.*?)(?=\*\/)/m, Comment
       end
 
       state :number do
@@ -78,13 +78,13 @@ module Rouge
       state :indented_string do
         mixin :indented_string_content
         rule /''/, Str::Double, :pop!
-        rule /./, Str::Double
+        rule /(.*?)(?='')/m, Str::Double
       end
 
       state :double_quoted_string do
         mixin :string_content
         rule /"/, Str::Double, :pop!
-        rule /./, Str::Double
+        rule /(.*?)(?=")/m, Str::Double
       end
 
       state :operator do

--- a/lib/rouge/lexers/sieve.rb
+++ b/lib/rouge/lexers/sieve.rb
@@ -66,7 +66,7 @@ module Rouge
         rule /"/, Str::Double, :pop!
         # Variables Extension (rfc5229)
         rule /\${(?:[0-9][.0-9]*|[a-zA-Z_][.a-zA-Z0-9_]*)}/, Str::Interpol
-        rule /./, Str::Double
+        rule /./m, Str::Double
       end
 
       state :root do

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -434,7 +434,9 @@ module Rouge
   private
     def yield_token(tok, val)
       return if val.nil? || val.empty?
-      puts "    yielding #{tok.qualname}, #{val.inspect}" if @debug
+      if @debug && (tok != nil)
+        puts "    yielding #{tok.qualname}, #{val.inspect}"
+      end
       @output_stream.yield(tok, val)
     end
   end


### PR DESCRIPTION
I ran the samples of each language, and if the output of `document.querySelectorAll("span.err")` gave errors, I fixed those. Most errors were caused by multi line strings or comments: their regexes weren't matching newlines.

Also fixed the fact that if you loaded `liquid?debug` you got an error.