### PR TITLE
Rust: Fix integer literals' delimiters

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -166,8 +166,8 @@ module Rouge
 
         rule %r(
           ( 0b[10_]+
-          | 0x[0-9a-fA-F-]+
-          | [0-9]+
+          | 0x[0-9a-fA-F_]+
+          | [0-9_]+
           ) (u#{size}?|i#{size})?
         )x, Num::Integer
 

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -381,6 +381,11 @@ enum HTMLFragment {
     text(~str),
 }
 
+fn int_literals_delimiter() {
+    let billion = 1000_000_000;
+    let red_color = 0xff_60_60;
+}
+
 // Some hidden lines by starting with hash
 # extern crate core;
 # use core::str;


### PR DESCRIPTION
I noticed `_` is not lexed as delimiter in integer literals. This PR fixes the point. Additionally, `-` was considered as delimiter in `0x` literal, but it's not correct. I also fixed the point.

example:

```rust
123_456_789
0x123_456_789_abc
```
