### PR TITLE
Support for (Smallworld) Magik language

### DIFF
--- a/lib/rouge/demos/magik
+++ b/lib/rouge/demos/magik
@@ -1,0 +1,58 @@
+def_slotted_exemplar(
+	:test_object,
+	{
+		{:slot, _unset}
+	})
+$
+
+_method test_object.new()
+	_return _clone.init()
+_endmethod
+$
+
+_method test_object.init()
+	## initializer
+	_return _self
+_endmethod
+$
+
+_method test_object.run(arg_1, _gather args)
+	## Does something.
+	write("calling test_object.run()")
+	write(%tab, %newline)
+	show(:args, _scatter args)
+
+	_local x <<
+		_if arg_1 _is :start
+		_then
+			>> 10.0
+		_endif
+	_local results << rope.new()
+
+	_for arg _over rgs.fast_elements()
+	_loop
+		results.add_last(arg)
+	_endloop
+	
+	_local stream << external_text_output_stream.new("$HOME/test.txt")
+	_protect
+		local y << p_args.map(_proc(p_obj)
+			>> p_obj + 1
+		_endproc
+	_protection
+		stream.close()
+	_endprotect
+
+	_return results
+_endmethod
+$
+
+_block
+	_local obj << test_object.new()
+	_try _with cond
+		_local results << obj.run()
+	_when error
+		write("Caught error: ", cond.report_string)
+	_endtry
+endblock
+$

--- a/lib/rouge/demos/magik
+++ b/lib/rouge/demos/magik
@@ -1,58 +1,6 @@
-def_slotted_exemplar(
-	:test_object,
-	{
-		{:slot, _unset}
-	})
-$
-
-_method test_object.new()
-	_return _clone.init()
-_endmethod
-$
-
-_method test_object.init()
+_private _method test_object.init()
 	## initializer
+	.slot1 << _self.default_value
 	_return _self
 _endmethod
-$
-
-_method test_object.run(arg_1, _gather args)
-	## Does something.
-	write("calling test_object.run()")
-	write(%tab, %newline)
-	show(:args, _scatter args)
-
-	_local x <<
-		_if arg_1 _is :start
-		_then
-			>> 10.0
-		_endif
-	_local results << rope.new()
-
-	_for arg _over rgs.fast_elements()
-	_loop
-		results.add_last(arg)
-	_endloop
-	
-	_local stream << external_text_output_stream.new("$HOME/test.txt")
-	_protect
-		local y << p_args.map(_proc(p_obj)
-			>> p_obj + 1
-		_endproc
-	_protection
-		stream.close()
-	_endprotect
-
-	_return results
-_endmethod
-$
-
-_block
-	_local obj << test_object.new()
-	_try _with cond
-		_local results << obj.run()
-	_when error
-		write("Caught error: ", cond.report_string)
-	_endtry
-endblock
 $

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -47,10 +47,10 @@ module Rouge
 
       character = /%u[0-9a-z]{4}|%[^\s]+/i
 
-      simple_identifier = /(?:[a-z!]|\\.)(?:[a-z0-9_!?]|\\.)*/i
+      simple_identifier = /(?>(?:[a-z0-9_!?]|\\.)+)/i
       piped_identifier = /\|[^\|\n]*\|/
       identifier = /(?:#{simple_identifier}|#{piped_identifier})+/i
-
+      package_identifier = /#{identifier}:#{identifier}/
       symbol = /:#{identifier}/i
       global_ref = /@[\s]*#{identifier}:#{identifier}/
       label = /@[\s]*#{identifier}/
@@ -73,15 +73,14 @@ module Rouge
         rule label, Name::Label
         rule character, Literal::String::Char
         rule number, Literal::Number
+        rule package_identifier, Name
+        rule identifier, Name
 
         rule /[\[\]{}()\.,;]/, Punctuation
         rule /\$/, Punctuation
         rule /(<<|^<<)/, Operator
         rule /(>>)/, Operator
         rule /[-~+\/*%=&^<>]|!=/, Operator
-
-        rule /#{identifier}:#{identifier}/, Name
-        rule identifier, Name
 
         rule /[\s]+/, Text::Whitespace
       end

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Magik < RegexLexer
+      title "Magik"
+      desc "Smallworld Magik"
+      tag 'magik'
+      aliases 'magik'
+      filenames '*.magik'
+      mimetypes 'text/x-magik', 'application/x-magik'
+
+      keywords = %w(
+           _package
+           _pragma
+           _block _endblock
+           _handling _default
+           _protect _protection _endprotect
+           _try _with _when _endtry
+           _catch _endcatch
+           _throw
+           _lock _endlock
+           _if _then _elif _else _endif
+           _for _over _loop _endloop _loopbody _continue _leave
+           _return
+           _local _constant _recursive _global _dynamic _import
+           _private _iter _abstract _method _endmethod
+           _proc _endproc
+           _gather _scatter _allresults _optional
+           _thisthread _self _clone _super
+           _primitive
+           _unset _true _false _maybe
+           _is _isnt _not _and _or _xor _cf _andif _orif
+           _div _mod
+        )
+
+      string_double = /"[^"\n]*"/
+      string_single = /'[^'\n]*'/
+
+      digits = /[0-9]+/
+      hex_digits = /[0-9a-f]+/i
+      radix = /r#{hex_digits}/i
+      exponent = /(e|&)[+-]?#{digits}/i
+      decimal = /\.#{digits}/
+      number = /#{digits}(#{radix}|#{exponent}|#{decimal})*/
+
+      character = /%u[0-9a-z]{4}|%[^\s]+/i
+
+      simple_identifier = /(?:[a-z!]|\\.)(?:[a-z0-9_!?]|\\.)*/i
+      piped_identifier = /\|[^\|\n]*\|/
+      identifier = /(?:#{simple_identifier}|#{piped_identifier})+/i
+
+      symbol = /:#{identifier}/i
+      global_ref = /@[\s]*#{identifier}:#{identifier}/
+      label = /@[\s]*#{identifier}/
+
+      state :root do
+        rule /##(.*)?\n?/, Comment::Doc
+        rule /#(.*)?\n?/, Comment::Single
+
+        rule /(_method)(\s+)/ do
+          groups Keyword, Text::Whitespace
+          push :method_name
+        end
+
+        rule /(?:#{keywords.join('|')})\b/, Keyword
+
+        rule string_double, Literal::String
+        rule string_single, Literal::String
+        rule symbol, Str::Symbol
+        rule global_ref, Name::Label
+        rule label, Name::Label
+        rule character, Literal::String::Char
+        rule number, Literal::Number
+
+        rule /[\[\]{}()\.,;]/, Punctuation
+        rule /\$/, Punctuation
+        rule /(<<|^<<)/, Operator
+        rule /(>>)/, Operator
+        rule /[-~+\/*%=&^<>]|!=/, Operator
+
+        rule /#{identifier}:#{identifier}/, Name
+        rule identifier, Name
+
+        rule /[\s]+/, Text::Whitespace
+      end
+
+      state :method_name do
+        rule /(#{identifier})(\.)(#{identifier})/ do
+          groups Name::Class, Punctuation, Name::Function
+          pop!
+        end
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -86,8 +86,8 @@ module Rouge
       end
 
       state :root do
-        rule /##(.*)?\n?/, Comment::Doc
-        rule /#(.*)?\n?/, Comment::Single
+        rule /##(.*)?/, Comment::Doc
+        rule /#(.*)?/, Comment::Single
 
         rule /(_method)(\s+)/ do
           groups Keyword, Text::Whitespace

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -7,7 +7,6 @@ module Rouge
       title "Magik"
       desc "Smallworld Magik"
       tag 'magik'
-      aliases 'magik'
       filenames '*.magik'
       mimetypes 'text/x-magik', 'application/x-magik'
 

--- a/spec/lexers/magik_spec.rb
+++ b/spec/lexers/magik_spec.rb
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Magik do
+  let(:subject) { Rouge::Lexers::Magik.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.magik'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-magik'
+      assert_guess :mimetype => 'application/x-magik'
+    end
+  end
+end

--- a/spec/visual/samples/magik
+++ b/spec/visual/samples/magik
@@ -1,4 +1,4 @@
-let_automatic_engine_start_testrunner_for
+let_automatic_engine_start_unittests_for
 abc| ab de |deffffffffffffffffffffffffffff
 aaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbb
 @abcdefffffffffffffffffffffffffffffff

--- a/spec/visual/samples/magik
+++ b/spec/visual/samples/magik
@@ -1,0 +1,69 @@
+let_automatic_engine_start_testrunner_for
+abc| ab de |deffffffffffffffffffffffffffff
+aaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbb
+@abcdefffffffffffffffffffffffffffffff
+@abc:deffffffffffffffffffffffffff
+
+def_slotted_exemplar(
+        :test_object,
+        {
+                {:slot, _unset}
+        })
+$
+
+_pragma(classify_level=basic, topic={test_topic, rouge})
+_method test_object.method_name(arg_1, _gather args)
+        _local x << _self.test() + 15
+        _if arg_1 _is :test_symbol _orif
+            arg_1 <> "abc" _orif
+            arg_1 = "def"
+        _then
+                .slot << x
+        _else
+                .slot << write_string("string" + 'string', "test")
+        _endif
+
+        _local l_y << _true
+        l_y _and<< _true
+
+        # numbers
+        45, 0, -101
+        2r101, -8r123
+        16rA0, 16rFF
+        2e5, 6&6, 6rA0&2, 6rA0&2e4
+        0.5, 45.0, 16rA0.8
+        23.007e5, 0.4E-5, 16rA0.8&2
+
+        # characters
+        %q, %Z, %u
+        %u000A
+        %newline, %space, %tab
+
+        # identifiers
+        identifier, identifier_abc, identifier_0123, |IDENTIFIER|, identifier:identifier
+
+        # symbols
+        :symbol, :symbol_symbol, :|symbol()|, :|Symbol|, :|Symbol^<<__|, :\|test
+
+        # labels
+        @label
+        @ label
+
+        _proc@test(p_args)
+        _endproc
+
+        _proc@ test(p_args)
+        _endproc
+
+        # global references
+        @namespace:identifier
+        @123
+
+        >> l_x
+_endmethod
+$
+
+_block
+        _thisthread.traceback()
+_endblock
+$


### PR DESCRIPTION
This adds support for the [(Smallworld) Magik](https://en.wikipedia.org/wiki/Magik_(programming_language)) language. It is a language specific to a GIS (Geo) software package.

Please do not merge yet, the regexp for `identifier` is not behaving yet. I.e., on longer identifiers it seems to be exploding with regard to time it needs to match.