### PR TITLE
Add support for `*.svelte` files as alias of HTML

### DIFF
--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -7,7 +7,7 @@ module Rouge
       title "HTML"
       desc "HTML, the markup language of the web"
       tag 'html'
-      filenames '*.htm', '*.html', '*.xhtml'
+      filenames '*.htm', '*.html', '*.xhtml', '*.svelte'
       mimetypes 'text/html', 'application/xhtml+xml'
 
       def self.detect?(text)


### PR DESCRIPTION
[Svelte framework](https://svelte.technology/) will use `*.svelte` extension for its component files —  https://github.com/sveltejs/svelte/issues/2067. It would be nice to add highlighting for it.