### PR TITLE
Change Rubies to target for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,14 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-  - "2.0"
-  - "2.1"
-  - "2.2"
   - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
 
 cache:
   bundler: true
 bundler_args: --without development
-before_install:
-  - gem install bundler
-  - gem update --system
 script:
   - bundle exec rake
   - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'bundler', '~> 1.15'
 gem 'rake'
 
 gem 'minitest', '>= 5.0'


### PR DESCRIPTION
The purpose of #1110 is to get tests to work on Travis again as quickly as possible. To that end, it seeks to maintain as much as possible the current testing environment so as to avoid a longer policy discussion about what versions of Ruby to test.

This PR is intended to be a complement to #1110. It does propose a policy change: namely, that _**Rouge should drop support for Rubies prior to 2.3**_. It removes older Rubies from those tested by Travis and removes cruft from Gemfile that is no longer needed once older Rubies are dropped. It also adds 2.6 as a target.

The rationale for dropping support is, essentially, that Rubies prior to 2.3 are too old. Ruby 2.3 is itself no longer supported but since this support only ended in March 2019, it seems reasonable to keep it in the rotation for a little longer.

The counterargument is that Rouge is an important library and that, since we are not depending on features that are not in prior Rubies, we should maintain support as long as possible. As @mojavelinux said in #269 in the context of removing Ruby 1.9 from the Travis builds:

> Rouge is a pretty fundamental library, so we want to be sure that no downstream programs still have a Ruby 1.9.3 requirement. Otherwise Rouge forces that decision, which I don't think is appropriate.

If accepted, this would close #1062 as it would no longer be necessary. It would also close #1081.