### PR TITLE
shell lexer: add Alpine Linux APKBUILD (simple two line patch)

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -10,7 +10,7 @@ module Rouge
       tag 'shell'
       aliases 'bash', 'zsh', 'ksh', 'sh'
       filenames '*.sh', '*.bash', '*.zsh', '*.ksh',
-                '.bashrc', '.zshrc', '.kshrc', '.profile', 'PKGBUILD'
+                '.bashrc', '.zshrc', '.kshrc', '.profile', 'APKBUILD', 'PKGBUILD'
 
       mimetypes 'application/x-sh', 'application/x-shellscript'
 

--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -41,6 +41,7 @@ describe Rouge::Lexers::Shell do
       assert_guess :filename => 'foo.zsh'
       assert_guess :filename => 'foo.ksh'
       assert_guess :filename => 'foo.bash'
+      assert_guess :filename => 'APKBUILD'
       assert_guess :filename => 'PKGBUILD'
       deny_guess   :filename => 'foo'
     end


### PR DESCRIPTION
Properly highlight [Alpine](https://alpinelinux.org)'s package build recipes. Done in the same way as 5dca906f7357342bddb0ea618f3f1756646d34b9 for Arch Linux.

Downstream feature request:
https://gitlab.com/gitlab-org/gitlab-ce/issues/56579