### PR TITLE
Support 'MicrosoftShell' and 'MSShell' as alias for 'PowerShell'

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -9,7 +9,7 @@ module Rouge
       title 'powershell'
       desc 'powershell'
       tag 'powershell'
-      aliases 'posh'
+      aliases 'posh', 'microsoftshell', 'msshell'
       filenames '*.ps1', '*.psm1', '*.psd1', '*.psrc', '*.pssc'
       mimetypes 'text/x-powershell'
 


### PR DESCRIPTION
PowerShell was previously called MS Shell. It might make sense to also support those aliases to not break backwards compatibility basically.

Ref: https://en.wikipedia.org/wiki/PowerShell