### PR TITLE
Fix quoted lists

### DIFF
--- a/lib/rouge/lexers/clojure.rb
+++ b/lib/rouge/lexers/clojure.rb
@@ -86,14 +86,19 @@ module Rouge
         rule /::?#{keyword}/, Name::Constant
         rule /\\(.|[a-z]+)/i, Str::Char
 
-
-        rule /~@|[`\'#^~&@]/, Operator
+        rule /(')(\()(\s*)/m do |m|
+          token Operator, m[1]
+          token Punctuation, m[2]
+          token Text::Whitespace, m[3]
+        end
 
         rule /(\()(\s*)(#{identifier})/m do |m|
           token Punctuation, m[1]
           token Text::Whitespace, m[2]
           token(name_token(m[3]) || Name::Function, m[3])
         end
+
+        rule /~@|[`\'#^~&@]/, Operator
 
         rule identifier do |m|
           token name_token(m[0]) || Name


### PR DESCRIPTION
As discussed in #458, the first element in a quoted list should not be treated as if it were a function. This commit adds a new rule for lists that begin with a quotation mark and moves the operator rule to avoid an early match. This does not handle the case where a list is quoted by use of the `quote` special form.