### PR TITLE
Fix string parsing in Coq lexer

### DIFF
--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -141,7 +141,7 @@ module Rouge
       end
 
       state :string do
-        rule /[^\\"]+/, Str::Double
+        rule /(?:\\")+|[^"]/, Str::Double
         mixin :escape_sequence
         rule /\\\n/, Str::Double
         rule /"/, Str::Double, :pop!

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -11,3 +11,5 @@ Section with_T.
 End with_T.
 
 Definition a_string := "hello\" world".
+
+Notation "A /\ B" := (and A B) : type_scope.


### PR DESCRIPTION
As identified in #1105, there is an error in the Coq lexer where strings containing a backslash are not parsed correctly. This fixes #1105.