### PR TITLE
CommonLisp lexer crashes on unbalanced parentheses

### DIFF
--- a/spec/lexers/common_lisp_spec.rb
+++ b/spec/lexers/common_lisp_spec.rb
@@ -18,4 +18,12 @@ describe Rouge::Lexers::CommonLisp do
       assert_guess :mimetype => 'text/x-common-lisp'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'does not crash on unbalanced parentheses' do
+      subject.lex(")\n").to_a
+    end
+  end
 end


### PR DESCRIPTION
:wave: We noticed a crash in Rouge on GitHub Pages, and have isolated the cause: unbalanced parentheses will crash the CommonLisp lexer. Here's a test case that demonstrates this.

I don't have the time to make a full fix right now, but I thought the reproduction might be useful for someone who does.

/cc @darrowby385