### PR TITLE
Correctly highlight placeholders in Gherkin syntax

### DIFF
--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -132,7 +132,7 @@ module Rouge
         mixin :basic
         rule %r/<.*?>/, Name::Variable
         rule %r/".*?"/, Str
-        rule %r/\S[^ \r\n\t<]*/, Text
+        rule %r/\S[^\s<]*/, Text
         rule rest_of_line, Text, :pop!
       end
     end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -130,9 +130,9 @@ module Rouge
 
       state :step do
         mixin :basic
-        rule /<.*?>/, Name::Variable
-        rule /".*?"/, Str
-        rule /\S[^ \r\n\t<]*/, Text
+        rule %r/<.*?>/, Name::Variable
+        rule %r/".*?"/, Str
+        rule %r/\S[^ \r\n\t<]*/, Text
         rule rest_of_line, Text, :pop!
       end
     end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -30,6 +30,8 @@ module Rouge
           keywords[:step].map do |w|
             if w.end_with? '<'
               Regexp.escape(w.chop)
+            elsif w.end_with?(' ')
+              Regexp.escape(w)
             else
               "#{Regexp.escape(w)}\\b"
             end
@@ -128,9 +130,9 @@ module Rouge
 
       state :step do
         mixin :basic
-        rule %r/<.*?>/, Name::Variable
-        rule %r/".*?"/, Str
-        rule %r/\S+/, Text
+        rule /<.*?>/, Name::Variable
+        rule /".*?"/, Str
+        rule /\S[^ <]*/, Text
         rule rest_of_line, Text, :pop!
       end
     end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -8,7 +8,7 @@ module Rouge
       aliases 'cucumber', 'behat'
 
       title "Gherkin"
-      desc 'A business-readable spec DSL ( github.com/cucumber/cucumber/wiki/Gherkin )'
+      desc 'A business-readable spec DSL (github.com/cucumber/cucumber/wiki/Gherkin)'
 
       filenames '*.feature'
       mimetypes 'text/x-gherkin'

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -132,7 +132,7 @@ module Rouge
         mixin :basic
         rule /<.*?>/, Name::Variable
         rule /".*?"/, Str
-        rule /\S[^ <]*/, Text
+        rule /\S[^ \r\n\t<]*/, Text
         rule rest_of_line, Text, :pop!
       end
     end

--- a/spec/lexers/gherkin_spec.rb
+++ b/spec/lexers/gherkin_spec.rb
@@ -19,4 +19,20 @@ describe Rouge::Lexers::Gherkin do
       assert_guess :source => '#!/usr/bin/env cucumber'
     end
   end
+
+  describe 'lexing' do
+    it 'highlights placeholders correctly' do
+      subject.push :has_examples
+      tokens = subject.lex('When <foo> (<bar>, <baz>)< garbage', continue: true).to_a
+
+      assert { tokens.size == 7 }
+      assert { tokens[0][0] == Token['Name.Function'] }
+      assert { tokens[1][0] == Token['Name.Variable'] }
+      assert { tokens[2][0] == Token['Text'] }
+      assert { tokens[3][0] == Token['Name.Variable'] }
+      assert { tokens[4][0] == Token['Text'] }
+      assert { tokens[5][0] == Token['Name.Variable'] }
+      assert { tokens[6][0] == Token['Text'] }
+    end
+  end
 end

--- a/spec/lexers/gherkin_spec.rb
+++ b/spec/lexers/gherkin_spec.rb
@@ -21,9 +21,18 @@ describe Rouge::Lexers::Gherkin do
   end
 
   describe 'lexing' do
+    it 'highlights multiline steps correctly' do
+      tokens = subject.lex("When this\nAnd that").to_a
+
+      assert { tokens.size == 4 }
+      assert { tokens[0][0] == Token['Name.Function'] }
+      assert { tokens[1][0] == Token['Text'] }
+      assert { tokens[2][0] == Token['Name.Function'] }
+      assert { tokens[3][0] == Token['Text'] }
+    end
+
     it 'highlights placeholders correctly' do
-      subject.push :has_examples
-      tokens = subject.lex('When <foo> (<bar>, <baz>)< garbage', continue: true).to_a
+      tokens = subject.lex('When <foo> (<bar>, <baz>)< garbage').to_a
 
       assert { tokens.size == 7 }
       assert { tokens[0][0] == Token['Name.Function'] }

--- a/spec/visual/samples/gherkin
+++ b/spec/visual/samples/gherkin
@@ -31,7 +31,7 @@ Feature: Feature Text
       |g|h|
       |e|r|
       |k|i|
-      |n|| 
+      |n||
     And I am done testing these tables
     #Comment on line 29
     Then I am happy
@@ -44,6 +44,16 @@ Feature: Feature Text
       """
     Then crazy
 
+  Scenario Outline: Variable highlighting
+    Given a variable <foo>
+    When <foo> is surrounded by punctuation like (<foo> or <bar>)
+    Then all variables should be highlighted properly.
+
+    Examples:
+      | foo  | bar |
+      | 1    | 2   |
+      | good | bad |
+
 #language:zh-CN
 功能:加法
 
@@ -52,4 +62,3 @@ Feature: Feature Text
     而且我已经在计算器里输入7
     当我按相加按钮
     那么我应该在屏幕上看到的结果是13
-


### PR DESCRIPTION
While placeholders (variables surrounded by angle brackets, like `<this>`) are mostly highlighted correctly, there are two cases that are not:

1. When the angle bracket is immediately preceded by text, like `something (<foo>)`, and
2. When the angle bracket is the first non-whitespace text following a step keyword, like `When <foo>`.

This PR addresses these two cases. Some things to note about this PR.

1. The `Text` rule in the `step` state now stops as soon as it encounters either whitespace, OR a left angle bracket. This fixes case number 1.
2.  `Rouge::Lexers::Gherkin.step_regex` has been modified so that it does _not_ added a `\b` to the end of the regex, if the pattern ends with a whitespace character. In fact, I wonder if there is a disconnect between the `step_regex` function and the keyword configs, since the comment mentions patterns that end with a `<`, but there are no patterns in the config that do so. This change, though, fixes case number 2.