### PR TITLE
Resolve bundler version issue and update list of tested Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-  - "2.0"
-  - "2.1"
-  - "2.2"
-  - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 bundler_args: --without development
 before_install:
   - gem update --system
-  - gem install bundler -v 1.17.2
+  - gem install bundler -v 1.15
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 bundler_args: --without development
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler || gem install bundler -v 1.15
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
-  - gem update --system
+  - gem update --system || true
   - gem install bundler || gem install bundler -v 1.15
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
+  - "2.0"
+  - "2.1"
+  - "2.2"
+  - "2.3"  
   - "2.4"
   - "2.5"
   - "2.6"
@@ -11,7 +15,7 @@ cache:
 bundler_args: --without development
 before_install:
   - gem update --system
-  - gem install bundler -v 1.15
+  - gem install bundler
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
-  - gem install bundler
   - gem update --system
+  - gem install bundler -v 1.17.2
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'bundler', '~> 1.15'
+gem 'bundler', '>= 1.15', '< 3.0'
 gem 'rake'
 
 gem 'minitest', '>= 5.0'


### PR DESCRIPTION
Older Rubies are unsupported by bundler 2.0.1. This is attempting to resolve that by explicitly installing 1.17.2 *after* updating rubygems.
