### PR TITLE
Update Scala lexer to output more differentiated token types.

### DIFF
--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -47,12 +47,38 @@ module Rouge
         rule %r(/\*), Comment::Multiline, :comment
 
         rule /@#{idrest}/, Name::Decorator
+
+        rule /(def)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+          groups Keyword, Text, Name::Function, Text
+        end
+
+        rule /(val)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+          groups Keyword, Text, Name::Variable, Text
+        end
+
+        rule /(this)(\n*)(\.)(#{idrest})/ do
+          groups Keyword, Text, Operator, Name::Property
+        end
+
+        rule /(#{idrest}|_)(\n*)(\.)(#{idrest})/ do
+          groups Name::Variable, Text, Operator, Name::Property
+        end
+
+        rule /#{upper}#{idrest}\b/, Name::Class
+
+        rule /(#{idrest})(#{whitespace}*)(\()/ do
+          groups Name::Function, Text, Operator
+        end
+
+        rule /(\.)(#{idrest})/ do
+          groups Operator, Name::Property
+        end
+
         rule %r(
           (#{keywords.join("|")})\b|
           (<[%:-]|=>|>:|[#=@_\u21D2\u2190])(\b|(?=\s)|$)
         )x, Keyword
-        rule /:(?!#{op})/, Keyword, :type
-        rule /#{upper}#{idrest}\b/, Name::Class
+        rule /:(?!#{op})/, Keyword, :type        
         rule /(true|false|null)\b/, Keyword::Constant
         rule /(import|package)(\s+)/ do
           groups Keyword, Text

--- a/spec/visual/samples/scala
+++ b/spec/visual/samples/scala
@@ -30,6 +30,14 @@ String
   val constant = true
 
   import more.stuff._
+
+  def methodChaining(s: String): String = {
+    val n = s.length.toInt
+    s.foreach(print)
+    s
+      .take(n)
+      .toLowerCase
+  }
 }
 
 abstract case class Foo[+A, B <: List[A]](a: A) {


### PR DESCRIPTION
### Motivation
I decided to write this lexer addition because I felt the tokens being output by the current Scala lexer implementation were too general, usually a `Name` token. This PR makes the lexer output some more specific token types. This allows the stylesheet to define more specific colors for different tokens while also leaving it open to having these new token types be styled the same way as before.

### New Token Types
- `Name::Function` for def names
- `Name::Variable` for val names
- `Name::Property` for anything used after a `.` e.g. method calls, class fields. I chose `Name::Property` because calling `val`s or `def`s on an instance are more or less interchangeable
- `Name::Function` for def/function calls

### Before:
![chrome_2018-11-25_20-01-30](https://user-images.githubusercontent.com/5376488/48987475-49bf7680-f0ed-11e8-8a72-1c154017f535.png)
![chrome_2018-11-25_20-02-18](https://user-images.githubusercontent.com/5376488/48987480-4deb9400-f0ed-11e8-8629-97f945b1c541.png)

### After:
![chrome_2018-11-25_19-59-37](https://user-images.githubusercontent.com/5376488/48987477-4b893a00-f0ed-11e8-8f64-8fe599422a7c.png)
![chrome_2018-11-25_20-03-25](https://user-images.githubusercontent.com/5376488/48987481-4f1cc100-f0ed-11e8-9802-c32e25ae005d.png)