### PR TITLE
Add a lexer for ARM assembly files

### DIFF
--- a/lib/rouge/demos/armasm
+++ b/lib/rouge/demos/armasm
@@ -1,0 +1,12 @@
+            GET     common.s
+
+RetVal      *       0x123 :SHL: 4
+
+            AREA    |Area$$Name|, CODE, READONLY
+
+MyFunction  ROUT             ; This is a comment
+            ASSERT  RetVal <> 0
+1           MOVW    r0, #RetVal
+            BX      lr
+
+            END

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -38,8 +38,9 @@ module Rouge
         rule /(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
         rule /(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
         rule /(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
+        rule /[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
         rule /[.@]|\{(ARCHITECTURE|AREANAME|ARMASM_VERSION|CODESIZE|COMMANDLINE|CONFIG|CPU|ENDIAN|FALSE|FPIC|FPU|INPUTFILE|INTER|LINENUM(UP(PER)?)?|OBJASM_VERSION|OPT|PC|PCSTOREOFFSET|REENTRANT|ROPI|RWPI|TRUE|VAR)\}/, Name::Constant
-        rule /([-!#%&()*+,\/:<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(AND|BASE|CC|CC_ENCODING|CHR|DEF|EOR|FATTR|FEXEC|FLOAD|FSIZE|INDEX|LAND|LEFT|LEN|LEOR|LNOT|LOR|LOWERCASE|MOD|NOT|OR|RCONST|REVERSE_CC|RIGHT|ROL|ROR|SHL|SHR|STR|TARGET_ARCH_[A-Z_]+|TARGET_FEATURE_[A-Z_]+|TARGET_FPU_[A-Z_]+|TARGET_PROFILE_[ARM]|UAL|UPPERCASE):)/, Operator
+        rule /([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(AND|BASE|CC|CC_ENCODING|CHR|DEF|EOR|FATTR|FEXEC|FLOAD|FSIZE|INDEX|LAND|LEFT|LEN|LEOR|LNOT|LOR|LOWERCASE|MOD|NOT|OR|RCONST|REVERSE_CC|RIGHT|ROL|ROR|SHL|SHR|STR|TARGET_ARCH_[A-Z_]+|TARGET_FEATURE_[A-Z_]+|TARGET_FPU_[A-Z_]+|TARGET_PROFILE_[ARM]|UAL|UPPERCASE):)/, Operator
         rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
         rule /'/, Literal::String::Char, :singlequoted
         rule /"/, Literal::String::Double, :doublequoted

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class ArmAsm < RegexLexer
+      title "ArmAsm"
+      desc "Arm assembly syntax"
+      tag 'armasm'
+      filenames '*.s'
+
+      state :root do
+        rule /\n/, Text
+        rule /[ \t]+/, Text, :command
+        rule /;.*\n/, Comment
+        rule /\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace # variable substitution or macro argument
+        rule /([0-9A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Label
+        end
+
+      state :command do
+        rule /\n/, Text, :root
+        rule /[ \t]+/, Text, :args
+        rule /;.*\n/, Comment, :root
+        rule /(ALIAS|ALIGN|AOF|AOUT|AREA|ARM|ASSERT|ATTR|BIN|CN|CODE16|CODE32|COMMON|CP|DATA|DCB|DCD|DCDO|DCDU|DCFD|DCFDU|DCFH|DCFHU|DCFS|DCFSU|DCI(\.[NW])?|DCQ|DCQU|DCW|DCWU|DN|ELIF|ELSE|END|ENDFUNC|ENDIF|ENDP|ENTRY|EQU|EXPORT|EXPORTAS|EXTERN|FIELD|FILL|FN|FRAME|FUNCTION|GBL[ALS]|GET|GLOBAL|IF|IMPORT|INCBIN|INCLUDE|INFO|KEEP|LCL[ALS]|LEADR|LEAF|LNK|LTORG|MACRO|MAP|MEND|MEXIT|NOFP|OPT|ORG|PRESERVE8|PROC|QN|RELOC|REQUIRE8?|RLIST|RN|ROUT|SET[ALS]|SN|SPACE|STRONG|SUBT|THUMBX?|TTL|WEND|WHILE|\[|\]|[|!#*=%&^])(?=[; \t\n])/, Keyword
+        rule /([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^0-9A-Za-z_])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule /([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Function # probably a macro name
+        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+      end
+
+      state :args do
+        rule /\n/, Text, :root
+        rule /[ \t]+/, Text
+        rule /;.*\n/, Comment, :root
+        rule /([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
+        rule /%[BFbf]?[ATat]?[0-9]+([A-Za-z_][0-9A-Za-z_]*)?/, Name::Label
+        rule /(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
+        rule /(&|0[Xx])[.0-9A-Fa-f]+([Pp][-+]?[0-9]+)?/, Literal::Number::Float
+        rule /(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
+        rule /(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
+        rule /(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
+        rule /[.@]|\{(ARCHITECTURE|AREANAME|ARMASM_VERSION|CODESIZE|COMMANDLINE|CONFIG|CPU|ENDIAN|FALSE|FPIC|FPU|INPUTFILE|INTER|LINENUM(UP(PER)?)?|OBJASM_VERSION|OPT|PC|PCSTOREOFFSET|REENTRANT|ROPI|RWPI|TRUE|VAR)\}/, Name::Constant
+        rule /([-!#%&()*+,\/:<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(AND|BASE|CC|CC_ENCODING|CHR|DEF|EOR|FATTR|FEXEC|FLOAD|FSIZE|INDEX|LAND|LEFT|LEN|LEOR|LNOT|LOR|LOWERCASE|MOD|NOT|OR|RCONST|REVERSE_CC|RIGHT|ROL|ROR|SHL|SHR|STR|TARGET_ARCH_[A-Z_]+|TARGET_FEATURE_[A-Z_]+|TARGET_FPU_[A-Z_]+|TARGET_PROFILE_[ARM]|UAL|UPPERCASE):)/, Operator
+        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule /'/, Literal::String::Char, :singlequoted
+        rule /"/, Literal::String::Double, :doublequoted
+      end
+
+      state :singlequoted do
+        rule /\n/, Text, :root
+        rule /\$\$/, Literal::String::Char
+        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule /'/, Literal::String::Char, :args
+        rule /[^$'\n]+/, Literal::String::Char
+      end
+
+      state :doublequoted do
+        rule /\n/, Text, :root
+        rule /\$\$/, Literal::String::Double
+        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule /"/, Literal::String::Double, :args
+        rule /[^$"\n]+/, Literal::String::Double
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -35,10 +35,6 @@ module Rouge
         rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
       end
 
-      state :filespec do
-        rule /.*\n/, Literal::String::Other, :root
-      end
-
       state :args do
         rule /\n/, Text, :root
         rule /[ \t]+/, Text
@@ -73,6 +69,13 @@ module Rouge
         rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
         rule /"/, Literal::String::Double, :args
         rule /[^$"\n]+/, Literal::String::Double
+      end
+
+      state :filespec do
+        rule /\n/, Text, :root
+        rule /\$\$/, Literal::String::Other
+        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule /[^$\n]+/, Literal::String::Other
       end
     end
   end

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -91,11 +91,11 @@ module Rouge
         rule %r/(?:#{ArmAsm.shift_or_condition.join('|')})\b/, Name::Builtin
         rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Variable # various types of symbol
         rule %r/%[bf]?[at]?\d+(?:[a-z_]\w*)?/i, Name::Label
-        rule %r/(?:&|0[x])\h+(?![\hp])/i, Literal::Number::Hex
-        rule %r/(?:&|0[x])[.\h]+(?:[p][-+]?\d+)?/i, Literal::Number::Float
-        rule %r/0[f]_\h{8}|0[d]_\h{16}/i, Literal::Number::Float
+        rule %r/(?:&|0x)\h+(?![\hp])/i, Literal::Number::Hex
+        rule %r/(?:&|0x)[.\h]+(?:p[-+]?\d+)?/i, Literal::Number::Float
+        rule %r/0f_\h{8}|0d_\h{16}/i, Literal::Number::Float
         rule %r/(?:2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\de])/i, Literal::Number::Integer
-        rule %r/(?:2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)(?:[e][-+]?\d+)?/i, Literal::Number::Float
+        rule %r/(?:2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)(?:e[-+]?\d+)?/i, Literal::Number::Float
         rule %r/[@:](?=[ \t]*(?:8|16|32|64|128|256)[^\d])/, Operator
         rule %r/[.@]|\{(?:#{ArmAsm.builtin.join('|')})\}/, Name::Constant
         rule %r/[-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(?:#{ArmAsm.operator.join('|')}):/, Operator

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -63,7 +63,7 @@ module Rouge
         rule %r/^[ \t]*#[ \t]*((#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*\n/, Comment
-        rule %r/\$[A-Za-z_]\w*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
+        rule %r/\$[a-z_]\w*\.?/i, Name::Namespace, :afterlabel # variable substitution or macro argument
         rule %r/(\w+|\|[^|\n]+\|)/, Name::Label, :afterlabel
       end
 
@@ -89,8 +89,8 @@ module Rouge
         end
         rule %r/(#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
         rule %r/([A-Z][\dA-Z]*|[a-z][\da-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
-        rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Function # probably a macro name
-        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
+        rule %r/([a-z_]\w*|\|[^|\n]+\|)/i, Name::Function # probably a macro name
+        rule %r/\$[a-z]\w*\.?/i, Name::Namespace
       end
 
       state :args do
@@ -98,17 +98,17 @@ module Rouge
         rule %r/[ \t]+/, Text
         rule %r/;.*\n/, Comment, :pop!
         rule %r/(?<!\w)(#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
-        rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
-        rule %r/%[BFbf]?[ATat]?\d+([A-Za-z_]\w*)?/, Name::Label
-        rule %r/(&|0[Xx])\h+(?![\hPp])/, Literal::Number::Hex
-        rule %r/(&|0[Xx])[.\h]+([Pp][-+]?\d+)?/, Literal::Number::Float
-        rule %r/(0[Ff]_\h{8}|0[Dd]_\h{16})/, Literal::Number::Float
-        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\dEe])/, Literal::Number::Integer
-        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)([Ee][-+]?\d+)?/, Literal::Number::Float
+        rule %r/([a-z_]\w*|\|[^|\n]+\|)/i, Name::Variable # various types of symbol
+        rule %r/%[bf]?[at]?\d+([a-z_]\w*)?/i, Name::Label
+        rule %r/(&|0[x])\h+(?![\hp])/i, Literal::Number::Hex
+        rule %r/(&|0[x])[.\h]+([p][-+]?\d+)?/i, Literal::Number::Float
+        rule %r/(0[f]_\h{8}|0[d]_\h{16})/i, Literal::Number::Float
+        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\de])/i, Literal::Number::Integer
+        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)([e][-+]?\d+)?/i, Literal::Number::Float
         rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^\d])/, Operator
         rule %r/[.@]|\{(#{ArmAsm.builtin.join('|')})\}/, Name::Constant
         rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{ArmAsm.operator.join('|')}):)/, Operator
-        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
+        rule %r/\$[a-z]\w*\.?/i, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char
           goto :singlequoted
@@ -122,7 +122,7 @@ module Rouge
       state :singlequoted do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Char
-        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
+        rule %r/\$[a-z]\w*\.?/i, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char
           goto :args
@@ -133,7 +133,7 @@ module Rouge
       state :doublequoted do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Double
-        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
+        rule %r/\$[a-z]\w*\.?/i, Name::Namespace
         rule %r/"/ do |m|
           token Literal::String::Double
           goto :args
@@ -144,7 +144,7 @@ module Rouge
       state :filespec do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Other
-        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
+        rule %r/\$[a-z]\w*\.?/i, Name::Namespace
         rule %r/[^$\n]+/, Literal::String::Other
       end
     end

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -62,7 +62,7 @@ module Rouge
         rule %r/\n/, Text
         rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
-        rule %r/;.*\n/, Comment
+        rule %r/;.*/, Comment
         rule %r/\$[a-z_]\w*\.?/i, Name::Namespace # variable substitution or macro argument
         rule %r/\w+|\|[^|\n]+\|/, Name::Label
       end
@@ -73,7 +73,7 @@ module Rouge
           token Text
           goto :args
         end
-        rule %r/;.*\n/, Comment, :pop!
+        rule %r/;.*/, Comment, :pop!
         rule %r/(?:#{ArmAsm.file_directive.join('|')})\b/ do |m|
           token Keyword
           goto :filespec
@@ -87,7 +87,7 @@ module Rouge
       state :args do
         rule %r/\n/, Text, :pop!
         rule %r/[ \t]+/, Text
-        rule %r/;.*\n/, Comment, :pop!
+        rule %r/;.*/, Comment, :pop!
         rule %r/(?:#{ArmAsm.shift_or_condition.join('|')})\b/, Name::Builtin
         rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Variable # various types of symbol
         rule %r/%[bf]?[at]?\d+(?:[a-z_]\w*)?/i, Name::Label

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -60,11 +60,11 @@ module Rouge
 
       state :root do
         rule %r/\n/, Text
-        rule %r/^[ \t]*#[ \t]*((#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
+        rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*\n/, Comment
         rule %r/\$[a-z_]\w*\.?/i, Name::Namespace, :afterlabel # variable substitution or macro argument
-        rule %r/(\w+|\|[^|\n]+\|)/, Name::Label, :afterlabel
+        rule %r/\w+|\|[^|\n]+\|/, Name::Label, :afterlabel
       end
 
       state :afterlabel do
@@ -83,13 +83,13 @@ module Rouge
           goto :args
         end
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(#{ArmAsm.file_directive.join('|')})(?=[ \t])/ do |m|
+        rule %r/(?:#{ArmAsm.file_directive.join('|')})(?=[ \t])/ do |m|
           token Keyword
           goto :filespec
         end
-        rule %r/(#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
-        rule %r/([A-Z][\dA-Z]*|[a-z][\da-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
-        rule %r/([a-z_]\w*|\|[^|\n]+\|)/i, Name::Function # probably a macro name
+        rule %r/(?:#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
+        rule %r/(?:[A-Z][\dA-Z]*|[a-z][\da-z]*)(?:\.[NWnw])?(?:\.[DFIPSUdfipsu]?(?:8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Function # probably a macro name
         rule %r/\$[a-z]\w*\.?/i, Name::Namespace
       end
 
@@ -97,17 +97,17 @@ module Rouge
         rule %r/\n/, Text, :pop!
         rule %r/[ \t]+/, Text
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(?<!\w)(#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
-        rule %r/([a-z_]\w*|\|[^|\n]+\|)/i, Name::Variable # various types of symbol
-        rule %r/%[bf]?[at]?\d+([a-z_]\w*)?/i, Name::Label
-        rule %r/(&|0[x])\h+(?![\hp])/i, Literal::Number::Hex
-        rule %r/(&|0[x])[.\h]+([p][-+]?\d+)?/i, Literal::Number::Float
-        rule %r/(0[f]_\h{8}|0[d]_\h{16})/i, Literal::Number::Float
-        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\de])/i, Literal::Number::Integer
-        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)([e][-+]?\d+)?/i, Literal::Number::Float
-        rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^\d])/, Operator
-        rule %r/[.@]|\{(#{ArmAsm.builtin.join('|')})\}/, Name::Constant
-        rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{ArmAsm.operator.join('|')}):)/, Operator
+        rule %r/(?<!\w)(?:#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
+        rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Variable # various types of symbol
+        rule %r/%[bf]?[at]?\d+(?:[a-z_]\w*)?/i, Name::Label
+        rule %r/(?:&|0[x])\h+(?![\hp])/i, Literal::Number::Hex
+        rule %r/(?:&|0[x])[.\h]+(?:[p][-+]?\d+)?/i, Literal::Number::Float
+        rule %r/0[f]_\h{8}|0[d]_\h{16}/i, Literal::Number::Float
+        rule %r/(?:2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\de])/i, Literal::Number::Integer
+        rule %r/(?:2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)(?:[e][-+]?\d+)?/i, Literal::Number::Float
+        rule %r/[@:](?=[ \t]*(?:8|16|32|64|128|256)[^\d])/, Operator
+        rule %r/[.@]|\{(?:#{ArmAsm.builtin.join('|')})\}/, Name::Constant
+        rule %r/[-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(?:#{ArmAsm.operator.join('|')}):/, Operator
         rule %r/\$[a-z]\w*\.?/i, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -91,10 +91,10 @@ module Rouge
         rule %r/(?:#{ArmAsm.shift_or_condition.join('|')})\b/, Name::Builtin
         rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Variable # various types of symbol
         rule %r/%[bf]?[at]?\d+(?:[a-z_]\w*)?/i, Name::Label
-        rule %r/(?:&|0x)\h+(?![\hp])/i, Literal::Number::Hex
+        rule %r/(?:&|0x)\h+(?!p)/i, Literal::Number::Hex
         rule %r/(?:&|0x)[.\h]+(?:p[-+]?\d+)?/i, Literal::Number::Float
         rule %r/0f_\h{8}|0d_\h{16}/i, Literal::Number::Float
-        rule %r/(?:2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\de])/i, Literal::Number::Integer
+        rule %r/(?:2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?!e)/i, Literal::Number::Integer
         rule %r/(?:2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)(?:e[-+]?\d+)?/i, Literal::Number::Float
         rule %r/[@:](?=[ \t]*(?:8|16|32|64|128|256)[^\d])/, Operator
         rule %r/[.@]|\{(?:#{ArmAsm.builtin.join('|')})\}/, Name::Constant

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -74,12 +74,12 @@ module Rouge
           goto :args
         end
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(?:#{ArmAsm.file_directive.join('|')})(?=[ \t])/ do |m|
+        rule %r/(?:#{ArmAsm.file_directive.join('|')})\b/ do |m|
           token Keyword
           goto :filespec
         end
         rule %r/(?:#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
-        rule %r/(?:[A-Z][\dA-Z]*|[a-z][\da-z]*)(?:\.[NWnw])?(?:\.[DFIPSUdfipsu]?(?:8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule %r/(?:[A-Z][\dA-Z]*|[a-z][\da-z]*)(?:\.[NWnw])?(?:\.[DFIPSUdfipsu]?(?:8|16|32|64)?){,3}\b/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
         rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Function # probably a macro name
         rule %r/\$[a-z]\w*\.?/i, Name::Namespace
       end
@@ -88,7 +88,7 @@ module Rouge
         rule %r/\n/, Text, :pop!
         rule %r/[ \t]+/, Text
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(?<!\w)(?:#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
+        rule %r/(?:#{ArmAsm.shift_or_condition.join('|')})\b/, Name::Builtin
         rule %r/[a-z_]\w*|\|[^|\n]+\|/i, Name::Variable # various types of symbol
         rule %r/%[bf]?[at]?\d+(?:[a-z_]\w*)?/i, Name::Label
         rule %r/(?:&|0[x])\h+(?![\hp])/i, Literal::Number::Hex

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -47,93 +47,93 @@ module Rouge
       )
 
       state :root do
-        rule /\n/, Text
-        rule /^[ \t]*#[ \t]*((#{preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
-        rule /[ \t]+/, Text, :command
-        rule /;.*\n/, Comment
-        rule /\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
-        rule /([0-9A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Label, :afterlabel
+        rule %r/\n/, Text
+        rule %r/^[ \t]*#[ \t]*((#{preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
+        rule %r/[ \t]+/, Text, :command
+        rule %r/;.*\n/, Comment
+        rule %r/\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
+        rule %r/([0-9A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Label, :afterlabel
       end
 
       state :afterlabel do
-        rule /\n/,  Text, :pop!
-        rule /[ \t]+/ do |m|
+        rule %r/\n/,  Text, :pop!
+        rule %r/[ \t]+/ do |m|
           token Text
           goto :command
         end
-        rule /;.*\n/, Comment, :pop!
+        rule %r/;.*\n/, Comment, :pop!
       end
 
       state :command do
-        rule /\n/, Text, :pop!
-        rule /[ \t]+/ do |m|
+        rule %r/\n/, Text, :pop!
+        rule %r/[ \t]+/ do |m|
           token Text
           goto :args
         end
-        rule /;.*\n/, Comment, :pop!
-        rule /(#{file_directive.join('|')})(?=[ \t])/ do |m|
+        rule %r/;.*\n/, Comment, :pop!
+        rule %r/(#{file_directive.join('|')})(?=[ \t])/ do |m|
           token Keyword
           goto :filespec
         end
-        rule /(#{general_directive.join('|')})(?=[; \t\n])/, Keyword
-        rule /([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^0-9A-Za-z_])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
-        rule /([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Function # probably a macro name
-        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/(#{general_directive.join('|')})(?=[; \t\n])/, Keyword
+        rule %r/([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^0-9A-Za-z_])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Function # probably a macro name
+        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
       end
 
       state :args do
-        rule /\n/, Text, :pop!
-        rule /[ \t]+/, Text
-        rule /;.*\n/, Comment, :pop!
-        rule /(?<![0-9A-Za-z_])(#{shift_or_condition.join('|')})(?![0-9A-Za-z_])/, Name::Builtin
-        rule /([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
-        rule /%[BFbf]?[ATat]?[0-9]+([A-Za-z_][0-9A-Za-z_]*)?/, Name::Label
-        rule /(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
-        rule /(&|0[Xx])[.0-9A-Fa-f]+([Pp][-+]?[0-9]+)?/, Literal::Number::Float
-        rule /(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
-        rule /(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
-        rule /(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
-        rule /[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
-        rule /[.@]|\{(#{builtin.join('|')})\}/, Name::Constant
-        rule /([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{operator.join('|')}):)/, Operator
-        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
-        rule /'/ do |m|
+        rule %r/\n/, Text, :pop!
+        rule %r/[ \t]+/, Text
+        rule %r/;.*\n/, Comment, :pop!
+        rule %r/(?<![0-9A-Za-z_])(#{shift_or_condition.join('|')})(?![0-9A-Za-z_])/, Name::Builtin
+        rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
+        rule %r/%[BFbf]?[ATat]?[0-9]+([A-Za-z_][0-9A-Za-z_]*)?/, Name::Label
+        rule %r/(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
+        rule %r/(&|0[Xx])[.0-9A-Fa-f]+([Pp][-+]?[0-9]+)?/, Literal::Number::Float
+        rule %r/(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
+        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
+        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
+        rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
+        rule %r/[.@]|\{(#{builtin.join('|')})\}/, Name::Constant
+        rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{operator.join('|')}):)/, Operator
+        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/'/ do |m|
           token Literal::String::Char
           goto :singlequoted
         end
-        rule /"/ do |m|
+        rule %r/"/ do |m|
           token Literal::String::Double
           goto :doublequoted
         end
       end
 
       state :singlequoted do
-        rule /\n/, Text, :pop!
-        rule /\$\$/, Literal::String::Char
-        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
-        rule /'/ do |m|
+        rule %r/\n/, Text, :pop!
+        rule %r/\$\$/, Literal::String::Char
+        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/'/ do |m|
           token Literal::String::Char
           goto :args
         end
-        rule /[^$'\n]+/, Literal::String::Char
+        rule %r/[^$'\n]+/, Literal::String::Char
       end
 
       state :doublequoted do
-        rule /\n/, Text, :pop!
-        rule /\$\$/, Literal::String::Double
-        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
-        rule /"/ do |m|
+        rule %r/\n/, Text, :pop!
+        rule %r/\$\$/, Literal::String::Double
+        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/"/ do |m|
           token Literal::String::Double
           goto :args
         end
-        rule /[^$"\n]+/, Literal::String::Double
+        rule %r/[^$"\n]+/, Literal::String::Double
       end
 
       state :filespec do
-        rule /\n/, Text, :pop!
-        rule /\$\$/, Literal::String::Other
-        rule /\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
-        rule /[^$\n]+/, Literal::String::Other
+        rule %r/\n/, Text, :pop!
+        rule %r/\$\$/, Literal::String::Other
+        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/[^$\n]+/, Literal::String::Other
       end
     end
   end

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -9,46 +9,58 @@ module Rouge
       tag 'armasm'
       filenames '*.s'
 
-      preproc_keyword ||= %w(
-        define elif else endif error if ifdef ifndef include line pragma undef warning
-      )
+      def self.preproc_keyword
+        @preproc_keyword ||= %w(
+          define elif else endif error if ifdef ifndef include line pragma undef warning
+        )
+      end
 
-      file_directive ||= %w(
-        BIN GET INCBIN INCLUDE LNK
-      )
+      def self.file_directive
+        @file_directive ||= %w(
+          BIN GET INCBIN INCLUDE LNK
+        )
+      end
 
-      general_directive ||= %w(
-        ALIAS ALIGN AOF AOUT AREA ARM ASSERT ATTR CN CODE16 CODE32 COMMON CP
-        DATA DCB DCD DCDO DCDU DCFD DCFDU DCFH DCFHU DCFS DCFSU DCI DCI.N DCI.W
-        DCQ DCQU DCW DCWU DN ELIF ELSE END ENDFUNC ENDIF ENDP ENTRY EQU EXPORT
-        EXPORTAS EXTERN FIELD FILL FN FRAME FUNCTION GBLA GBLL GBLS GLOBAL IF
-        IMPORT INFO KEEP LCLA LCLL LCLS LEADR LEAF LTORG MACRO MAP MEND MEXIT
-        NOFP OPT ORG PRESERVE8 PROC QN RELOC REQUIRE REQUIRE8 RLIST RN ROUT
-        SETA SETL SETS SN SPACE STRONG SUBT THUMB THUMBX TTL WEND WHILE
-        \[ \] [|!#*=%&^]
-      )
+      def self.general_directive
+        @general_directive ||= %w(
+          ALIAS ALIGN AOF AOUT AREA ARM ASSERT ATTR CN CODE16 CODE32 COMMON CP
+          DATA DCB DCD DCDO DCDU DCFD DCFDU DCFH DCFHU DCFS DCFSU DCI DCI.N DCI.W
+          DCQ DCQU DCW DCWU DN ELIF ELSE END ENDFUNC ENDIF ENDP ENTRY EQU EXPORT
+          EXPORTAS EXTERN FIELD FILL FN FRAME FUNCTION GBLA GBLL GBLS GLOBAL IF
+          IMPORT INFO KEEP LCLA LCLL LCLS LEADR LEAF LTORG MACRO MAP MEND MEXIT
+          NOFP OPT ORG PRESERVE8 PROC QN RELOC REQUIRE REQUIRE8 RLIST RN ROUT
+          SETA SETL SETS SN SPACE STRONG SUBT THUMB THUMBX TTL WEND WHILE
+          \[ \] [|!#*=%&^]
+        )
+      end
 
-      shift_or_condition ||= %w(
-        ASR LSL LSR ROR RRX AL CC CS EQ GE GT HI HS LE LO LS LT MI NE PL VC VS
-        asr lsl lsr ror rrx al cc cs eq ge gt hi hs le lo ls lt mi ne pl vc vs
-      )
+      def self.shift_or_condition
+        @shift_or_condition ||= %w(
+          ASR LSL LSR ROR RRX AL CC CS EQ GE GT HI HS LE LO LS LT MI NE PL VC VS
+          asr lsl lsr ror rrx al cc cs eq ge gt hi hs le lo ls lt mi ne pl vc vs
+        )
+      end
 
-      builtin ||= %w(
-        ARCHITECTURE AREANAME ARMASM_VERSION CODESIZE COMMANDLINE CONFIG CPU
-        ENDIAN FALSE FPIC FPU INPUTFILE INTER LINENUM LINENUMUP LINENUMUPPER
-        OBJASM_VERSION OPT PC PCSTOREOFFSET REENTRANT ROPI RWPI TRUE VAR
-      )
+      def self.builtin
+        @builtin ||= %w(
+          ARCHITECTURE AREANAME ARMASM_VERSION CODESIZE COMMANDLINE CONFIG CPU
+          ENDIAN FALSE FPIC FPU INPUTFILE INTER LINENUM LINENUMUP LINENUMUPPER
+          OBJASM_VERSION OPT PC PCSTOREOFFSET REENTRANT ROPI RWPI TRUE VAR
+        )
+      end
 
-      operator ||= %w(
-        AND BASE CC CC_ENCODING CHR DEF EOR FATTR FEXEC FLOAD FSIZE INDEX LAND
-        LEFT LEN LEOR LNOT LOR LOWERCASE MOD NOT OR RCONST REVERSE_CC RIGHT ROL
-        ROR SHL SHR STR TARGET_ARCH_[0-9A-Z_]+ TARGET_FEATURE_[0-9A-Z_]+
-        TARGET_FPU_[A-Z_] TARGET_PROFILE_[ARM] UAL UPPERCASE
-      )
+      def self.operator
+        @operator ||= %w(
+          AND BASE CC CC_ENCODING CHR DEF EOR FATTR FEXEC FLOAD FSIZE INDEX LAND
+          LEFT LEN LEOR LNOT LOR LOWERCASE MOD NOT OR RCONST REVERSE_CC RIGHT ROL
+          ROR SHL SHR STR TARGET_ARCH_[0-9A-Z_]+ TARGET_FEATURE_[0-9A-Z_]+
+          TARGET_FPU_[A-Z_] TARGET_PROFILE_[ARM] UAL UPPERCASE
+        )
+      end
 
       state :root do
         rule %r/\n/, Text
-        rule %r/^[ \t]*#[ \t]*((#{preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
+        rule %r/^[ \t]*#[ \t]*((#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*\n/, Comment
         rule %r/\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
@@ -71,11 +83,11 @@ module Rouge
           goto :args
         end
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(#{file_directive.join('|')})(?=[ \t])/ do |m|
+        rule %r/(#{ArmAsm.file_directive.join('|')})(?=[ \t])/ do |m|
           token Keyword
           goto :filespec
         end
-        rule %r/(#{general_directive.join('|')})(?=[; \t\n])/, Keyword
+        rule %r/(#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
         rule %r/([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^0-9A-Za-z_])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
         rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Function # probably a macro name
         rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
@@ -85,7 +97,7 @@ module Rouge
         rule %r/\n/, Text, :pop!
         rule %r/[ \t]+/, Text
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(?<![0-9A-Za-z_])(#{shift_or_condition.join('|')})(?![0-9A-Za-z_])/, Name::Builtin
+        rule %r/(?<![0-9A-Za-z_])(#{ArmAsm.shift_or_condition.join('|')})(?![0-9A-Za-z_])/, Name::Builtin
         rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
         rule %r/%[BFbf]?[ATat]?[0-9]+([A-Za-z_][0-9A-Za-z_]*)?/, Name::Label
         rule %r/(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
@@ -94,8 +106,8 @@ module Rouge
         rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
         rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
         rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
-        rule %r/[.@]|\{(#{builtin.join('|')})\}/, Name::Constant
-        rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{operator.join('|')}):)/, Operator
+        rule %r/[.@]|\{(#{ArmAsm.builtin.join('|')})\}/, Name::Constant
+        rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{ArmAsm.operator.join('|')}):)/, Operator
         rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -88,7 +88,7 @@ module Rouge
           goto :filespec
         end
         rule %r/(#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
-        rule %r/([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule %r/([A-Z][\dA-Z]*|[a-z][\da-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
         rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Function # probably a macro name
         rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
       end
@@ -99,13 +99,13 @@ module Rouge
         rule %r/;.*\n/, Comment, :pop!
         rule %r/(?<!\w)(#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
         rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
-        rule %r/%[BFbf]?[ATat]?[0-9]+([A-Za-z_]\w*)?/, Name::Label
-        rule %r/(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
-        rule %r/(&|0[Xx])[.0-9A-Fa-f]+([Pp][-+]?[0-9]+)?/, Literal::Number::Float
-        rule %r/(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
-        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|[0-9]+)(?![0-9Ee])/, Literal::Number::Integer
-        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.0-9]+)([Ee][-+]?[0-9]+)?/, Literal::Number::Float
-        rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
+        rule %r/%[BFbf]?[ATat]?\d+([A-Za-z_]\w*)?/, Name::Label
+        rule %r/(&|0[Xx])[\dA-Fa-f]+(?![\dA-FPa-fp])/, Literal::Number::Hex
+        rule %r/(&|0[Xx])[.\dA-Fa-f]+([Pp][-+]?\d+)?/, Literal::Number::Float
+        rule %r/(0[Ff]_[\dA-Fa-f]{8}|0[Dd]_[\dA-Fa-f]{16})/, Literal::Number::Float
+        rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\dEe])/, Literal::Number::Integer
+        rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)([Ee][-+]?\d+)?/, Literal::Number::Float
+        rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^\d])/, Operator
         rule %r/[.@]|\{(#{ArmAsm.builtin.join('|')})\}/, Name::Constant
         rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{ArmAsm.operator.join('|')}):)/, Operator
         rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -63,17 +63,8 @@ module Rouge
         rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*\n/, Comment
-        rule %r/\$[a-z_]\w*\.?/i, Name::Namespace, :afterlabel # variable substitution or macro argument
-        rule %r/\w+|\|[^|\n]+\|/, Name::Label, :afterlabel
-      end
-
-      state :afterlabel do
-        rule %r/\n/,  Text, :pop!
-        rule %r/[ \t]+/ do |m|
-          token Text
-          goto :command
-        end
-        rule %r/;.*\n/, Comment, :pop!
+        rule %r/\$[a-z_]\w*\.?/i, Name::Namespace # variable substitution or macro argument
+        rule %r/\w+|\|[^|\n]+\|/, Name::Label
       end
 
       state :command do

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -16,7 +16,7 @@ module Rouge
         rule /;.*\n/, Comment
         rule /\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
         rule /([0-9A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Label, :afterlabel
-        end
+      end
 
       state :afterlabel do
         rule /\n/, Text, :root

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -60,7 +60,7 @@ module Rouge
 
       state :root do
         rule %r/\n/, Text
-        rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
+        rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})(?:[ \t].*)?)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*/, Comment
         rule %r/\$[a-z_]\w*\.?/i, Name::Namespace # variable substitution or macro argument

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -100,9 +100,9 @@ module Rouge
         rule %r/(?<!\w)(#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
         rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
         rule %r/%[BFbf]?[ATat]?\d+([A-Za-z_]\w*)?/, Name::Label
-        rule %r/(&|0[Xx])[\dA-Fa-f]+(?![\dA-FPa-fp])/, Literal::Number::Hex
-        rule %r/(&|0[Xx])[.\dA-Fa-f]+([Pp][-+]?\d+)?/, Literal::Number::Float
-        rule %r/(0[Ff]_[\dA-Fa-f]{8}|0[Dd]_[\dA-Fa-f]{16})/, Literal::Number::Float
+        rule %r/(&|0[Xx])\h+(?![\hPp])/, Literal::Number::Hex
+        rule %r/(&|0[Xx])[.\h]+([Pp][-+]?\d+)?/, Literal::Number::Float
+        rule %r/(0[Ff]_\h{8}|0[Dd]_\h{16})/, Literal::Number::Float
         rule %r/(2_[01]+|3_[0-2]+|4_[0-3]+|5_[0-4]+|6_[0-5]+|7_[0-6]+|8_[0-7]+|9_[0-8]+|\d+)(?![\dEe])/, Literal::Number::Integer
         rule %r/(2_[.01]+|3_[.0-2]+|4_[.0-3]+|5_[.0-4]+|6_[.0-5]+|7_[.0-6]+|8_[.0-7]+|9_[.0-8]+|[.\d]+)([Ee][-+]?\d+)?/, Literal::Number::Float
         rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^\d])/, Operator

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -63,8 +63,8 @@ module Rouge
         rule %r/^[ \t]*#[ \t]*((#{ArmAsm.preproc_keyword.join('|')})[ \t].*)?\n/, Comment::Preproc
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*\n/, Comment
-        rule %r/\$[A-Za-z_][0-9A-Za-z_]*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
-        rule %r/([0-9A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Label, :afterlabel
+        rule %r/\$[A-Za-z_]\w*\.?/, Name::Namespace, :afterlabel # variable substitution or macro argument
+        rule %r/(\w+|\|[^|\n]+\|)/, Name::Label, :afterlabel
       end
 
       state :afterlabel do
@@ -88,18 +88,18 @@ module Rouge
           goto :filespec
         end
         rule %r/(#{ArmAsm.general_directive.join('|')})(?=[; \t\n])/, Keyword
-        rule %r/([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^0-9A-Za-z_])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
-        rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Function # probably a macro name
-        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/([A-Z][0-9A-Z]*|[a-z][0-9a-z]*)(\.[NWnw])?(\.[DFIPSUdfipsu]?(8|16|32|64)?){,3}(?=[^\w])/, Name::Builtin # rather than attempt to list all opcodes, rely on all-uppercase or all-lowercase rule
+        rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Function # probably a macro name
+        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
       end
 
       state :args do
         rule %r/\n/, Text, :pop!
         rule %r/[ \t]+/, Text
         rule %r/;.*\n/, Comment, :pop!
-        rule %r/(?<![0-9A-Za-z_])(#{ArmAsm.shift_or_condition.join('|')})(?![0-9A-Za-z_])/, Name::Builtin
-        rule %r/([A-Za-z_][0-9A-Za-z_]*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
-        rule %r/%[BFbf]?[ATat]?[0-9]+([A-Za-z_][0-9A-Za-z_]*)?/, Name::Label
+        rule %r/(?<!\w)(#{ArmAsm.shift_or_condition.join('|')})(?!\w)/, Name::Builtin
+        rule %r/([A-Za-z_]\w*|\|[^|\n]+\|)/, Name::Variable # various types of symbol
+        rule %r/%[BFbf]?[ATat]?[0-9]+([A-Za-z_]\w*)?/, Name::Label
         rule %r/(&|0[Xx])[0-9A-Fa-f]+(?![0-9A-FPa-fp])/, Literal::Number::Hex
         rule %r/(&|0[Xx])[.0-9A-Fa-f]+([Pp][-+]?[0-9]+)?/, Literal::Number::Float
         rule %r/(0[Ff]_[0-9A-Fa-f]{8}|0[Dd]_[0-9A-Fa-f]{16})/, Literal::Number::Float
@@ -108,7 +108,7 @@ module Rouge
         rule %r/[@:](?=[ \t]*(8|16|32|64|128|256)[^0-9])/, Operator
         rule %r/[.@]|\{(#{ArmAsm.builtin.join('|')})\}/, Name::Constant
         rule %r/([-!#%&()*+,\/<=>?^{|}]|\[|\]|!=|&&|\/=|<<|<=|<>|==|><|>=|>>|\|\||:(#{ArmAsm.operator.join('|')}):)/, Operator
-        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char
           goto :singlequoted
@@ -122,7 +122,7 @@ module Rouge
       state :singlequoted do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Char
-        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
         rule %r/'/ do |m|
           token Literal::String::Char
           goto :args
@@ -133,7 +133,7 @@ module Rouge
       state :doublequoted do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Double
-        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
         rule %r/"/ do |m|
           token Literal::String::Double
           goto :args
@@ -144,7 +144,7 @@ module Rouge
       state :filespec do
         rule %r/\n/, Text, :pop!
         rule %r/\$\$/, Literal::String::Other
-        rule %r/\$[A-Za-z][0-9A-Za-z_]*\.?/, Name::Namespace
+        rule %r/\$[A-Za-z]\w*\.?/, Name::Namespace
         rule %r/[^$\n]+/, Literal::String::Other
       end
     end

--- a/spec/lexers/armasm_spec.rb
+++ b/spec/lexers/armasm_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::ArmAsm do
+  let(:subject) { Rouge::Lexers::ArmAsm.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.s'
+    end
+  end
+end

--- a/spec/visual/samples/armasm
+++ b/spec/visual/samples/armasm
@@ -1,0 +1,86 @@
+; it shouldn't have any problem with apostrophes in comments
+; or "quotation marks" or more ;s
+
+        GET     otherfile.s
+
+        ^       0,r12 ; typical data structure layout
+offset1 #       4
+        #       4 ; sometimes no label assigned
+offset2 #       0
+size    *       :INDEX:@
+
+ IF ?offset1 = 4
+        ! 1, "This is an assembly-time assert"
+ ELIF -1<>:NOT:0
+        ! 1, "This is another assert"
+ ELSE
+        ! 0, "But this is a warning", 1
+ ENDIF
+
+my_r0   RN      0 ; non-standard register name symbols
+
+sixteen * 4 * 4
+
+        GBLS    VBar
+VBar    SETS    "|"
+
+        MACRO
+$label  MyMacro$suffix $arg1 = default, $arg2
+        LCLS    thing
+ [ "$arg2"=""
+thing   SETS    "wibble ; this isn't a comment"
+ |
+thing   SETS    $arg2
+ ]
+        LCLL    boolean
+boolean SETL    {TRUE}
+        EXPORT  $arg1
+$arg1
+$thing  MOV     pc, #0
+        MEND
+
+        
+        ORG     0
+
+        ARM
+
+        AREA    |Area$$Name|, CODE, READONLY
+
+MyFunc  ROUT
+
+just_a_label
+label_and ; comment
+        LDR     my_r0, =just_a_statement
+label   AND     r0, r1, r2 ; and a comment
+        MOV     r0, r1, r2, LSL r3
+        MOV.W   r0, r1, r2, ROR #1
+        ADDS.N  r0, r1
+        IT      MI
+        MOVMI   r0, r1, RRX
+        UND     #0x10-&10
+        PUSH    {r0,r2-r4,ip,lr}
+        LDF     F0, =25E-1
+        VMOVEQ.F64 d0, #-.7e1
+
+Symbols_may_contain_d161ts_and_underscores
+but_must_start_with_a_letter
+and_are_case_SenSitIve
+01 ; this, by contrast, is a local label
+
+        LDR     r0, here
+        B       .+8
+here    DATA
+        DCD     1
+        BNE     %BT01
+
+        DCB 1,2,3,'A',';','"' ; bytes
+        = "This is a string with embedded $$ dollar and "" double quote characters", 0
+        = "$VBar.not_part_of_variable_name", 0
+        DCD     -1 ; words
+        &       -2,:INDEX:offset1 ; more words
+        %       16
+same_as SPACE   16
+or      FILL    16, 0
+        INCBIN  include.bin
+
+        END

--- a/spec/visual/samples/armasm
+++ b/spec/visual/samples/armasm
@@ -1,3 +1,7 @@
+#ifndef Version
+    #include "Version.h"
+#endif
+
 ; it shouldn't have any problem with apostrophes in comments
 ; or "quotation marks" or more ;s
 


### PR DESCRIPTION
This is for the syntax used by ARM DS-5, Keil, RealView, ADS, SDT, objasm, asasm and aasm toolchains, which is *not* the same as that shared by GNU AS and Clang's integrated assembler.