### PR TITLE
Add GDScript language support

### DIFF
--- a/lib/rouge/demos/gdscript
+++ b/lib/rouge/demos/gdscript
@@ -1,0 +1,18 @@
+extends Node
+
+# Variables & Built-in Types
+
+var a = 5
+var b = true
+var s = "Hello"
+var arr = [1, 2, 3]
+
+# Constants & Enums
+
+const ANSWER = 42
+enum { UNIT_NEUTRAL, UNIT_ENEMY, UNIT_ALLY }
+
+# Functions
+
+func _ready():
+    print("Hello, World")

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class GDScript < RegexLexer
+      title "GDScript"
+      desc "The Godot Engine programming language (https://godotengine.org/)"
+      tag 'gdscript'
+      aliases 'gd', 'gdscript'
+      filenames '*.gd'
+      mimetypes 'text/x-gdscript', 'application/x-gdscript'
+
+      affix_long  = '[rR]|[uUbB][rR]|[rR][uUbB]|[@]'
+      affix_short = '[uUbB]?'
+
+      keywords = %w(
+        and in not or as breakpoint class class_name extends is func setget
+        signal tool const enum export onready static var break continue
+        if elif else for pass return match while remote master puppet
+        remotesync mastersync puppetsync
+      ).join('|')
+
+      # Reserved for future implementation
+      keywords_reserved = %w(
+        do switch case
+      ).join('|')
+
+      buildins = %w(
+        Color8 ColorN abs acos asin assert atan atan2 bytes2var ceil char
+        clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst
+        ease exp floor fmod fposmod funcref hash inst2dict instance_from_id
+        is_inf is_nan lerp linear2db load log max min nearest_po2 pow
+        preload print print_stack printerr printraw prints printt rad2deg
+        rand_range rand_seed randf randi randomize range round seed sign
+        sin sinh sqrt stepify str str2var tan tan tanh type_exist typeof
+        var2bytes var2str weakref yield
+      ).join('|')
+
+      builtins_type = %w(
+        bool int float String Vector2 Rect2 Transform2D Vector3 AABB
+        Plane Quat Basis Transform Color RID Object NodePath Dictionary
+        Array PoolByteArray PoolIntArray PoolRealArray PoolStringArray
+        PoolVector2Array PoolVector3Array PoolColorArray null
+      ).join('|')
+
+      state :root do
+        rule %r/\n/, Text
+        rule %r/^(\s*)([rRuUbB]{,2})("""(?:.|\n)*?""")/ do
+          # groups Text, Str::Affix, Str::Doc
+          groups Text, Str::Char, Str::Doc
+        end
+        rule %r/^(\s*)([rRuUbB]{,2})('''(?:.|\n)*?''')/ do
+          # groups Text, Str::Affix, Str::Doc
+          groups Text, Str::Char, Str::Doc
+        end
+        rule %r/[^\S\n]+/, Text
+        rule %r/#.*$/, Comment::Single
+        rule %r/[\[\]{}:(),;]/, Punctuation
+        rule %r/\\\n/, Text
+        rule %r/\\/, Text
+        rule %r/(in|and|or|not)\b/, Operator::Word
+        rule %r/!=|==|<<|>>|&&|\+=|-=|\*=|\/=|%=|&=|\|=|\|\||[-~+\/*%=<>&^.!|$]/, Operator
+        rule %r/(func)((?:\s|\\\s)+)/ do
+          groups Keyword, Text
+          push :funcname
+        end
+        rule %r/(class)((?:\s|\\\s)+)/ do
+          groups Keyword, Text
+          push :classname
+        end
+        mixin :keywords
+        mixin :buildins
+        rule %r/(#{affix_long})(""")/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Double
+          push :tdqs
+        end
+        rule %r/(#{affix_long})(''')/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Single
+          push :tsqs
+        end
+        rule %r/(#{affix_long})(")/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Double
+          push :dqs
+        end
+        rule %r/(#{affix_long})(')/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Single
+          push :sqs
+        end
+        rule %r/(#{affix_short})(""")/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Double
+          push :escape_tdqs
+        end
+        rule %r/(#{affix_short})(''')/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Single
+          push :escape_tsqs
+        end
+        rule %r/(#{affix_short})(")/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Double
+          push :escape_dqs
+        end
+        rule %r/(#{affix_short})(')/ do
+          # groups Str::Affix, Str::Double
+          groups Str::Char, Str::Single
+          push :escape_sqs
+        end
+        mixin :name
+        mixin :numbers
+      end
+
+      state :keywords do
+        rule %r/(#{keywords})\b/, Keyword
+        rule %r/(?<!\.)(#{keywords_reserved})\b/, Keyword::Reserved
+      end
+
+      state :buildins do
+        rule %r/(?<!\.)(#{buildins})\b/, Name::Builtin
+        rule %r/((?<!\.)(self|false|true)|(PI|TAU|NAN|INF))\b/, Name::Builtin::Pseudo
+        rule %r/(?<!\.)(#{builtins_type})\b/, Keyword::Type
+      end
+
+      state :numbers do
+        rule %r/(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?/, Num::Float
+        rule %r/\d+[eE][+-]?[0-9]+j?/, Num::Float
+        rule %r/0[xX][a-fA-F0-9]+/, Num::Hex
+        rule %r/\d+j?/, Num::Integer
+      end
+
+      state :name do
+        rule %r/[a-zA-Z_]\w*/, Name
+      end
+
+      state :funcname do
+        rule %r/[a-zA-Z_]\w*/, Name::Function, :pop!
+      end
+
+      state :classname do
+        rule %r/[a-zA-Z_]\w*/, Name::Class, :pop!
+      end
+
+      state :string_escape do
+        rule %r/\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})/, Str::Escape
+      end
+
+      state :strings_single do
+        rule %r/%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?[hlL]?[E-GXc-giorsux%]/, Str::Interpol
+        rule %r/[^\\\'"%\n]+/, Str::Single
+        rule %r/[\'"\\]/, Str::Single
+        rule %r/%/, Str::Single
+      end
+
+      state :strings_double do
+        rule %r/%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?[hlL]?[E-GXc-giorsux%]/, Str::Interpol
+        rule %r/[^\\\'"%\n]+/, Str::Double
+        rule %r/[\'"\\]/, Str::Double
+        rule %r/%/, Str::Double
+      end
+
+      state :dqs do
+        rule %r/"/, Str::Double, :pop!
+        rule %r/\\\\|\\"|\\\n/, Str::Escape
+        mixin :strings_double
+      end
+
+      state :escape_dqs do
+        mixin :string_escape
+        mixin :dqs
+      end
+
+      state :sqs do
+        rule %r/'/, Str::Single, :pop!
+        rule %r/\\\\|\\'|\\\n/, Str::Escape
+        mixin :strings_single
+      end
+
+      state :escape_sqs do
+        mixin :string_escape
+        mixin :sqs
+      end
+
+      state :tdqs do
+        rule %r/"""/, Str::Double, :pop!
+        mixin :strings_double
+        rule %r/\n/, Str::Double
+      end
+
+      state :escape_tdqs do
+        mixin :string_escape
+        mixin :tdqs
+      end
+
+      state :tsqs do
+        rule %r/'''/, Str::Single, :pop!
+        mixin :strings_single
+        rule %r/\n/, Str::Single
+      end
+
+      state :escape_tsqs do
+        mixin :string_escape
+        mixin :tsqs
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -54,8 +54,9 @@ module Rouge
         rule %r/[^\S\n]+/, Text
         rule %r/#.*/, Comment::Single
         rule %r/[\[\]{}:(),;]/, Punctuation
+        rule %r/\\\n/, Text
         rule %r/(in|and|or|not)\b/, Operator::Word
-        rule %r/!=|==|<<|>>|&&|\+=|-=|\*=|\/=|%=|&=|\|=|\|\||[-~+\/\\*%=<>&^.!|$]/, Operator
+        rule %r/!=|==|<<|>>|&&|\+=|-=|\*=|\/=|%=|&=|\|=|\|\||[-~+\/*%=<>&^.!|$]/, Operator
         rule %r/(func)((?:\s|\\)+)/ do
           groups Keyword, Text
           push :funcname
@@ -66,22 +67,10 @@ module Rouge
         end
         mixin :keywords
         mixin :builtins
-        rule %r/(""")/ do
-          groups Str::Affix, Str::Double
-          push :escape_tdqs
-        end
-        rule %r/(''')/ do
-          groups Str::Affix, Str::Double
-          push :escape_tsqs
-        end
-        rule %r/(")/ do
-          groups Str::Affix, Str::Double
-          push :escape_dqs
-        end
-        rule %r/(')/ do
-          groups Str::Affix, Str::Double
-          push :escape_sqs
-        end
+        rule %r/"""/, Str::Double, :escape_tdqs
+        rule %r/'''/, Str::Double, :escape_tsqs
+        rule %r/"/, Str::Double, :escape_dqs
+        rule %r/'/, Str::Double, :escape_sqs
         mixin :name
         mixin :numbers
       end

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -47,12 +47,10 @@ module Rouge
       state :root do
         rule %r/\n/, Text
         rule %r/^(\s*)([rRuUbB]{,2})("""(?:.|\n)*?""")/ do
-          # groups Text, Str::Affix, Str::Doc
-          groups Text, Str::Char, Str::Doc
+          groups Text, Str::Affix, Str::Doc
         end
         rule %r/^(\s*)([rRuUbB]{,2})('''(?:.|\n)*?''')/ do
-          # groups Text, Str::Affix, Str::Doc
-          groups Text, Str::Char, Str::Doc
+          groups Text, Str::Affix, Str::Doc
         end
         rule %r/[^\S\n]+/, Text
         rule %r/#.*$/, Comment::Single
@@ -72,43 +70,35 @@ module Rouge
         mixin :keywords
         mixin :buildins
         rule %r/(#{affix_long})(""")/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Double
+          groups Str::Affix, Str::Double
           push :tdqs
         end
         rule %r/(#{affix_long})(''')/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Single
+          groups Str::Affix, Str::Double
           push :tsqs
         end
         rule %r/(#{affix_long})(")/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Double
+          groups Str::Affix, Str::Double
           push :dqs
         end
         rule %r/(#{affix_long})(')/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Single
+          groups Str::Affix, Str::Double
           push :sqs
         end
         rule %r/(#{affix_short})(""")/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Double
+          groups Str::Affix, Str::Double
           push :escape_tdqs
         end
         rule %r/(#{affix_short})(''')/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Single
+          groups Str::Affix, Str::Double
           push :escape_tsqs
         end
         rule %r/(#{affix_short})(")/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Double
+          groups Str::Affix, Str::Double
           push :escape_dqs
         end
         rule %r/(#{affix_short})(')/ do
-          # groups Str::Affix, Str::Double
-          groups Str::Char, Str::Single
+          groups Str::Affix, Str::Double
           push :escape_sqs
         end
         mixin :name

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -11,14 +11,6 @@ module Rouge
       filenames '*.gd'
       mimetypes 'text/x-gdscript', 'application/x-gdscript'
 
-      def self.affix_long
-        @affix_long = '[rR]|[uUbB][rR]|[rR][uUbB]|[@]'
-      end
-
-      def self.affix_short
-        @affix_short = '[uUbB]?'
-      end
-
       def self.keywords
         @keywords = %w(
           and in not or as breakpoint class class_name extends is func setget
@@ -59,58 +51,34 @@ module Rouge
 
       state :root do
         rule %r/\n/, Text
-        rule %r/^(\s*)([rRuUbB]{,2})("""(?:.|\n)*?""")/ do
-          groups Text, Str::Affix, Str::Doc
-        end
-        rule %r/^(\s*)([rRuUbB]{,2})('''(?:.|\n)*?''')/ do
-          groups Text, Str::Affix, Str::Doc
-        end
         rule %r/[^\S\n]+/, Text
         rule %r/#.*/, Comment::Single
         rule %r/[\[\]{}:(),;]/, Punctuation
-        rule %r/\\\n/, Text
-        rule %r/\\/, Text
         rule %r/(in|and|or|not)\b/, Operator::Word
-        rule %r/!=|==|<<|>>|&&|\+=|-=|\*=|\/=|%=|&=|\|=|\|\||[-~+\/*%=<>&^.!|$]/, Operator
-        rule %r/(func)((?:\s|\\\s)+)/ do
+        rule %r/!=|==|<<|>>|&&|\+=|-=|\*=|\/=|%=|&=|\|=|\|\||[-~+\/\\*%=<>&^.!|$]/, Operator
+        rule %r/(func)((?:\s|\\)+)/ do
           groups Keyword, Text
           push :funcname
         end
-        rule %r/(class)((?:\s|\\\s)+)/ do
+        rule %r/(class)((?:\s|\\)+)/ do
           groups Keyword, Text
           push :classname
         end
         mixin :keywords
         mixin :builtins
-        rule %r/(#{GDScript.affix_long})(""")/ do
-          groups Str::Affix, Str::Double
-          push :tdqs
-        end
-        rule %r/(#{GDScript.affix_long})(''')/ do
-          groups Str::Affix, Str::Double
-          push :tsqs
-        end
-        rule %r/(#{GDScript.affix_long})(")/ do
-          groups Str::Affix, Str::Double
-          push :dqs
-        end
-        rule %r/(#{GDScript.affix_long})(')/ do
-          groups Str::Affix, Str::Double
-          push :sqs
-        end
-        rule %r/(#{GDScript.affix_short})(""")/ do
+        rule %r/(""")/ do
           groups Str::Affix, Str::Double
           push :escape_tdqs
         end
-        rule %r/(#{GDScript.affix_short})(''')/ do
+        rule %r/(''')/ do
           groups Str::Affix, Str::Double
           push :escape_tsqs
         end
-        rule %r/(#{GDScript.affix_short})(")/ do
+        rule %r/(")/ do
           groups Str::Affix, Str::Double
           push :escape_dqs
         end
-        rule %r/(#{GDScript.affix_short})(')/ do
+        rule %r/(')/ do
           groups Str::Affix, Str::Double
           push :escape_sqs
         end
@@ -119,14 +87,14 @@ module Rouge
       end
 
       state :keywords do
-        rule %r/(#{GDScript.keywords})\b/, Keyword
-        rule %r/(?<!\.)(#{GDScript.keywords_reserved})\b/, Keyword::Reserved
+        rule %r/\b(#{GDScript.keywords})\b/, Keyword
+        rule %r/\b(#{GDScript.keywords_reserved})\b/, Keyword::Reserved
       end
 
       state :builtins do
-        rule %r/(?<!\.)(#{GDScript.builtins})\b/, Name::Builtin
-        rule %r/((?<!\.)(self|false|true)|(PI|TAU|NAN|INF))\b/, Name::Builtin::Pseudo
-        rule %r/(?<!\.)(#{GDScript.builtins_type})\b/, Keyword::Type
+        rule %r/\b(#{GDScript.builtins})\b/, Name::Builtin
+        rule %r/\b((self|false|true)|(PI|TAU|NAN|INF))\b/, Name::Builtin::Pseudo
+        rule %r/\b(#{GDScript.builtins_type})\b/, Keyword::Type
       end
 
       state :numbers do
@@ -154,15 +122,15 @@ module Rouge
 
       state :strings_single do
         rule %r/%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?[hlL]?[E-GXc-giorsux%]/, Str::Interpol
-        rule %r/[^\\\'"%\n]+/, Str::Single
-        rule %r/[\'"\\]/, Str::Single
+        rule %r/[^\\'%\n]+/, Str::Single
+        rule %r/["\\]/, Str::Single
         rule %r/%/, Str::Single
       end
 
       state :strings_double do
         rule %r/%(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?[hlL]?[E-GXc-giorsux%]/, Str::Interpol
-        rule %r/[^\\\'"%\n]+/, Str::Double
-        rule %r/[\'"\\]/, Str::Double
+        rule %r/[^\\"%\n]+/, Str::Double
+        rule %r/['\\]/, Str::Double
         rule %r/%/, Str::Double
       end
 

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -11,38 +11,51 @@ module Rouge
       filenames '*.gd'
       mimetypes 'text/x-gdscript', 'application/x-gdscript'
 
-      affix_long  = '[rR]|[uUbB][rR]|[rR][uUbB]|[@]'
-      affix_short = '[uUbB]?'
+      def self.affix_long
+        @affix_long = '[rR]|[uUbB][rR]|[rR][uUbB]|[@]'
+      end
 
-      keywords = %w(
-        and in not or as breakpoint class class_name extends is func setget
-        signal tool const enum export onready static var break continue
-        if elif else for pass return match while remote master puppet
-        remotesync mastersync puppetsync
-      ).join('|')
+      def self.affix_short
+        @affix_short = '[uUbB]?'
+      end
+
+      def self.keywords
+        @keywords = %w(
+          and in not or as breakpoint class class_name extends is func setget
+          signal tool const enum export onready static var break continue
+          if elif else for pass return match while remote master puppet
+          remotesync mastersync puppetsync
+        ).join('|')
+      end
 
       # Reserved for future implementation
-      keywords_reserved = %w(
-        do switch case
-      ).join('|')
+      def self.keywords_reserved
+        @keywords_reserved = %w(
+          do switch case
+        ).join('|')
+      end
 
-      buildins = %w(
-        Color8 ColorN abs acos asin assert atan atan2 bytes2var ceil char
-        clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst
-        ease exp floor fmod fposmod funcref hash inst2dict instance_from_id
-        is_inf is_nan lerp linear2db load log max min nearest_po2 pow
-        preload print print_stack printerr printraw prints printt rad2deg
-        rand_range rand_seed randf randi randomize range round seed sign
-        sin sinh sqrt stepify str str2var tan tan tanh type_exist typeof
-        var2bytes var2str weakref yield
-      ).join('|')
+      def self.builtins
+        builtins = %w(
+          Color8 ColorN abs acos asin assert atan atan2 bytes2var ceil char
+          clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst
+          ease exp floor fmod fposmod funcref hash inst2dict instance_from_id
+          is_inf is_nan lerp linear2db load log max min nearest_po2 pow
+          preload print print_stack printerr printraw prints printt rad2deg
+          rand_range rand_seed randf randi randomize range round seed sign
+          sin sinh sqrt stepify str str2var tan tan tanh type_exist typeof
+          var2bytes var2str weakref yield
+        ).join('|')
+      end
 
-      builtins_type = %w(
-        bool int float String Vector2 Rect2 Transform2D Vector3 AABB
-        Plane Quat Basis Transform Color RID Object NodePath Dictionary
-        Array PoolByteArray PoolIntArray PoolRealArray PoolStringArray
-        PoolVector2Array PoolVector3Array PoolColorArray null
-      ).join('|')
+      def self.builtins_type
+        @builtins_type = %w(
+          bool int float String Vector2 Rect2 Transform2D Vector3 AABB
+          Plane Quat Basis Transform Color RID Object NodePath Dictionary
+          Array PoolByteArray PoolIntArray PoolRealArray PoolStringArray
+          PoolVector2Array PoolVector3Array PoolColorArray null
+        ).join('|')
+      end
 
       state :root do
         rule %r/\n/, Text
@@ -53,7 +66,7 @@ module Rouge
           groups Text, Str::Affix, Str::Doc
         end
         rule %r/[^\S\n]+/, Text
-        rule %r/#.*$/, Comment::Single
+        rule %r/#.*/, Comment::Single
         rule %r/[\[\]{}:(),;]/, Punctuation
         rule %r/\\\n/, Text
         rule %r/\\/, Text
@@ -68,36 +81,36 @@ module Rouge
           push :classname
         end
         mixin :keywords
-        mixin :buildins
-        rule %r/(#{affix_long})(""")/ do
+        mixin :builtins
+        rule %r/(#{GDScript.affix_long})(""")/ do
           groups Str::Affix, Str::Double
           push :tdqs
         end
-        rule %r/(#{affix_long})(''')/ do
+        rule %r/(#{GDScript.affix_long})(''')/ do
           groups Str::Affix, Str::Double
           push :tsqs
         end
-        rule %r/(#{affix_long})(")/ do
+        rule %r/(#{GDScript.affix_long})(")/ do
           groups Str::Affix, Str::Double
           push :dqs
         end
-        rule %r/(#{affix_long})(')/ do
+        rule %r/(#{GDScript.affix_long})(')/ do
           groups Str::Affix, Str::Double
           push :sqs
         end
-        rule %r/(#{affix_short})(""")/ do
+        rule %r/(#{GDScript.affix_short})(""")/ do
           groups Str::Affix, Str::Double
           push :escape_tdqs
         end
-        rule %r/(#{affix_short})(''')/ do
+        rule %r/(#{GDScript.affix_short})(''')/ do
           groups Str::Affix, Str::Double
           push :escape_tsqs
         end
-        rule %r/(#{affix_short})(")/ do
+        rule %r/(#{GDScript.affix_short})(")/ do
           groups Str::Affix, Str::Double
           push :escape_dqs
         end
-        rule %r/(#{affix_short})(')/ do
+        rule %r/(#{GDScript.affix_short})(')/ do
           groups Str::Affix, Str::Double
           push :escape_sqs
         end
@@ -106,14 +119,14 @@ module Rouge
       end
 
       state :keywords do
-        rule %r/(#{keywords})\b/, Keyword
-        rule %r/(?<!\.)(#{keywords_reserved})\b/, Keyword::Reserved
+        rule %r/(#{GDScript.keywords})\b/, Keyword
+        rule %r/(?<!\.)(#{GDScript.keywords_reserved})\b/, Keyword::Reserved
       end
 
-      state :buildins do
-        rule %r/(?<!\.)(#{buildins})\b/, Name::Builtin
+      state :builtins do
+        rule %r/(?<!\.)(#{GDScript.builtins})\b/, Name::Builtin
         rule %r/((?<!\.)(self|false|true)|(PI|TAU|NAN|INF))\b/, Name::Builtin::Pseudo
-        rule %r/(?<!\.)(#{builtins_type})\b/, Keyword::Type
+        rule %r/(?<!\.)(#{GDScript.builtins_type})\b/, Keyword::Type
       end
 
       state :numbers do

--- a/spec/lexers/gdscript_spec.rb
+++ b/spec/lexers/gdscript_spec.rb
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::GDScript do
+  let(:subject) { Rouge::Lexers::GDScript.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.gd'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-gdscript'
+      assert_guess :mimetype => 'application/x-gdscript'
+    end
+  end
+end

--- a/spec/visual/samples/gdscript
+++ b/spec/visual/samples/gdscript
@@ -1,0 +1,28 @@
+""" Everything on these lines is considered
+a comment. """
+
+tool
+extends BaseClass
+
+# Variables & Built-in Types
+
+var a = 5
+var b = true
+var s = "Hello"
+var arr = [1, 2, 3]
+var dict = {"key": "value", 2: 3}
+var v = Vector2(1, 2)
+
+# Constants & Enums
+
+const ANSWER = 42
+enum { UNIT_NEUTRAL, UNIT_ENEMY, UNIT_ALLY }
+
+# Functions
+
+signal some_signal
+
+func some_function(param1, param2):
+    var local_var = 5
+    print(param1, param2, local_var)
+    return local_var

--- a/spec/visual/samples/gdscript
+++ b/spec/visual/samples/gdscript
@@ -3,15 +3,21 @@ a comment. """
 
 tool
 extends BaseClass
+class_name ScriptName, "res://path/to/optional/icon.svg"
 
 # Variables & Built-in Types
 
-var a = 5
+var i = 5
+var f = 1.23
+var h = 0xDEADC0DE
 var b = true
 var s = "Hello"
 var arr = [1, 2, 3]
 var dict = {"key": "value", 2: 3}
 var v = Vector2(1, 2)
+var t = "Hello, " \
+        + "very long " \
+        + "text"
 
 # Constants & Enums
 
@@ -22,7 +28,17 @@ enum { UNIT_NEUTRAL, UNIT_ENEMY, UNIT_ALLY }
 
 signal some_signal
 
-func some_function(param1, param2):
+func some_function(param1: int, param2: float) -> int:
     var local_var = 5
+    var format_string_1 = "We're waiting for %s." % "Godot"
+    var format_string_2 = "We're waiting for {str}"
+    var actual_string = format_string_2.format({"str": "Godot"})
     print(param1, param2, local_var)
     return local_var
+
+# Inner Classes
+class InnerClass extends BaseClass:
+    var local_var
+
+    func _init():
+        print(local_var)


### PR DESCRIPTION
Added support for [Godot GDScript][gdscript] language. Mostly copied from [Pygments][pygments-gdscript] and [Chroma][chroma-gdscript] versions.

Resolves #1016 and [gitlab-org/gitlab-ce#19663][gitlab-issue].

~I've also pushed PR #1034 because Str::Affix is missing in rouge, but it is used in original lexers (I've used Str::Char as replacement).~
**Update:** replaced `Str::Char` with `Str::Affix`.

[gdscript]: http://docs.godotengine.org/en/3.0/getting_started/scripting/gdscript/gdscript_basics.html
[pygments-gdscript]: https://github.com/godotengine/godot-docs/blob/master/extensions/gdscript.py
[chroma-gdscript]: https://github.com/alecthomas/chroma/blob/master/lexers/g/gdscript.go
[gitlab-issue]: https://gitlab.com/gitlab-org/gitlab-ce/issues/19663