### PR TITLE
Fix single line comment formatting in Ruby files with CRLF

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -152,7 +152,7 @@ module Rouge
       state :whitespace do
         mixin :inline_whitespace
         rule /\n\s*/m, Text, :expr_start
-        rule /#.*$/, Comment::Single
+        rule /#[^\r\n]*/, Comment::Single
 
         rule %r(=begin\b.*?\n=end\b)m, Comment::Multiline
       end

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -31,6 +31,14 @@ describe Rouge::Lexers::Ruby do
         end
       end
 
+      describe 'line endings' do
+        it 'handles CRLF line endings in single line comments' do
+          assert_tokens_equal "# single line comment with CRLF\r\n",
+            ['Comment.Single', '# single line comment with CRLF'],
+            ['Text', "\r\n"]
+        end
+      end
+
       describe 'trailing dot' do
         it 'handles whitespace between the receiver and the method' do
           assert_tokens_equal "foo.\n  bar()",


### PR DESCRIPTION
Redmine 4 switched from CodeRay to Rouge (version 3.3.0) and we found an issue with single line comment formatting in Ruby files with CRLF (please see http://www.redmine.org/issues/30434 for more details).

Investigating the issue on rouge library, I found #723 which propose a fix for this problem, but the PR was never accepted because of the missing tests (is just my assumption). Based on the proposed fix, I've created a fix only for Ruby files (for now) which includes a test as well.

I've tested the fix on my Redmine local environment and it works as expected:

1. Redmine current trunk with Rouge 3.3.0
<img width="660" alt="screenshot 2019-02-02 at 12 32 14" src="https://user-images.githubusercontent.com/5037739/52163140-9d9a9d00-26e6-11e9-860d-5305110668ea.png">

2. Redmine current trunk with Rouge forked from my repository with the fix applied.
<img width="865" alt="screenshot 2019-02-02 at 12 20 06" src="https://user-images.githubusercontent.com/5037739/52163130-72b04900-26e6-11e9-94b8-81d89e418d95.png">

If the fix is accepted, I can provide another PR for other file types supported where the issue reproduces.
  

 