### PR TITLE
Dockerfile Naming Convention | Edge Case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.2
   - gem update --system
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
-  - gem install bundler -v 1.17.2
+  - gem install bundler
   - gem update --system
 script:
   - bundle exec rake

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Dockerfile syntax"
       tag 'docker'
       aliases 'dockerfile'
-      filenames 'Dockerfile', '*.docker', 'Dockerfile_*
+      filenames 'Dockerfile', '*.docker', 'Dockerfile_*'
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Dockerfile syntax"
       tag 'docker'
       aliases 'dockerfile'
-      filenames 'Dockerfile', '*.docker', 'Dockerfile_*'
+      filenames 'Dockerfile', '*.docker', '*.Dockerfile', 'Dockerfile_*'
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Dockerfile syntax"
       tag 'docker'
       aliases 'dockerfile'
-      filenames 'Dockerfile', '*.docker'
+      filenames 'Dockerfile', '*.docker', 'Dockerfile_*
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/spec/lexers/docker_spec.rb
+++ b/spec/lexers/docker_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::Docker do
 
     it 'guesses by filename' do
       assert_guess :filename => 'Dockerfile'
+      assert_guess :filename => 'Dockerfile_*'
       assert_guess :filename => 'docker.docker'
     end
 

--- a/spec/lexers/docker_spec.rb
+++ b/spec/lexers/docker_spec.rb
@@ -9,7 +9,8 @@ describe Rouge::Lexers::Docker do
 
     it 'guesses by filename' do
       assert_guess :filename => 'Dockerfile'
-      assert_guess :filename => 'Dockerfile_*'
+      assert_guess :filename => 'some.Dockerfile'
+      assert_guess :filename => 'Dockerfile_1.1.1'
       assert_guess :filename => 'docker.docker'
     end
 


### PR DESCRIPTION
I was wondering if this would be useful in your project. I found that GitLab uses it and thought I'd attempt to contribute. I've since found a workaround for syntax highlighting in our `Dockerfile_1.11.1` type naming convention. Let me know if I've missed something and I'd be happy to commit more to this awesome project! 