### PR TITLE
Recognize more Julia types and constants

### DIFF
--- a/lib/rouge/lexers/julia.rb
+++ b/lib/rouge/lexers/julia.rb
@@ -21,6 +21,8 @@ module Rouge
                             | NaN       | NaN16    | NaN32   | NaN64
                             | stdout    | stderr   | stdin   | devnull
                             | pi        | π        | ℯ       | im
+                            | ARGS      | C_NULL   | ENV     | ENDIAN_BOM
+                            | VERSION   | undef    | (LOAD|DEPOT)_PATH
                             )\b/x
 
       KEYWORDS            = /\b(?:
@@ -30,21 +32,137 @@ module Rouge
                             | const    | local  | global | using  | struct
                             | mutable struct    | abstract type   | finally
                             | begin    | do     | quote  | macro  | for outer
+                            | where
                             )\b/x
 
+      # NOTE: The list of types was generated automatically using the following script:
+      # using Pkg, InteractiveUtils
+      #
+      # allnames = [names(Core); names(Base, imported=true)]
+      #
+      # for stdlib in readdir(Pkg.Types.stdlib_dir())
+      #     mod = Symbol(basename(stdlib))
+      #     @eval begin
+      #         using $mod
+      #         append!(allnames, names($mod))
+      #     end
+      # end
+      #
+      # sort!(unique!(allnames))
+      #
+      # i = 1
+      # for sym in allnames
+      #     global i # needed at the top level, e.g. in the REPL
+      #     isdefined(Main, sym) || continue
+      #     getfield(which(Main, sym), sym) isa Type || continue
+      #     sym === :(=>) && continue # Actually an alias for Pair
+      #     print("| ", sym)
+      #     i % 3 == 0 ? println() : print(" ") # print 3 to a line
+      #     i += 1
+      # end
       TYPES               = /\b(?:
-                              Int         | UInt           | Int8
-                            | UInt8       | Int16          | UInt16
-                            | Int32       | UInt32         | Int64
-                            | UInt64      | Int128         | UInt128
-                            | Float16     | Float32        | Float64
-                            | Bool        | BigInt         | BigFloat
-                            | Complex     | ComplexF16     | ComplexF32
-                            | ComplexF64  | Missing        | Nothing
-                            | Char        | String         | SubString
-                            | Regex       | RegexMatch     | Any
-                            | Type        | DataType       | UnionAll
-                            | (Abstract)?(Array|Vector|Matrix|VecOrMat)
+                              ARPACKException | AbstractArray | AbstractChannel
+                            | AbstractChar | AbstractDict | AbstractDisplay
+                            | AbstractFloat | AbstractIrrational | AbstractLogger
+                            | AbstractMatrix | AbstractREPL | AbstractRNG
+                            | AbstractRange | AbstractSerializer | AbstractSet
+                            | AbstractSparseArray | AbstractSparseMatrix | AbstractSparseVector
+                            | AbstractString | AbstractUnitRange | AbstractVecOrMat
+                            | AbstractVector | AbstractWorkerPool | Adjoint
+                            | Any | ArgumentError | Array
+                            | AssertionError | Base64DecodePipe | Base64EncodePipe
+                            | BasicREPL | Bidiagonal | BigFloat
+                            | BigInt | BitArray | BitMatrix
+                            | BitSet | BitVector | Bool
+                            | BoundsError | BunchKaufman | CachingPool
+                            | CapturedException | CartesianIndex | CartesianIndices
+                            | Cchar | Cdouble | Cfloat
+                            | Channel | Char | Cholesky
+                            | CholeskyPivoted | Cint | Cintmax_t
+                            | Clong | Clonglong | ClusterManager
+                            | Cmd | Colon | Complex
+                            | ComplexF16 | ComplexF32 | ComplexF64
+                            | CompositeException | Condition | ConsoleLogger
+                            | Cptrdiff_t | Cshort | Csize_t
+                            | Cssize_t | Cstring | Cuchar
+                            | Cuint | Cuintmax_t | Culong
+                            | Culonglong | Cushort | Cvoid
+                            | Cwchar_t | Cwstring | DataType
+                            | Date | DateFormat | DatePeriod
+                            | DateTime | Day | DenseArray
+                            | DenseMatrix | DenseVecOrMat | DenseVector
+                            | Diagonal | Dict | DimensionMismatch
+                            | Dims | DivideError | DomainError
+                            | EOFError | Eigen | Enum
+                            | ErrorException | Exception | ExponentialBackOff
+                            | Expr | FDWatcher | Factorization
+                            | FileMonitor | Float16 | Float32
+                            | Float64 | FolderMonitor | Function
+                            | GeneralizedEigen | GeneralizedSVD | GeneralizedSchur
+                            | GenericArray | GenericDict | GenericSet
+                            | GenericString | GitConfig | GitRepo
+                            | GlobalRef | HMAC_CTX | HTML
+                            | Hermitian | Hessenberg | Hour
+                            | IO | IOBuffer | IOContext
+                            | IOStream | IPAddr | IPv4
+                            | IPv6 | IdDict | IndexCartesian
+                            | IndexLinear | IndexStyle | InexactError
+                            | InitError | Int | Int128
+                            | Int16 | Int32 | Int64
+                            | Int8 | Integer | InterruptException
+                            | InvalidStateException | Irrational | KeyError
+                            | LAPACKException | LDLt | LQ
+                            | LU | LinRange | LineEditREPL
+                            | LineNumberNode | LinearIndices | LoadError
+                            | LogLevel | LowerTriangular | MIME
+                            | Matrix | MersenneTwister | Method
+                            | MethodError | Microsecond | Millisecond
+                            | Minute | Missing | MissingException
+                            | Module | Month | NTuple
+                            | NamedTuple | Nanosecond | Nothing
+                            | NullLogger | Number | OrdinalRange
+                            | OutOfMemoryError | OverflowError | PackageMode
+                            | PackageSpec | Pair | PartialQuickSort
+                            | Period | PermutedDimsArray | Pipe
+                            | PollingFileWatcher | PosDefException | ProcessExitedException
+                            | Ptr | QR | QRPivoted
+                            | QuoteNode | RandomDevice | RankDeficientException
+                            | Rational | RawFD | ReadOnlyMemoryError
+                            | Real | ReentrantLock | Ref
+                            | Regex | RegexMatch | RemoteChannel
+                            | RemoteException | RoundingMode | SHA1_CTX
+                            | SHA224_CTX | SHA256_CTX | SHA2_224_CTX
+                            | SHA2_256_CTX | SHA2_384_CTX | SHA2_512_CTX
+                            | SHA384_CTX | SHA3_224_CTX | SHA3_256_CTX
+                            | SHA3_384_CTX | SHA3_512_CTX | SHA512_CTX
+                            | SVD | Schur | Second
+                            | SegmentationFault | Serializer | Set
+                            | SharedArray | SharedMatrix | SharedVector
+                            | Signed | SimpleLogger | SingularException
+                            | Some | SparseMatrixCSC | SparseVector
+                            | StackOverflowError | StepRange | StepRangeLen
+                            | StreamREPL | StridedArray | StridedMatrix
+                            | StridedVecOrMat | StridedVector | String
+                            | StringIndexError | SubArray | SubString
+                            | SubstitutionString | SymTridiagonal | Symbol
+                            | Symmetric | SystemError | TCPSocket
+                            | Task | TestSetException | Text
+                            | TextDisplay | Time | TimePeriod
+                            | TimeType | TimeZone | Timer
+                            | Transpose | Tridiagonal | Tuple
+                            | Type | TypeError | TypeVar
+                            | UDPSocket | UInt | UInt128
+                            | UInt16 | UInt32 | UInt64
+                            | UInt8 | UTC | UUID
+                            | UndefInitializer | UndefKeywordError | UndefRefError
+                            | UndefVarError | UniformScaling | Union
+                            | UnionAll | UnitLowerTriangular | UnitRange
+                            | UnitUpperTriangular | Unsigned | UpgradeLevel
+                            | UpperTriangular | Val | Vararg
+                            | VecElement | VecOrMat | Vector
+                            | VersionNumber | WeakKeyDict | WeakRef
+                            | Week | WorkerConfig | WorkerPool
+                            | Year
                             )\b/x
 
       OPERATORS           = / \+      | =        | -     | \*   | \/
@@ -58,10 +176,10 @@ module Rouge
                               | ::    | <:       | ->    | \?   | \.\*
                               | \.\^  | \.\\     | \.\/  | \\   | <
                               | >     | ÷        | >:    | :    | ===
-                              | !==
+                              | !==   | =>
                             /x
 
-      PUNCTUATION         = / [ \[ \] { } \( \) , ; @ ] /x
+      PUNCTUATION         = / [ \[ \] { } \( \) , ; ] /x
 
 
       state :root do
@@ -74,14 +192,14 @@ module Rouge
         rule /\\/, Text
 
 
-        # functions
-        rule /(function)((?:\s|\\\s)+)/ do
+        # functions and macros
+        rule /(function|macro)((?:\s|\\\s)+)/ do
           groups Keyword, Name::Function
           push :funcname
         end
 
         # types
-        rule /(type|typealias|abstract)((?:\s|\\\s)+)/ do
+        rule /((mutable )?struct|(abstract|primitive) type)((?:\s|\\\s)+)/ do
           groups Keyword, Name::Class
           push :typename
         end
@@ -91,7 +209,10 @@ module Rouge
         rule /(local|global|const)\b/, Keyword::Declaration
         rule KEYWORDS, Keyword
 
+        # TODO: end is a builtin when inside of an indexing expression
         rule BUILTINS, Name::Builtin
+
+        # TODO: symbols
 
         # backticks
         rule /`.*?`/, Literal::String::Backtick
@@ -103,6 +224,8 @@ module Rouge
         rule /(?<=[.\w)\]])\'+/, Operator
 
         # strings
+        # TODO: triple quoted string literals
+        # TODO: Detect string interpolation
         rule /(?:[IL])"/, Literal::String, :string
         rule /[E]?"/, Literal::String, :string
 


### PR DESCRIPTION
Addresses some of https://github.com/jneen/rouge/issues/934.

Summary of changes:

* Expand the list of recognized types to all types exported from Julia's Base and Core modules, as well as all of its standard library packages. A Julia script for generating the list is included as a comment.

* Add a missing keyword.

* Add a few constants missing from the builtins list.

* Highlight macro names in the same manner as function names in definitions.

* ~~Minor, incomplete corrections and improvements to the visual Julia sample.~~

* Inline TODOs to remind onlookers of currently missing functionality for Julia highlighting.

* Add a missing operator.

* Fix highlighting of macro calls.