### PR TITLE
Update for Swift 4.2  

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -20,6 +20,8 @@ module Rouge
         as dynamicType is new super self Self Type __COLUMN__ __FILE__ __FUNCTION__ __LINE__
 
         associativity didSet get infix inout mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup
+
+        #available #colorLiteral #column #else #elseif #endif #error #file #fileLiteral #function #if #imageLiteral #line #selector #sourceLocation #warning
       )
 
       declarations = Set.new %w(

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -165,6 +165,7 @@ module Rouge
         rule /\\[(]/, Str::Escape, :interp
         rule /\\u\{\h{1,8}\}/, Str::Escape
         rule /[^\\"]+/, Str
+        rule /"""/, Str, :pop!
         rule /"/, Str, :pop!
       end
 

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -75,7 +75,7 @@ module Rouge
         rule /'(\\.|.)'/, Str::Char
         rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
-        rule /0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
+        rule /0o?[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -76,7 +76,7 @@ module Rouge
         rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /0o?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p\d+)?/, Num::Hex
+        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p[+-]\d+)?/, Num::Hex
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -76,7 +76,7 @@ module Rouge
         rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /0o?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p[+-]\d+)?/, Num::Hex
+        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p[+-]?\d+)?/, Num::Hex
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -73,7 +73,7 @@ module Rouge
         rule %r([-/=+*%<>!&|^.~]+), Operator
         rule /@?"/, Str, :dq
         rule /'(\\.|.)'/, Str::Char
-        rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
+        rule /(\d+(?:_\d+)*\*|(?:\d+(?:_\d+)*)*\.\d+(?:_\d)*)(e[+-]?\d+(?:_\d)*)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /0o?[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p[+-]?\d+)?/, Num::Hex

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -76,7 +76,7 @@ module Rouge
         rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
         rule /\d+e[+-]?[0-9]+/i, Num::Float
         rule /0o?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
+        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p\d+)?/, Num::Hex
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -61,6 +61,25 @@ let ქართულადაც = "This is Georgian"
 let こんにちは = "...and Japanese"
 let 𓂀 = "and hieroglyphs"
 
+// Integer Literals
+let decimalInteger = 1234567
+let decimalIntegerWithGroupings = 1_234_567
+let hexadecimalInteger = 0xABCDEF
+let octalInteger = 0o0644
+let binaryInteger = 0b1010
+
+// Floating-Point Literals
+let decimalFloatingPoint = 1234567.89
+let decimalFloatingPointWithGroupings = 1_2345_67.89
+let hexadecimalFloatingPoint = 0xA.1p-3
+
+// String Literals
+let string = "Hello, world!"
+let multilineString = """
+All human beings are born free and equal in dignity and rights.
+They are endowed with reason and conscience
+and should act towards one another in a spirit of brotherhood.
+"""
 
 func join(#firstString:String,#secondString:String,joiner:String = " & ") -> String {
     return "\(firstString)\(joiner)\(secondString)"
@@ -314,6 +333,8 @@ enum State: Equatable {
         typealias View = UIView
     #elseif arch(arm64)
         typealias View = UIView64
+    #else
+        #warning("Unknown architecture")
     #endif
 #elseif os(OSX)
     /* Uncomment this when the Mac goes 64bit


### PR DESCRIPTION
This PR improves support for Swift 4.2 with the following changes:

- Add support for keywords beginning with `#` (e.g. `#available`)
- Fix syntax for octal integer literals (e.g. `0o744`)
- Add support for multi-line string literals, which are delimited by three quotation marks (`"""`)