### PR TITLE
Add lean lexer

### DIFF
--- a/lib/rouge/demos/lean
+++ b/lib/rouge/demos/lean
@@ -1,0 +1,9 @@
+import hott.hit.pushout
+universes u v w
+
+hott_theory
+
+open hott hott.trunc hott.pushout
+
+@[hott, instance] def is_prop_total_image_of_weakly_constant {A : Type u} {P : Type v}
+  [is_set P] (f : A → P) [p : hott.is_weakly_constant f] : is_prop (hott.total_image f) :=

--- a/lib/rouge/lexers/lean.rb
+++ b/lib/rouge/lexers/lean.rb
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Lean < RegexLexer
+      title "lean"
+      desc 'Lean (leanprover.github.io)'
+      tag 'lean'
+      mimetypes 'text/x-lean'
+
+      keywords = Set.new %w(
+        import abbreviation opaque_hint tactic_hint definition
+        renaming inline hiding exposing parameter parameters
+        conjecture hypothesis lemma corollary variable variables
+        theorem axiom inductive structure universe universes alias hott
+        help options precedence postfix prefix calc_trans
+        calc_subst calc_refl infix infixl infixr notation eval
+        check exit coercion private using namespace include
+        including instance section context protected expose
+        export set_option add_rewrite extends open example
+        constant constants print opaque reducible irreducible
+      )
+
+      tac = %w(
+        forall fun Pi obtain from have show assume
+        take let if else then by in with begin end
+        proof qed calc match
+      )
+
+      operators = %w(
+        != # & && \* \+ - / @ ! ` -\. ->
+        \. \.\. \.\.\. :: :> ; ;; <
+        <- = == > _ \| \|\| ~ => <= >=
+        /\ \/ ∀ Π λ ↔ ∧ ∨ ≠ ≤ ≥ ⊎
+        ¬ ⁻¹ ⬝ ▸ → ∃ ℕ ℤ ≈ × ⌞ ⌟ ≡ ⟨ ⟩
+      )
+
+      punctuation = %w@\( \) : \{ \} , \[ \] ⦃ ⦄ :=@
+
+      name_start = "A-Za-z_\u03b1-\u03ba\u03bc-\u03fb\u1f00-\u1ffe\u2100-\u214f"
+      name_mid1 = "A-Za-z_'\u03b1-\u03ba\u03bc-\u03fb\u1f00-\u1ffe\u2070-\u2079"
+      name_mid2 = "\u207f-\u2089\u2090-\u209c\u2100-\u214f0-9."
+      name = %r([#{name_start}][#{name_mid1}#{name_mid2}]*)
+
+      state :root do
+        rule /\s+/m, Text::Whitespace
+        rule %r(/-), Comment::Multiline, :comment
+        rule /--.*$/, Comment::Single
+        rule /\"/, Str, :string
+        rule /\d+/, Num::Integer
+        rule /[~?][a-z][\w\']*:/, Name::Variable
+        rule name do |m|
+          name = m[0]
+          if keywords.include? name
+            token Keyword
+          elsif tac.include? name
+            token Keyword::Pseudo
+          else
+            token Name
+          end
+        end
+        rule %r(#{operators.join('|')}), Name::Builtin::Pseudo
+        rule %r(#{punctuation.join('|')}), Operator
+        # rule %r@\(@, Operator
+      end
+
+      state :comment do
+        rule %r([^/-]+), Comment::Multiline
+        rule(%r(/-)) { token Comment::Multiline; push }
+        rule %r(-/), Comment::Multiline, :pop!
+        rule /-/, Comment::Multiline
+      end
+
+      state :string do
+        rule /[^\\\"]+/, Str
+        rule /\\[n\"\\]/, Str::Escape
+        rule /\"/, Str, :pop!
+      end
+    end
+  end
+end

--- a/spec/lexers/lean_spec.rb
+++ b/spec/lexers/lean_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Lean do
+  let(:subject) { Rouge::Lexers::Lean.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-lean'
+    end
+  end
+end

--- a/spec/visual/samples/lean
+++ b/spec/visual/samples/lean
@@ -1,0 +1,34 @@
+/- lean: leanprover.github.io
+/- nested comments are allowed -/
+-/
+
+section
+set_option formatter.hide_full_terms false
+parameters
+  (W : hott.trunctype.{u} 0)
+  (deg : W → ℕ)
+  (R : W → W → Type u)
+  (dec_R : Π {w v}, R v w → deg w < deg v)
+include W deg R dec_R -- test
+
+@[hott] def R_r : W → W → Type u := λ v w, R "test\nstrings" v w ⊎ (v = w)
+
+import hott.types.trunc
+import hott.types.sigma
+import hott.function
+import hott.hit.pushout
+universes u v w
+
+hott_theory
+
+open hott hott.trunc hott.pushout
+
+@[hott, instance] def is_prop_total_image_of_weakly_constant {A : Type u} {P : Type v}
+  [is_set P] (f : A → P) [p : hott.is_weakly_constant f] : is_prop (hott.total_image f) :=
+begin
+  fapply hott.is_trunc.is_prop.mk, intros x y,
+  cases x with x fx, cases y with y fy, hinduction fx with fx, hinduction fy with fy,
+  cases fx with a ax, cases fy with b be, induction ax, induction be,
+  fapply hott.sigma.sigma_eq, apply p,
+  apply hott.is_trunc.is_prop.elimo,
+end


### PR DESCRIPTION
Simple [lean](https://leanprover.github.io) lexer, mostly copied from [the one in pygments](https://bitbucket.org/birkenfeld/pygments-main/src/default/pygments/lexers/theorem.py).