### PR TITLE
Kotlin suspend keyword

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -19,9 +19,9 @@ module Rouge
         external false final finally for fun get if import in infix
         inline inner interface internal is lateinit noinline null
         object open operator out override package private protected
-        public reified return sealed set super tailrec this throw
-        true try typealias typeof val var vararg when where while
-        yield
+        public reified return sealed set super suspend tailrec this
+        throw true try typealias typeof val var vararg when where
+        while yield
       )
 
       name = %r'@?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}][\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'


### PR DESCRIPTION
Since Kotlin coroutines are no longer experimental, `suspend` should be a highlighted keyword.

It seems GitHub has it:
```kotlin
private suspend fun foo() = 42
```

Disclaimer: I don't know Ruby, I didn't tested it, I just want to have proper syntax highligting in GitLab, which uses this syntax highlighting library. So feel free to fix it, or tell me how to implement it properly.