### PR TITLE
Restore support for highlighting XML-encoded plists

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -101,6 +101,12 @@ module Rouge
 
         Cpp
       end
+
+      disambiguate '*.plist' do
+        next XML if matches?(/\A<\?xml\b/)
+
+        Plist
+      end
     end
   end
 end

--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -7,7 +7,7 @@ module Rouge
       title "XML"
       desc %q(<desc for="this-lexer">XML</desc>)
       tag 'xml'
-      filenames *%w(*.xml *.xsl *.rss *.xslt *.xsd *.wsdl *.svg)
+      filenames *%w(*.xml *.xsl *.rss *.xslt *.xsd *.wsdl *.svg *.plist)
       mimetypes *%w(
         text/xml
         application/xml

--- a/spec/lexers/plist_spec.rb
+++ b/spec/lexers/plist_spec.rb
@@ -8,11 +8,17 @@ describe Rouge::Lexers::Plist do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.pbxproj'
+      assert_guess :filename => 'foo.plist', :source => 'foo'
     end
 
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'text/x-plist'
       assert_guess :mimetype => 'application/x-plist'
+    end
+
+    it 'does not guess XML-encoded plists' do
+      deny_guess :filename => 'foo.plist', :mimetype => 'application/xml'
+      deny_guess :filename => 'foo.plist', :source => '<?xml version="1.0" encoding="UTF-8">'
     end
   end
 end

--- a/spec/lexers/xml_spec.rb
+++ b/spec/lexers/xml_spec.rb
@@ -16,6 +16,8 @@ describe Rouge::Lexers::XML do
       assert_guess :filename => 'foo.xsd'
       assert_guess :filename => 'foo.wsdl'
       assert_guess :filename => 'foo.svg'
+      assert_guess :filename => 'foo.plist', :source => '<?xml version="1.0" encoding="utf-8"?>'
+      deny_guess   :filename => 'foo.plist', :source => 'foo'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
The XML lexer can now read *.plists, and a disambiguation has been added for
*.plist files since now both the Plist and XML lexers can handle them.

The reason this change was made is that the current Plist lexer handles (and
mangles) property lists that are XML-based. Property lists can be encoded as
binary, ASCII, or XML, with most files being XML-encoded.