### PR TITLE
Fix Rust attributes and doc comments on the first line

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -88,7 +88,7 @@ module Rouge
         end
         rule /\n/, Text, :try_doc_comment
         mixin :whitespace
-        rule /#\[/, Name::Decorator, :attribute
+        rule /#!?\[/, Name::Decorator, :attribute
         rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -63,15 +63,15 @@ module Rouge
 
       state :try_doc_comment do
         mixin :whitespace
-        rule /#\s[^\n]*/, Comment::Preproc
-        rule //, Text, :pop!
+        rule %r/#\s[^\n]*/, Comment::Preproc
+        rule %r//, Text, :pop!
       end
 
       state :attribute do
         mixin :whitespace
         mixin :has_literals
-        rule /[(,)=:]/, Name::Decorator
-        rule /\]/, Name::Decorator, :pop!
+        rule %r/[(,)=:]/, Name::Decorator
+        rule %r/\]/, Name::Decorator, :pop!
         rule id, Name::Decorator
       end
 
@@ -83,13 +83,13 @@ module Rouge
 
       state :root do
         if @beginning
-          rule //, Text, :try_doc_comment
+          rule %r//, Text, :try_doc_comment
           @beginning = false
         end
-        rule /\n/, Text, :try_doc_comment
+        rule %r/\n/, Text, :try_doc_comment
         mixin :whitespace
-        rule /#!?\[/, Name::Decorator, :attribute
-        rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
+        rule %r/#!?\[/, Name::Decorator, :attribute
+        rule %r/\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals
 
         rule %r([=-]>), Keyword

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -70,8 +70,8 @@ module Rouge
       state :attribute do
         mixin :whitespace
         mixin :has_literals
-        rule %r/[(,)=]/, Name::Decorator
-        rule %r/\]/, Name::Decorator, :pop!
+        rule /[(,)=:]/, Name::Decorator
+        rule /\]/, Name::Decorator, :pop!
         rule id, Name::Decorator
       end
 

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -1,4 +1,4 @@
-#[test]
+#![test]
 fn f() {
     let a = String::new("hello");
     let b: &str = a;

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -1,3 +1,4 @@
+#[test]
 fn f() {
     let a = String::new("hello");
     let b: &str = a;

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -1,4 +1,4 @@
-#![test]
+#![test(a::b)]
 fn f() {
     let a = String::new("hello");
     let b: &str = a;


### PR DESCRIPTION
A bug was causing files starting with attributes and doc comments
to produce incorrect error nodes. This change also allows attributes
to occur in positions other than the start of a line, bringing it in
line with the language's grammar.

I still question the inclusion of doc comments because they're not part of the grammar of the language. They're used inside comments containing code to hide irrelevant lines of code while generating documentation. Still, someone probably found them useful so best to keep them working.