### PR TITLE
Reduce allocations from just loading the gem

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -34,51 +34,54 @@ module Rouge
   end
 end
 
-load_dir = Pathname.new(__FILE__).dirname
-load load_dir.join('rouge/version.rb')
-
-load load_dir.join('rouge/util.rb')
-
-load load_dir.join('rouge/text_analyzer.rb')
-load load_dir.join('rouge/token.rb')
-
-load load_dir.join('rouge/lexer.rb')
-load load_dir.join('rouge/regex_lexer.rb')
-load load_dir.join('rouge/template_lexer.rb')
-
-lexers_dir = load_dir.join('rouge/lexers')
-Dir.glob(lexers_dir.join('*.rb')).each do |f|
-  Rouge::Lexers.load_lexer(Pathname.new(f).relative_path_from(lexers_dir).to_s)
+# mimic Kernel#require_relative API
+def load_relative(path)
+  load File.join(__dir__, "#{path}.rb")
 end
 
-load load_dir.join('rouge/guesser.rb')
-load load_dir.join('rouge/guessers/util.rb')
-load load_dir.join('rouge/guessers/glob_mapping.rb')
-load load_dir.join('rouge/guessers/modeline.rb')
-load load_dir.join('rouge/guessers/filename.rb')
-load load_dir.join('rouge/guessers/mimetype.rb')
-load load_dir.join('rouge/guessers/source.rb')
-load load_dir.join('rouge/guessers/disambiguation.rb')
+def lexer_dir(path = '')
+  File.join(__dir__, 'rouge', 'lexers', path)
+end
 
-load load_dir.join('rouge/formatter.rb')
-load load_dir.join('rouge/formatters/html.rb')
-load load_dir.join('rouge/formatters/html_table.rb')
-load load_dir.join('rouge/formatters/html_pygments.rb')
-load load_dir.join('rouge/formatters/html_legacy.rb')
-load load_dir.join('rouge/formatters/html_linewise.rb')
-load load_dir.join('rouge/formatters/html_inline.rb')
-load load_dir.join('rouge/formatters/terminal256.rb')
-load load_dir.join('rouge/formatters/null.rb')
+load_relative 'rouge/version'
+load_relative 'rouge/util'
+load_relative 'rouge/text_analyzer'
+load_relative 'rouge/token'
 
-load load_dir.join('rouge/theme.rb')
-load load_dir.join('rouge/themes/thankful_eyes.rb')
-load load_dir.join('rouge/themes/colorful.rb')
-load load_dir.join('rouge/themes/base16.rb')
-load load_dir.join('rouge/themes/github.rb')
-load load_dir.join('rouge/themes/igor_pro.rb')
-load load_dir.join('rouge/themes/monokai.rb')
-load load_dir.join('rouge/themes/molokai.rb')
-load load_dir.join('rouge/themes/monokai_sublime.rb')
-load load_dir.join('rouge/themes/gruvbox.rb')
-load load_dir.join('rouge/themes/tulip.rb')
-load load_dir.join('rouge/themes/pastie.rb')
+load_relative 'rouge/lexer'
+load_relative 'rouge/regex_lexer'
+load_relative 'rouge/template_lexer'
+
+Dir.glob(lexer_dir('*rb')).each { |f| Rouge::Lexers.load_lexer(f.sub(lexer_dir, '')) }
+
+load_relative 'rouge/guesser'
+load_relative 'rouge/guessers/util'
+load_relative 'rouge/guessers/glob_mapping'
+load_relative 'rouge/guessers/modeline'
+load_relative 'rouge/guessers/filename'
+load_relative 'rouge/guessers/mimetype'
+load_relative 'rouge/guessers/source'
+load_relative 'rouge/guessers/disambiguation'
+
+load_relative 'rouge/formatter'
+load_relative 'rouge/formatters/html'
+load_relative 'rouge/formatters/html_table'
+load_relative 'rouge/formatters/html_pygments'
+load_relative 'rouge/formatters/html_legacy'
+load_relative 'rouge/formatters/html_linewise'
+load_relative 'rouge/formatters/html_inline'
+load_relative 'rouge/formatters/terminal256'
+load_relative 'rouge/formatters/null'
+
+load_relative 'rouge/theme'
+load_relative 'rouge/themes/thankful_eyes'
+load_relative 'rouge/themes/colorful'
+load_relative 'rouge/themes/base16'
+load_relative 'rouge/themes/github'
+load_relative 'rouge/themes/igor_pro'
+load_relative 'rouge/themes/monokai'
+load_relative 'rouge/themes/molokai'
+load_relative 'rouge/themes/monokai_sublime'
+load_relative 'rouge/themes/gruvbox'
+load_relative 'rouge/themes/tulip'
+load_relative 'rouge/themes/pastie'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -454,9 +454,7 @@ module Rouge
     def self.load_lexer(relpath)
       return if @_loaded_lexers.key?(relpath)
       @_loaded_lexers[relpath] = true
-
-      root = Pathname.new(__FILE__).dirname.join('lexers')
-      load root.join(relpath)
+      load File.join(__dir__, 'lexers', relpath)
     end
   end
 end


### PR DESCRIPTION
Pathname generates a lot of intermediate strings during operations on its instances. This change swaps Pathname objects with regular String objects.

To compare with `master`, use below script:
```ruby
# frozen_string_literal: true

require 'memory_profiler'
require 'bundler/setup'

MemoryProfiler.report(trace: [String]) do
  require 'rouge'
end.pretty_print(to_file: '.memprof', scale_bytes: true)
```