### PR TITLE
Fixes #1009, fixes #879 issues w/C and C++ highlighting

### DIFF
--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -44,15 +44,8 @@ module Rouge
         rule /@\d+l?/, Num::Integer
         rule /\bin\b/, Keyword
 
-        rule /@(?:interface|implementation)\b/ do
-          token Keyword
-          goto :classname
-        end
-
-        rule /@(?:class|protocol)\b/ do
-          token Keyword
-          goto :forward_classname
-        end
+        rule /@(?:interface|implementation)\b/, Keyword, :classname
+        rule /@(?:class|protocol)\b/, Keyword, :forward_classname
 
         rule /@([[:alnum:]]+)/ do |m|
           if self.class.at_keywords.include? m[1]
@@ -80,7 +73,7 @@ module Rouge
         rule /\{/, Punctuation, :pop!
         rule /;/, Error
 
-        mixin :statement
+        mixin :statements
       end
 
       state :message do

--- a/spec/visual/samples/c
+++ b/spec/visual/samples/c
@@ -31,9 +31,6 @@ static int not_a_comment();
 
 #macro
 
-
-/* Bug #277: C function prototype syntax highlighting broken if space before semicolon */
-
 void foo() ;
 
 void foo() {
@@ -45,6 +42,14 @@ void foo2(void)
     /* nothing */
 }
 
+/* Broken declarations should not break subsequent highlighting */
+
+void foo() {
+    if(x) {
+    } else if(y) {
+      puts("foo")
+    }
+  }
 
 /* Execute compiled code */
 


### PR DESCRIPTION
1. void foo(); without space before ";" does not highlight correctly.
2. else if() in certain contexts highlights incorrectly.
3. any error in a function definition or declaration has the potential
 to cause incorrect highlighting further down in the file.

Contains minor changes to Objc-C lexer to fix dependencies on the
C lexer that were broken by the C lexer fix.