### PR TITLE
lexers/haskell: Recognize hs-boot files as Haskell

### DIFF
--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -9,7 +9,7 @@ module Rouge
 
       tag 'haskell'
       aliases 'hs'
-      filenames '*.hs'
+      filenames '*.hs', '*.hs-boot'
       mimetypes 'text/x-haskell'
 
       def self.detect?(text)

--- a/spec/lexers/haskell_spec.rb
+++ b/spec/lexers/haskell_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::Haskell do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.hs'
+      assert_guess :filename => 'foo.hs-boot'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
`hs-boot` files are used by GHC, the most widely used Haskell implementation.