### PR TITLE
resolves #1084 preserve newlines in linewise formatter

### DIFF
--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -6,22 +6,17 @@ module Rouge
     class HTMLLinewise < Formatter
       def initialize(formatter, opts={})
         @formatter = formatter
+        @tag_name = opts.fetch(:tag_name, 'div')
         @class_format = opts.fetch(:class, 'line-%i')
       end
 
       def stream(tokens, &b)
-        token_lines(tokens) do |line|
-          yield "<div class=#{next_line_class}>"
-          line.each do |tok, val|
-            yield @formatter.span(tok, val)
-          end
-          yield '</div>'
+        lineno = 0
+        token_lines(tokens) do |line_tokens|
+          yield %(<#{@tag_name} class="#{sprintf @class_format, lineno += 1}">)
+          @formatter.stream(line_tokens) {|formatted| yield formatted }
+          yield %(\n</#{@tag_name}>)
         end
-      end
-
-      def next_line_class
-        @lineno ||= 0
-        sprintf(@class_format, @lineno += 1).inspect
       end
     end
   end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -12,7 +12,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], 'foo']] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span></div>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div>) }
     end
   end
 
@@ -20,7 +20,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div>) }
+      assert { output == %(<div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
     end
   end
 
@@ -28,7 +28,16 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], "foo\nbar"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
+    end
+  end
+
+  describe 'alternate tag name' do
+    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
+    let(:options) { { tag_name: 'span' } }
+
+    it 'should use tag name specified by :tag_name option' do
+      assert { output == %(<span class="line-1">foo\n</span><span class="line-2"><span class="n">bar</span>\n</span>) }
     end
   end
 end


### PR DESCRIPTION
resolves #1084

- switch from `<div>` to `<span>`
- preserve newlines
- delegate to stream method instead of span method on inner formatter