### PR TITLE
Add lexer development documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,5 @@
 --no-private
+--protected
 --markup-provider=redcarpet
 --markup=markdown
+- docs/LexerDevelopment.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 If you'd like to help out with this project, assign yourself something from the [issues][] page, and send me a pull request (even if it's not done yet!).  Bonus points for feature branches.
 
-[issues]: https://github.com/jneen/rouge/issues "Help Out"
+[issues]: https://github.com/rouge-ruby/rouge/issues "Help Out"
 [pygments]: http://pygments.org/ "Pygments"
 
 ## Usage
@@ -86,7 +86,7 @@ $ rougify style monokai.sublime > syntax.css
 
 ### Advantages to pygments.rb
 * No need to [spawn Python processes](https://github.com/tmm1/pygments.rb).
-* We're faster in [almost every measure](https://github.com/jneen/rouge/pull/41#issuecomment-223751572)
+* We're faster in [almost every measure](https://github.com/rouge-ruby/rouge/pull/41#issuecomment-223751572)
 
 ### Advantages to CodeRay
 * The HTML output from Rouge is fully compatible with stylesheets designed for pygments.
@@ -126,7 +126,7 @@ Rouge is only for UTF-8 strings.  If you'd like to highlight a string with a dif
 
 ### Installing Ruby
 
-If you're here to implement a lexer for your awesome language, there's a good chance you don't already have a ruby development environment set up.  Follow the [instructions on the wiki](https://github.com/jneen/rouge/wiki/Setting-up-Ruby) to get up and running.  If you have trouble getting set up, let me know - I'm always happy to help.
+If you're here to implement a lexer for your awesome language, there's a good chance you don't already have a ruby development environment set up.  Follow the [instructions on the wiki](https://github.com/rouge-ruby/rouge/wiki/Setting-up-Ruby) to get up and running.  If you have trouble getting set up, let me know - I'm always happy to help.
 
 ### Run the tests
 
@@ -145,7 +145,7 @@ is at http://rubydoc.info/gems/rouge/frames.
 
 We have [a guide][lexer-dev-doc] on lexer development in the documentation but you'll also learn a lot by reading through the existing lexers. 
 
-[lexer-dev-doc]: https://www.rubydoc.info/github/jneen/rouge/file/docs/LexerDevelopment.md
+[lexer-dev-doc]: https://www.rubydoc.info/github/rouge-ruby/rouge/file/docs/LexerDevelopment.md
 
 Please don't submit lexers that are largely copy-pasted from other files.
 

--- a/README.md
+++ b/README.md
@@ -141,86 +141,11 @@ To test a lexer visually, run `rackup` from the root and go to `localhost:9292/#
 
 is at http://rubydoc.info/gems/rouge/frames.
 
-### Using the lexer DSL
+### Developing lexers
 
-You can probably learn a lot just by reading through the existing lexers.  Basically, a lexer consists of a collection of states, each of which has several rules.  A rule consists of a regular expression and an action, which yields tokens and manipulates the state stack.  Each rule in the state on top of the stack is tried *in order* until a match is found, at which point the action is run, the match consumed from the stream, and the process repeated with the new lexer on the top of the stack.  Each lexer has a special state called `:root`, and the initial state stack consists of just this state.
+We have [a guide][lexer-dev-doc] on lexer development in the documentation but you'll also learn a lot by reading through the existing lexers. 
 
-Here's how you might use it:
-
-``` ruby
-class MyLexer < Rouge::RegexLexer
-  state :root do
-    # the "easy way"
-
-    # simple rules
-    rule /0x[0-9a-f]+/, Num::Hex
-
-    # simple state stack manipulation
-    rule /{-/, Comment, :next_state
-    rule /-}/, Comment, :pop!
-
-    # the "flexible way"
-    rule /abc/ do |m|
-      # m is the match, for accessing match groups manually
-
-      # you can do the following things:
-      pop!
-      push :another_state
-      push # assumed to be the current state
-      state? :some_state # check if the current state is :some_state
-      in_state? :some_state # check if :some_state is in the state stack
-
-      # yield a token.  if no second argument is supplied, the value is
-      # taken to be the whole match.
-      # The sum of all the tokens yielded must be equivalent to the whole
-      # match - otherwise characters will go missing from the user's input.
-      token Generic::Output, m[0]
-
-      # calls SomeOtherLexer.lex(str) and yields its output.  See the
-      # HTML lexer for a nice example of this.
-      # if no second argument is supplied, it is assumed to be the whole
-      # match string.
-      delegate SomeOtherLexer, str
-
-      # the context object is the lexer itself, so you can stash state here
-      @count ||= 0
-      @count += 1
-
-      # advanced: push a dynamically created anonymous state
-      push do
-        rule /.../, Generic::Output
-      end
-    end
-
-    rule /(\w+)(:)/ do
-      # "groups" yields the matched groups in order
-      groups Name::Label, Punctuation
-    end
-  end
-
-  start do
-    # this is run whenever a fresh lex is started
-  end
-end
-```
-
-If you're creating a lexer that's very similar to a different lexer, you can use subclassing (see C/C++/ObjC and also QML/Javascript for examples):
-
-``` ruby
-class MyLexer < OtherLexer
-  # independent states
-  state :my_state do ... end
-
-  # override states
-  state :your_state do ... end
-
-  # prepend rules to states
-  prepend :parent_state do ... end
-
-  # append rules to states
-  append :parent_state do ... end
-end
-```
+[lexer-dev-doc]: https://www.rubydoc.info/github/jneen/rouge/file/docs/LexerDevelopment.md
 
 Please don't submit lexers that are largely copy-pasted from other files.
 

--- a/docs/LexerDevelopment.md
+++ b/docs/LexerDevelopment.md
@@ -1,0 +1,376 @@
+# Lexer Development 
+
+## Overview
+
+A critical concept in the design of Rouge is the "lexer". A lexer converts
+ordinary text into a series of tokens that Rouge can then process.
+
+Rouge supports the languages it does by having a separate lexer for each
+language. Lexer development is important both for fixing Rouge when syntax isn't
+being highlighted properly and for adding languages that Rouge doesn't support.
+
+The remainder of this document explains how to develop a lexer for Rouge.
+
+<p class="note">
+  Please don't submit lexers that are largely copy-pasted from other files.
+  These submissions will be rejected.
+</p>
+
+## Getting Started
+
+A lexer is saved in the `lib/rouge/lexers/` directory and needs to be a subclass
+of the {Rouge::Lexer Lexer} abstract class. Most lexers are in fact subclassed
+from {Rouge::RegexLexer RegexLexer} as the simplest way to define the states of
+a lexer is to use rules consisting of regular expressions.
+
+You can learn a lot by reading through some of the existing lexers. A good
+example that's not too long is [the JSON lexer][json-lexer].
+
+[json-lexer]:
+https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/json.rb
+
+## Structure
+
+Basically, a lexer consists of two parts:
+
+1. a series of properties that are usually declared at the top of the lexer; and
+2. a collection of states, each of which has several rules.
+
+There are some additional features that a lexer can implement and we'll cover
+those at the end.
+
+Now, using [the JSON lexer][json-lexer] as an example, let's look at each of
+these parts in turn.
+
+### Lexer Properties
+
+To be usable by Rouge, a lexer should declare a **title**, a **description**, a
+**tag**, any **aliases**, associated **filenames** and associated
+**mimetypes**.
+
+#### Title
+
+```rb
+title "JSON"
+```
+
+The title of the lexer. It is declared using the {Rouge::Lexer.title
+Lexer.title} method. As a subclass of {Rouge::RegexLexer RegexLexer}, the JSON
+lexer inherits this method (and its inherited methods) into its namespace and
+can call those methods without needing to prefix each with `Rouge::Lexer`.
+This is the case with all of the property defining methods.
+
+#### Description
+
+```rb
+desc "JavaScript Object Notation (json.org)"
+```
+
+The description of the lexer. It is declared using the {Rouge::Lexer.desc
+Lexer.desc} method.
+
+#### Tag
+
+```rb
+tag "json"
+```
+
+The tag associated with the lexer. It is declared using the {Rouge::Lexer.tag
+Lexer.tag} method. A tag provides a way to specify the lexer that should apply
+to text within a given code block. In various flavours of Markdown, it's used
+after the opening of a code block, such as in the following example:
+
+    ```ruby
+    puts "This is some Ruby"
+    ```
+
+The `ruby` tag is defined in [the Ruby lexer][ruby-lexer].
+
+[ruby-lexer]:
+https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/ruby.rb
+
+#### Aliases
+
+The aliases associated with a lexer. These are declared using the
+{Rouge::Lexer.aliases Lexer.aliases} method. Aliases are alternative ways that
+the lexer can be identified.
+
+The JSON lexer does not define any aliases but [the Ruby one][ruby-lexer] does.
+We can see how it could be used by looking at another example in Markdown. This
+time, instead of specifying the tag after the opening of the code block, we'll
+use an alias instead:
+
+    ```rb
+    puts "This is still some Ruby"
+    ```
+
+#### Filenames
+
+```rb
+filenames "*.json"
+```
+
+The filename(s) associated with a lexer. These are declared using the
+{Rouge::Lexer.filenames Lexer.filenames} method. Filenames are declared as
+"globs" that will match a particular pattern. A "glob" may be merely the
+specific name of a file (eg. `Rakefile`) or it could include one or more
+wildcards (eg. `*.json`).
+
+#### Mimetypes
+
+```rb
+mimetypes "application/json", "application/vnd.api+json",
+          "application/hal+json"
+```
+
+The mimetype(s) associated with a lexer. These are declared using the
+{Rouge::Lexer.mimetypes Lexer.mimetypes} method.
+
+### Lexer States
+
+The other major element of a lexer is the collection of states. States
+themselves are made up of rules. For lexers that subclass {Rouge::RegexLexer
+RegexLexer}, a rule consists of a regular expression and an action. The action
+yields tokens and manipulates the state stack.
+
+The state stack represents the series of states through which the lexer has
+passed. The initial state is the `:root` state. A lexer works by looking at the
+rules that are in the state on top of the stack. These are tried *in order*
+until a match is found. At this point, the action defined in the rule is run,
+the match is removed from the input stream and the process is repeated with the
+state that is now on top of the stack.
+
+#### States
+
+```rb
+state :root do
+  # ...
+end
+```
+
+A state is defined using the {Rouge::RegexLexer.state RegexLexer.state} method.
+The method consists of the name of the state as a Keyword and a block specifying
+the rules that Rouge will try to match as it parses the text.
+
+#### Rules
+
+A rule for lexers that subclass {Rouge::RegexLexer RegexLexer} is defined using
+the {Rouge::RegexLexer::StateDSL#rule StateDSL#rule} method. The `rule` method
+can define either "simple" rules or "complex" rules.
+
+*Simple Rules*
+
+```rb
+rule /\s+/m, Text::Whitespace
+rule /"/, Str::Double, :string
+```
+A simple rule takes:
+
+1. a regular expression to match against;
+2. a token to yield if the regular expression matches; and
+3. an optional new state to push onto the state stack if the regular
+   expression matches.
+
+In the above example, there are two rules. The first rule yields the token
+`Text::Whitespace` but does not do anything to the state stack. The second rule
+yields the token `Str::Double` and adds the new state `:string` to the top of
+the state stack. The text being parsed after this point will now be processed by
+the rules in the `:string` state.
+
+The following code shows the definition for this state and the rules that are
+defined within it:
+
+```rb
+state :string do
+  rule /[^\\"]+/, Str::Double
+  rule /\\./, Str::Escape
+  rule /"/, Str::Double, :pop!
+end
+```
+
+The last rule features the "special state" `:pop!`. This is not really a state,
+rather it is an instruction to the lexer to remove the current state from the
+top of the state stack. In the JSON lexer, when we encounter the double
+quotation mark `"` we enter into the state of being "in a string" and when we
+next encounter the double quotation mark, we leave the string and return to the
+previous state (in this case, the `:root` state).
+
+*Complex Rules*
+
+It is possible to define more complex rules for a lexer by calling `rule` with:
+
+1. a regular expression to match against; and
+2. a block to call if the regular expression matches.
+
+The block called can take one argument, usually written as `m`, that contains
+the regular expression match.
+
+These kind of rules allow for more fine-grained control of the state stack.
+Inside a complex rule's block, it's possible to {Rouge::RegexLexer#push push},
+{Rouge::RegexLexer#pop! pop}, {Rouge::RegexLexer#token yield a token} and 
+{Rouge::RegexLexer#delegate delegate to another lexer}.
+
+You can see an example of these more complex rules in [the Ruby
+lexer][ruby-lexer].
+
+### Additional Features
+
+While the properties and states are the minimum elements of a lexer that should
+be implemented, a lexer can include additional features.
+
+#### Source Detection 
+
+```rb
+def self.detect?(text)
+  return true if text.shebang? 'ruby'
+end
+```
+Rouge will attempt to guess the appropriate lexer if it is not otherwise clear.
+If Rouge is unable to do this on the basis of any tag, associated filename or
+associated mimetype, it will try to detect the appopriate lexer on the basis of
+the text itself (the source). This is done by calling `self.detect?` on the
+possible lexer (a default `self.detect?` method is defined in {Rouge::Lexer
+Lexer} and simply returns `false`).
+
+A lexer can implement its own `self.detect?` method that takes as a parameter a
+{Rouge::TextAnalyzer TextAnalyzer} object. If the `self.detect?` method
+returns true, the lexer will be selected as the appropriate lexer.
+
+The `self.detect?` method is intended to work by looking at the shebang or
+doctype that identifies a piece of text. To make this easier, Rouge provides
+the {Rouge::TextAnalyzer#shebang TextAnalyzer#shebang} method and the
+{Rouge::TextAnalyzer#doctype TextAnalyzer#doctype} method.
+
+#### Special Words
+
+Programming languages typically reserve certain keywords as identifiers that
+have a special meaning in the language. To make regular expressions that search
+for these words easier, many lexers will put the applicable keywords in an array
+and assign them to a particular variable. These keywords can then be inserted
+into a regular expression using interpolation (see [the Ruby lexer][ruby-lexer]
+for an example).
+
+#### Startup
+
+```rb
+start do
+  push :expr_start
+  @heredoc_queue = []
+end
+```
+
+The {Rouge::RegexLexer.start RegexLexer.start} method can take a block that will
+be called on a "fresh lex".
+
+## Subclassing
+
+If a lexer is for a language that is very similar to a language with an existing
+lexer, it's possible to subclass the existing lexer. See
+[the C++ lexer][cpp-lexer] and [the JSX lexer][jsx-lexer] for examples.
+
+[cpp-lexer]: https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/cpp.rb
+[jsx-lexer]: https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/jsx.rb
+
+## Testing
+
+When submitting a lexer, it is important to include files to test it. There are
+three files that should be included:
+
+1. a **spec** that will run as part of Rouge's test suite;
+2. a **demo** that will be tested as part of Rouge's test suite; and;
+3. a **visual sample** of the various language constructs.
+
+### Spec
+
+A spec is a list of expectations that are tested as part of the test suite.
+Rouge uses the Minitest library for defining these expectations. For more
+information about Minitest, refer to [the documentation][minitest-docs].
+
+[minitest-docs]: http://docs.seattlerb.org/minitest/
+
+Your spec should at a minimum test how your lexer interacts with Rouge's
+guessing algorithm. In particular, you should check:
+
+* the associated filenames;
+* the associated mimetypes; and
+* the associated sources (if any).
+
+#### Filenames
+
+```rb
+it "guesses by filename" do
+  assert_guess :filename => "foo.rb"
+end
+```
+
+Each of the filenames that are declared in the lexer should be tested in the
+spec. [As discussed below][conflict-globs], if the associated filename glob
+conflicts with a filename glob defined in another lexer, you will need to write
+a disambiguation.
+
+[conflict-globs]: #Conflicting_Filename_Globs
+
+#### Mimetypes
+
+```rb
+it "guesses by mimetype" do
+  assert_guess :mimetype => "text/x-ruby"
+end
+```
+
+Each of the mimetypes that are declared in the lexer should be tested in the
+spec.
+
+#### Sources
+
+```rb
+it "guesses by source" do
+  assert_guess :source => "#!/usr/local/bin/ruby"
+end
+```
+
+If the lexer implements the `self.detect?` method, then each predicate that
+returns true should be tested.
+
+### Demo
+
+The demo file is tested automatically as part of Rouge's test suite. The file
+should be able to be parsed without producing any `Error` tokens.
+
+### Visual Sample
+
+While the visual sample is tested by the testing suite to ensure that it does
+not raise any errors, the primary purpose is to allow the user to quickly scan
+through a large sample of text in a particular language and make sure that the
+highlighting looks correct.
+
+## Gotchas
+
+### Conflicting Filename Globs
+
+If two or more lexers define the same filename glob, this will cause an
+{Rouge::Guesser::Ambiguous Ambiguous} error to be raised by certain guessing
+methods (including the one used by the `assert_guess` method used in your spec).
+
+The solution to this is to define a disambiguation procedure in the
+{Rouge::Guessers::Disambiguation Disambiguation} class. Here's the procedure for
+the `*.pl` filename glob as an example:
+
+```rb
+disambiguate "*.pl" do
+  next Perl if contains?("my $")
+  next Prolog if contains?(":-")
+  next Prolog if matches?(/\A\w+(\(\w+\,\s*\w+\))*\./)
+end
+```
+
+Then, in your spec, include a `:source` parameter when calling `assert_guess`:
+
+```rb
+it "guesses by filename" do
+	# *.pl needs source hints because it's also used by Prolog
+	assert_guess :filename => "foo.pl", :source => "my $foo = 1"
+end
+```
+
+Happy lexing!

--- a/docs/LexerDevelopment.md
+++ b/docs/LexerDevelopment.md
@@ -1,4 +1,6 @@
-# @title Lexer Development
+<!-- 
+# @title Lexer Development 
+--> 
 # Lexer Development
 
 ## Overview
@@ -7,35 +9,46 @@ A critical concept in the design of Rouge is the "lexer". A lexer converts
 ordinary text into a series of tokens that Rouge can then process.
 
 Rouge supports the languages it does by having a separate lexer for each
-language. Lexer development is important both for fixing Rouge when syntax isn't
-being highlighted properly and for adding languages that Rouge doesn't support.
+language. Lexer development is important both for fixing Rouge when syntax
+isn't being highlighted properly and for adding languages that Rouge doesn't
+support.
 
 The remainder of this document explains how to develop a lexer for Rouge.
 
 <p class="note">
-  Please don't submit lexers that are largely copy-pasted from other files.
+  Please don't submit lexers that are largely copy-pasted from other files. 
   These submissions will be rejected.
 </p>
 
 ## Getting Started
 
-A lexer is saved in the `lib/rouge/lexers/` directory and needs to be a subclass
-of the {Rouge::Lexer Lexer} abstract class. Most lexers are in fact subclassed
-from {Rouge::RegexLexer RegexLexer} as the simplest way to define the states of
-a lexer is to use rules consisting of regular expressions.
+This guide assumes a familiarity with git. If you're new to git, GitHub has
+[documentation][gh-git] that will help get you started.
+
+[gh-git]: https://help.github.com/en/articles/git-and-github-learning-resources
+
+Rouge automatically loads lexers saved in the `lib/rouge/lexers/` directory and
+so if you're submitting a new lexer, that's the right place to put it.
+
+Your lexer needs to be a subclass of the {Rouge::Lexer Lexer} abstract class.
+Most lexers are in fact subclassed from {Rouge::RegexLexer RegexLexer} as the
+simplest way to define the states of a lexer is to use rules consisting of
+regular expressions. The remainder of this guide assumes your lexer is
+subclassed from {Rouge::RegexLexer RegexLexer}.
 
 You can learn a lot by reading through some of the existing lexers. A good
 example that's not too long is [the JSON lexer][json-lexer].
 
 [json-lexer]:
-https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/json.rb
+https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/json.rb
 
-## Structure
+## How to Structure
 
 Basically, a lexer consists of two parts:
 
-1. a series of properties that are usually declared at the top of the lexer; and
-2. a collection of states, each of which has several rules.
+1. a series of properties that are usually declared at the top of the lexer;
+   and
+2. a collection of one or more states, each of which has one or more rules.
 
 There are some additional features that a lexer can implement and we'll cover
 those at the end.
@@ -56,10 +69,12 @@ title "JSON"
 ```
 
 The title of the lexer. It is declared using the {Rouge::Lexer.title
-Lexer.title} method. As a subclass of {Rouge::RegexLexer RegexLexer}, the JSON
-lexer inherits this method (and its inherited methods) into its namespace and
-can call those methods without needing to prefix each with `Rouge::Lexer`.
-This is the case with all of the property defining methods.
+Lexer.title} method.
+
+Note: As a subclass of {Rouge::RegexLexer RegexLexer}, the JSON lexer inherits
+this method (and its inherited methods) into its namespace and can call those
+methods without needing to prefix each with `Rouge::Lexer`.  This is the case
+with all of the property defining methods.
 
 #### Description
 
@@ -77,9 +92,11 @@ tag "json"
 ```
 
 The tag associated with the lexer. It is declared using the {Rouge::Lexer.tag
-Lexer.tag} method. A tag provides a way to specify the lexer that should apply
-to text within a given code block. In various flavours of Markdown, it's used
-after the opening of a code block, such as in the following example:
+Lexer.tag} method.
+
+A tag provides a way to specify the lexer that should apply to text within a
+given code block. In various flavours of Markdown, it's used after the opening
+of a code block, such as in the following example:
 
     ```ruby
     puts "This is some Ruby"
@@ -88,7 +105,7 @@ after the opening of a code block, such as in the following example:
 The `ruby` tag is defined in [the Ruby lexer][ruby-lexer].
 
 [ruby-lexer]:
-https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/ruby.rb
+https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/ruby.rb
 
 #### Aliases
 
@@ -112,16 +129,16 @@ filenames "*.json"
 ```
 
 The filename(s) associated with a lexer. These are declared using the
-{Rouge::Lexer.filenames Lexer.filenames} method. Filenames are declared as
-"globs" that will match a particular pattern. A "glob" may be merely the
-specific name of a file (eg. `Rakefile`) or it could include one or more
-wildcards (eg. `*.json`).
+{Rouge::Lexer.filenames Lexer.filenames} method.
+
+Filenames are declared as "globs" that will match a particular pattern. A
+"glob" may be merely the specific name of a file (eg. `Rakefile`) or it could
+include one or more wildcards (eg. `*.json`).
 
 #### Mimetypes
 
 ```rb
-mimetypes "application/json", "application/vnd.api+json",
-          "application/hal+json"
+mimetypes "application/json", "application/vnd.api+json", "application/hal+json"
 ```
 
 The mimetype(s) associated with a lexer. These are declared using the
@@ -129,35 +146,42 @@ The mimetype(s) associated with a lexer. These are declared using the
 
 ### Lexer States
 
-The other major element of a lexer is the collection of states. States
-themselves are made up of rules. For lexers that subclass {Rouge::RegexLexer
-RegexLexer}, a rule consists of a regular expression and an action. The action
-yields tokens and manipulates the state stack.
+The other major element of a lexer is the collection of one or more states.
+For lexers that subclass {Rouge::RegexLexer RegexLexer}, a state will consist
+of one or more rules with a rule consisting of a regular expression and an
+action. The action yields tokens and manipulates the _state stack_.
+
+#### The State Stack
 
 The state stack represents the series of states through which the lexer has
-passed. The initial state is the `:root` state. A lexer works by looking at the
-rules that are in the state on top of the stack. These are tried *in order*
-until a match is found. At this point, the action defined in the rule is run,
-the match is removed from the input stream and the process is repeated with the
-state that is now on top of the stack.
+passed. States are added and removed from the "top" of the stack. The oldest
+state is on the bottom of the stack and the newest state is on the top.
+
+The initial (and therefore bottommost) state is the `:root` state. The lexer
+works by looking at the rules that are in the state that is on top of the
+stack. These are tried _in order_ until a match is found. At this point, the
+action defined in the rule is run, the match is removed from the input stream
+and the process is repeated with the state that is now on top of the stack.
+
+Now that we've explained the concepts, let's look at how you actually define
+these elements in your lexer.
 
 #### States
 
 ```rb
-state :root do
-  # ...
+state :root do 
+  ... # do some stuff
 end
 ```
 
 A state is defined using the {Rouge::RegexLexer.state RegexLexer.state} method.
-The method consists of the name of the state as a Keyword and a block specifying
-the rules that Rouge will try to match as it parses the text.
+The method consists of the name of the state as a `Symbol` and a block
+specifying the rules that Rouge will try to match as it parses the text.
 
 #### Rules
 
-A rule for lexers that subclass {Rouge::RegexLexer RegexLexer} is defined using
-the {Rouge::RegexLexer::StateDSL#rule StateDSL#rule} method. The `rule` method
-can define either "simple" rules or "complex" rules.
+A rule is defined using the {Rouge::RegexLexer::StateDSL#rule StateDSL#rule}
+method. The `rule` method can define either "simple" rules or "complex" rules.
 
 *Simple Rules*
 
@@ -165,26 +189,27 @@ can define either "simple" rules or "complex" rules.
 rule /\s+/m, Text::Whitespace
 rule /"/, Str::Double, :string
 ```
+
 A simple rule takes:
 
 1. a regular expression to match against;
 2. a token to yield if the regular expression matches; and
-3. an optional new state to push onto the state stack if the regular
-   expression matches.
+3. an optional new state to push onto the state stack if the regular expression
+   matches.
 
 In the above example, there are two rules. The first rule yields the token
 `Text::Whitespace` but does not do anything to the state stack. The second rule
 yields the token `Str::Double` and adds the new state `:string` to the top of
-the state stack. The text being parsed after this point will now be processed by
-the rules in the `:string` state.
+the state stack. The text being parsed after this point will now be processed
+by the rules in the `:string` state.
 
 The following code shows the definition for this state and the rules that are
 defined within it:
 
 ```rb
 state :string do
-  rule /[^\\"]+/, Str::Double
-  rule /\\./, Str::Escape
+  rule /[^\\"]+/, Str::Double 
+  rule /\\./, Str::Escape 
   rule /"/, Str::Double, :pop!
 end
 ```
@@ -204,11 +229,11 @@ It is possible to define more complex rules for a lexer by calling `rule` with:
 2. a block to call if the regular expression matches.
 
 The block called can take one argument, usually written as `m`, that contains
-the regular expression match.
+the regular expression match object.
 
 These kind of rules allow for more fine-grained control of the state stack.
 Inside a complex rule's block, it's possible to {Rouge::RegexLexer#push push},
-{Rouge::RegexLexer#pop! pop}, {Rouge::RegexLexer#token yield a token} and 
+{Rouge::RegexLexer#pop! pop}, {Rouge::RegexLexer#token yield a token} and
 {Rouge::RegexLexer#delegate delegate to another lexer}.
 
 You can see an example of these more complex rules in [the Ruby
@@ -216,16 +241,17 @@ lexer][ruby-lexer].
 
 ### Additional Features
 
-While the properties and states are the minimum elements of a lexer that should
-be implemented, a lexer can include additional features.
+While the properties and states are the minimum elements of a lexer that need
+to be implemented, a lexer can include additional features.
 
 #### Source Detection 
 
 ```rb
 def self.detect?(text)
   return true if text.shebang? 'ruby'
-end
+end 
 ```
+
 Rouge will attempt to guess the appropriate lexer if it is not otherwise clear.
 If Rouge is unable to do this on the basis of any tag, associated filename or
 associated mimetype, it will try to detect the appopriate lexer on the basis of
@@ -234,22 +260,48 @@ possible lexer (a default `self.detect?` method is defined in {Rouge::Lexer
 Lexer} and simply returns `false`).
 
 A lexer can implement its own `self.detect?` method that takes as a parameter a
-{Rouge::TextAnalyzer TextAnalyzer} object. If the `self.detect?` method
-returns true, the lexer will be selected as the appropriate lexer.
+{Rouge::TextAnalyzer TextAnalyzer} object. If the `self.detect?` method returns
+true, the lexer will be selected as the appropriate lexer.
 
 The `self.detect?` method is intended to work by looking at the shebang or
 doctype that identifies a piece of text. To make this easier, Rouge provides
 the {Rouge::TextAnalyzer#shebang TextAnalyzer#shebang} method and the
-{Rouge::TextAnalyzer#doctype TextAnalyzer#doctype} method.
+{Rouge::TextAnalyzer#doctype TextAnalyzer#doctype} method. For more general
+disambiguation between different lexers, see [Conflicting Filename
+Globs][conflict-globs] below.
+
+[conflict-globs]: #Conflicting_Filename_Globs
 
 #### Special Words
 
-Programming languages typically reserve certain keywords as identifiers that
+Every programming language reserves certain words for use as identifiers that
 have a special meaning in the language. To make regular expressions that search
-for these words easier, many lexers will put the applicable keywords in an array
-and assign them to a particular variable. These keywords can then be inserted
-into a regular expression using interpolation (see [the Ruby lexer][ruby-lexer]
-for an example).
+for these words easier, many lexers will put the applicable keywords in an
+array and make them available in a particular way (be it as a local variable,
+an instance variable or what have you).
+
+We recommend lexers use a class method:
+
+```rb
+module Rouge
+  module Lexers
+    class YetAnotherLanguage < RegexLexer
+    ...
+
+    def self.keywords
+      @keywords ||= %w(key words used in this language)
+    end
+
+    ...
+  end
+end
+```
+
+These keywords can then be included in a regular expression like so:
+
+```rb
+rule /(#{keywords.join('|')})\b/, Keyword
+```
 
 #### Startup
 
@@ -260,19 +312,62 @@ start do
 end
 ```
 
-The {Rouge::RegexLexer.start RegexLexer.start} method can take a block that will
-be called on a "fresh lex".
+The {Rouge::RegexLexer.start RegexLexer.start} method can take a block that
+will be called when the lexer commences lexing. This provides a way to enter
+into a special state "before" entering into the `:root` state (the `:root`
+state is still the bottommost state in the state stack; the state pushed by
+`start` sits "on top" but is the state in which the lexer begins.
 
-## Subclassing
+Why would you want to do this? In some languages, there may be language
+structures that can appear at the beginning of a file. {Rouge::RegexLexer.start
+RegexLexer.start} provides a way to parse these structures. An example is a
+preprocessor directive in C. You can see how these are lexed in [the C
+lexer][c-lexer].
 
-If a lexer is for a language that is very similar to a language with an existing
-lexer, it's possible to subclass the existing lexer. See
-[the C++ lexer][cpp-lexer] and [the JSX lexer][jsx-lexer] for examples.
+[c-lexer]: https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/c.rb 
 
-[cpp-lexer]: https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/cpp.rb
-[jsx-lexer]: https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/jsx.rb
+### Subclassing
 
-## Testing
+If a lexer is for a language that is very similar to a language with an
+existing lexer, it's possible to subclass the existing lexer. See [the C++
+lexer][cpp-lexer] and [the JSX lexer][jsx-lexer] for examples.
+
+[cpp-lexer]: https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/cpp.rb
+[jsx-lexer]: https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/jsx.rb
+
+### Gotchas
+
+#### Conflicting Filename Globs
+
+If two or more lexers define the same filename glob, this will cause an
+{Rouge::Guesser::Ambiguous Ambiguous} error to be raised by certain guessing
+methods (including the one used by the `assert_guess` method used in your
+spec).
+
+The solution to this is to define a disambiguation procedure in the
+{Rouge::Guessers::Disambiguation Disambiguation} class. Here's the procedure
+for the `*.pl` filename glob as an example:
+
+```rb
+disambiguate "*.pl" do
+  next Perl if contains?("my $")
+  next Prolog if contains?(":-")
+  next Prolog if matches?(/\A\w+(\(\w+\,\s*\w+\))*\./)
+end
+```
+
+Then, in [your spec][specs], include a `:source` parameter when calling
+`assert_guess`:
+
+[specs]: #Specs
+
+```rb
+it "guesses by filename" do
+  # *.pl needs source hints because it's also used by Prolog
+  assert_guess :filename => "foo.pl", :source => "my $foo = 1"
+end
+```
+## How to Test
 
 When submitting a lexer, it is important to include files to test it. There are
 three files that should be included:
@@ -281,7 +376,7 @@ three files that should be included:
 2. a **demo** that will be tested as part of Rouge's test suite; and;
 3. a **visual sample** of the various language constructs.
 
-### Spec
+### Specs
 
 A spec is a list of expectations that are tested as part of the test suite.
 Rouge uses the Minitest library for defining these expectations. For more
@@ -304,12 +399,10 @@ it "guesses by filename" do
 end
 ```
 
-Each of the filenames that are declared in the lexer should be tested in the
-spec. [As discussed below][conflict-globs], if the associated filename glob
+Each of the filename globs that are declared in the lexer should be tested in
+the spec. [As discussed above][conflict-globs], if the associated filename glob
 conflicts with a filename glob defined in another lexer, you will need to write
 a disambiguation.
-
-[conflict-globs]: #Conflicting_Filename_Globs
 
 #### Mimetypes
 
@@ -333,45 +426,40 @@ end
 If the lexer implements the `self.detect?` method, then each predicate that
 returns true should be tested.
 
-### Demo
+### Demos
 
 The demo file is tested automatically as part of Rouge's test suite. The file
 should be able to be parsed without producing any `Error` tokens.
 
-### Visual Sample
+### Visual Samples
 
 While the visual sample is tested by the testing suite to ensure that it does
 not raise any errors, the primary purpose is to allow the user to quickly scan
 through a large sample of text in a particular language and make sure that the
 highlighting looks correct.
 
-## Gotchas
+If you are adding or fixing rules in the lexer, please add some examples of the
+expressions that will be highlighted differently to the visual sample if
+they're not already present. This greatly assists in reviewing your lexer
+submission.
 
-### Conflicting Filename Globs
+## How to Submit
 
-If two or more lexers define the same filename glob, this will cause an
-{Rouge::Guesser::Ambiguous Ambiguous} error to be raised by certain guessing
-methods (including the one used by the `assert_guess` method used in your spec).
+So you've developed a lexer (or fixed an existing one)—that's great! The basic
+workflow for a lexer to be submitted is:
 
-The solution to this is to define a disambiguation procedure in the
-{Rouge::Guessers::Disambiguation Disambiguation} class. Here's the procedure for
-the `*.pl` filename glob as an example:
+1. you make a pull request;
+2. a maintainer reviews the lexer;
+3. the maintainer suggests any changes that need to be made;
+4. you make the necessary changes;
+5. the maintainer accepts the request and merges in the code; and
+6. the lexer is included in a future release of the Rouge gem.
 
-```rb
-disambiguate "*.pl" do
-  next Perl if contains?("my $")
-  next Prolog if contains?(":-")
-  next Prolog if matches?(/\A\w+(\(\w+\,\s*\w+\))*\./)
-end
-```
+Now you're on your way to fame and glory! (Maybe.)
 
-Then, in your spec, include a `:source` parameter when calling `assert_guess`:
+If you haven't submitted a pull request before, GitHub has [excellent
+documentation][gh-pr] that will help you get accustomed to the workflow.
 
-```rb
-it "guesses by filename" do
-	# *.pl needs source hints because it's also used by Prolog
-	assert_guess :filename => "foo.pl", :source => "my $foo = 1"
-end
-```
+[gh-pr]: https://help.github.com/en/articles/about-pull-requests
 
-Happy lexing!
+We're looking forward to seeing your code!

--- a/docs/LexerDevelopment.md
+++ b/docs/LexerDevelopment.md
@@ -1,4 +1,5 @@
-# Lexer Development 
+# @title Lexer Development
+# Lexer Development
 
 ## Overview
 

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -236,6 +236,13 @@ module Rouge
 
       # Specify a list of filename globs associated with this lexer.
       #
+      # If a filename glob is associated with more than one lexer, this can
+      # cause a Guesser::Ambiguous error to be raised in various guessing
+      # methods. These errors can be avoided by disambiguation. Filename globs
+      # are disambiguated in one of two ways. Either the lexer will define a
+      # `self.detect?` method (intended for use with shebangs and doctypes) or a
+      # manual rule will be specified in Guessers::Disambiguation.
+      #
       # @example
       #   class Ruby < Lexer
       #     filenames '*.rb', '*.ruby', 'Gemfile', 'Rakefile'


### PR DESCRIPTION
Rouge does not have a single document explaining how a lexer should be developed. The README contains a simplified example and there are existing lexers that can be looked at for reference but these are inconsistent and do not clearly explain some of the more difficult elements (eg. disambiguating conflicting filename globs).

This commit adds a docs directory with a basic guide. The guide is written in Markdown and so is viewable directly on GitHub but it is intended for use with YARD and uses YARD tags for cross referencing. For this reason, the commit also updates the `.yardopts` file. The README is also updated to refer to this guide.