### PR TITLE
Allow user to specify HTML tag in HTMLLinewise

### DIFF
--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -6,16 +6,17 @@ module Rouge
     class HTMLLinewise < Formatter
       def initialize(formatter, opts={})
         @formatter = formatter
+        @tag_name = opts.fetch(:tag_name, 'div')
         @class_format = opts.fetch(:class, 'line-%i')
       end
 
       def stream(tokens, &b)
         token_lines(tokens) do |line|
-          yield "<div class=#{next_line_class}>"
+          yield "<#{@tag_name} class=#{next_line_class}>"
           line.each do |tok, val|
             yield @formatter.span(tok, val)
           end
-          yield '</div>'
+          yield "</#{@tag_name}>\n"
         end
       end
 

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -16,7 +16,7 @@ module Rouge
           line.each do |tok, val|
             yield @formatter.span(tok, val)
           end
-          yield "</#{@tag_name}>\n"
+          yield "</#{@tag_name}>"
         end
       end
 


### PR DESCRIPTION
The `Rouge::Formatters::HTMLLinewise` class provides a user with the ability to wrap each line in a code block in a tag. Currently, that tag is hard-coded to be `<div>`. Arguably the more semantically correct tag to use would be `<code>`, but regardless of whether this is correct or not, lines that are wrapped in this way display unpleasantly in RSS readers.

This commit allows a user to specify the tag to use by passing a value with the key `:tag_name` to the class's initialiser. If no tag is specified, the class uses `<div>` as the default (ie. it is consistent with the current behaviour).

Finally, to enhance the readability of the HTML, a new line is added at the end of each line (this causes the tests to fail but is, I believe, more semantically correct).