### PR TITLE
Add missing CoffeeScript keywords and reserved words

### DIFF
--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -18,7 +18,7 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          for in of by while until loop break continue return
+          for by while until loop break continue return
           switch when then if else do yield throw try catch finally await
           new delete typeof instanceof super extends this class
           import export debugger
@@ -85,8 +85,8 @@ module Rouge
         rule(%r(^(?=\s|/|<!--))) { push :slash_starts_regex }
         mixin :comments_and_whitespace
         rule %r(
-          [+][+]|--|~|&&|\band\b|\bor\b|\bis\b|\bisnt\b|\bnot\b|[?]|:|=|
-          [|][|]|\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*`%&|^/])=?
+          [+][+]|--|~|&&|\band\b|\bor\b|\bis\b|\bisnt\b|\bnot\b|\bin\b|\bof\b|
+          [?]|:|=|[|][|]|\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*`%&|^/])=?
         )x, Operator, :slash_starts_regex
 
         rule /[-=]>/, Name::Function

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -18,9 +18,17 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          for in of while break return continue switch when then if else
-          throw try catch finally new delete typeof instanceof super
-          extends this class by
+          for in of by while until loop break continue return
+          switch when then if else do yield throw try catch finally await
+          new delete typeof instanceof super extends this class
+          import export debugger
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+          case function var void with const let enum
+          native implements interface package private protected public static
         )
       end
 


### PR DESCRIPTION
Added missing keywords:
* `until`, `loop`, `do`, `yield` (old ones),
* `debugger` (an obscure one inhereted from JavaScript), and
* `await`, `import`, `export` (added in CoffeeScript 2).

Added missing reserved words based on `RESERVED` list in CoffeeScript source code. (Previously there were no reserved words.)

See https://coffeescript.org/annotated-source/lexer.html#constants

I also made `in` and `of` into operators, as they can be used in arbitrary context, not just in `for` loops, and also to be consistent with `not` (currently an operator).  Before this PR, the `not in` operator formats rather inconsistently:
![image](https://user-images.githubusercontent.com/2218736/50921729-b7fa9700-1416-11e9-90d1-5343c51978f6.png)

As a bonus, this last change fixes #1056.

Not addressed by this PR: `for ... from` doesn't highlight `from` (which is *not* a keyword), and `for own` doesn't highlight `own` (also not a keyword). Should I add these to operators, or add more complex rules to capture [the context where they actually matter](https://coffeescript.org/annotated-source/lexer.html#section-13)? This PR or another PR? Actually, same for `import ... as` which `javascript.rb` seems to just call a keyword (which is not correct -- you can assign `as = 5` in JS and CS).