### PR TITLE
syntax highlighting support for CUDA C++ .cu / .cuh files

### DIFF
--- a/lib/rouge/demos/cuda
+++ b/lib/rouge/demos/cuda
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+__global__ void helloFromGPU() {
+    std::printf("Hello World\n");
+    __syncthreads();
+}
+
+int main() {
+    dim3 block(1, 10);
+    helloFromGPU<<<1, block>>>();
+}

--- a/lib/rouge/lexers/cuda.rb
+++ b/lib/rouge/lexers/cuda.rb
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    load_lexer 'cpp.rb'
+
+    class CUDA < Cpp
+      title "CUDA"
+      desc "Compute Unified Device Architecture, used for programming with NVIDIA GPU"
+
+      tag 'cuda'
+      filenames '*.cu', '*.cuh'
+
+      def self.keywords
+        @keywords ||= super + Set.new(%w(
+          __global__ __device__ __host__ __noinline__ __forceinline__
+          __constant__ __shared__ __managed__ __restrict__
+        ))
+      end
+
+      def self.keywords_type
+        @keywords_type ||= super + Set.new(%w(
+          char1 char2 char3 char4 uchar1 uchar2 uchar3 uchar4
+          short1 short2 short3 short4 ushort1 ushort2 ushort3 ushort4
+          int1 int2 int3 int4 uint1 uint2 uint3 uint4
+          long1 long2 long3 long4 ulong1 ulong2 ulong3 ulong4
+          longlong1 longlong2 longlong3 longlong4 
+          ulonglong1 ulonglong2 ulonglong3 ulonglong4 
+          float1 float2 float3 float4 double1 double2 double3 double4
+          dim3
+        ))
+      end
+    end
+  end
+end

--- a/spec/lexers/cuda_spec.rb
+++ b/spec/lexers/cuda_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::CUDA do
+  let(:subject) { Rouge::Lexers::CUDA.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.cu'
+      assert_guess :filename => 'foo.cuh'
+    end
+  end
+end

--- a/spec/visual/samples/cuda
+++ b/spec/visual/samples/cuda
@@ -1,0 +1,11 @@
+__global__ void kernel(float *a, float *b) {
+    __shared__ float sum;
+    some_func();
+}
+
+__device__ __host__ void some_func() {}
+
+int main() {
+    dim3 grid(1, 1);
+    kernel<<<grid, block>>>(&a, &b);
+}


### PR DESCRIPTION
## related issue
https://github.com/jneen/rouge/issues/535

## reference
https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#c-language-extensions

<hr>
CUDA is extended c/c++, and necessary change is three, I think.

###  Function Execution Space Specifiers
`__device__`, `__host__`, `__global__`, `__uninline__`, `__foreceinline__`

ex.
```cu
__device__ kernel_func(int a) {
  // do something
}
```

### Variable Memory Space Specifiers
`__device__`, `__constant__`, `__shared__`, `__managed__`, ` __restrict_`

ex.
```cu
__constant__ int i = 1;
```

### Built-in Vector Types  
`char`, `short`, `int`, `long`, `longlong`, `float`, `double` and `dim3`
