### PR TITLE
resolves #1082 HTMLTable formatter delegates to format method of inner formatter

### DIFF
--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -16,46 +16,35 @@ module Rouge
       end
 
       def style(scope)
-        yield "#{scope} .rouge-table { border-spacing: 0 }"
-        yield "#{scope} .rouge-gutter { text-align: right }"
+        yield %(#{scope} .rouge-table { border-spacing: 0 })
+        yield %(#{scope} .rouge-gutter { text-align: right })
       end
 
       def stream(tokens, &b)
-        num_lines = 0
-        last_val = ''
-        formatted = String.new('')
-
-        tokens.each do |tok, val|
-          last_val = val
-          num_lines += val.scan(/\n/).size
-          formatted << @inner.span(tok, val)
-        end
-
-        # add an extra line for non-newline-terminated strings
-        if last_val[-1] != "\n"
+        last_val = nil
+        num_lines = tokens.reduce(0) {|count, (_, val)| count + (last_val = val).count(?\n) }
+        formatted = @inner.format(tokens)
+        unless last_val && last_val.end_with?(?\n)
           num_lines += 1
-          @inner.span(Token::Tokens::Text::Whitespace, "\n") { |str| formatted << str }
+          formatted << ?\n
         end
 
         # generate a string of newline-separated line numbers for the gutter>
-        formatted_line_numbers = (@start_line..num_lines+@start_line-1).map do |i|
-          sprintf("#{@line_format}", i) << "\n"
-        end.join('')
+        formatted_line_numbers = (@start_line..(@start_line + num_lines - 1)).map do |i|
+          sprintf(@line_format, i)
+        end.join(?\n) << ?\n
 
-        numbers = %(<pre class="lineno">#{formatted_line_numbers}</pre>)
-
-        yield %(<table class="#@table_class"><tbody><tr>)
-
+        buffer = [%(<table class="#@table_class"><tbody><tr>)]
         # the "gl" class applies the style for Generic.Lineno
-        yield %(<td class="#@gutter_class gl">)
-        yield numbers
-        yield '</td>'
+        buffer << %(<td class="#@gutter_class gl">)
+        buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
+        buffer << '</td>'
+        buffer << %(<td class="#@code_class"><pre>)
+        buffer << formatted
+        buffer << '</pre></td>'
+        buffer << '</tr></tbody></table>'
 
-        yield %(<td class="#@code_class"><pre>)
-        yield formatted
-        yield '</pre></td>'
-
-        yield "</tr></tbody></table>"
+        yield buffer.join
       end
     end
   end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -31,4 +31,12 @@ describe Rouge::Formatters::HTMLLinewise do
       assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }
     end
   end
+
+  describe 'inside html table formatter' do
+    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
+
+    it 'formats' do
+      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div></pre></td></tr></tbody></table>) }
+    end
+  end
 end


### PR DESCRIPTION
resolves #1082

- HTMLTable formatter delegates to format method of inner formatter instead of span method
- append trailing newline if missing (but don't wrap as whitespace token)
- add test