### PR TITLE
Fix #1022 by supporting diffs other than unified.

### DIFF
--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -19,14 +19,18 @@ module Rouge
 
       state :root do
         rule(/^ .*$\n?/, Text)
-        rule(/^---$\n?/, Text)
+        rule(/^---$\n?/, Punctuation)
+        rule(/^[+>]+.*$\n?/, Generic::Inserted)
         rule(/^\+.*$\n?/, Generic::Inserted)
-        rule(/^-+.*$\n?/, Generic::Deleted)
+        rule(/^[-<]+.*$\n?/, Generic::Deleted)
         rule(/^!.*$\n?/, Generic::Strong)
-        rule(/^@.*$\n?/, Generic::Subheading)
         rule(/^([Ii]ndex|diff).*$\n?/, Generic::Heading)
+        rule(/^(@@[^@]*@@)([^\n]*\n)/) do
+          groups Punctuation, Text
+        end
+        rule(/^\w.*$\n?/, Punctuation)
         rule(/^=.*$\n?/, Generic::Heading)
-        rule(/.*$\n?/, Text)
+        rule(/\s.*$\n?/, Text)
       end
     end
   end

--- a/spec/visual/samples/diff
+++ b/spec/visual/samples/diff
@@ -53,3 +53,11 @@ index ab1701b..155fa52 100644
      token 'Name.Attribute',              'na'
      token 'Name.Builtin',                'nb'
      token 'Name.Builtin.Pseudo',         'bp'
+
+$ diff a b
+1a2
+> Added line
+3c4
+< diff
+---
+> Line before was removed


### PR DESCRIPTION
Close #846 as it conflicts and this commit differentiates further.

In addition to handling diffs done without the "-u" flag, this also more closely matches "git diff" output for unified diffs by treating `@@ [reference ] @@` as punctuation and the rest of the line as text, making "---" punctuation, and making the diff/index lines at the top headings. 
