### PR TITLE
Fix rendering of C# attributes

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -71,7 +71,6 @@ module Rouge
       state :root do
         mixin :whitespace
 
-        rule /^\s*\[.*?\]/, Name::Attribute
         rule /[$]\s*"/, Str, :splice_string
         rule /[$]@\s*"/, Str, :splice_literal
 

--- a/spec/visual/samples/csharp
+++ b/spec/visual/samples/csharp
@@ -2,6 +2,7 @@ interface IFoo {
   // stuff
 }
 
+[Bar("foo/[bar]")]
 class Foo {
   // stuff
 }


### PR DESCRIPTION
The C# lexer generated `Name::Attribute` tokens for attributes. As discussed in #1093, this caused attributes to be rendered incorrectly. This commit removes the rule that caused attributes to be rendered this way. It fixes #1093.