### PR TITLE
Fix untyped methods in Objective-C lexer

### DIFF
--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -160,8 +160,10 @@ module Rouge
           ([(].*?[)])?(\s*)
           (?=#{id}:?)
         )ix do |m|
-          token Keyword, m[1]; token Text, m[2]
-          recurse m[3]; token Text, m[4]
+          token Keyword, m[1]
+          token Text, m[2]
+          recurse(m[3]) if m[3]
+          token Text, m[4]
           push :method_definition
         end
       end

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -37,6 +37,10 @@ void (^simpleBlock)(void) = ^{
     NSLog(@"This is a block");
 };
 
+- foo:(id) foo {
+    [self bar:foo];
+}
+
 [[SomeClass] inlineBlock:(^NSString *){
     NSString *var = @"blah";
     return var;


### PR DESCRIPTION
The Objective-C lexer prepends a rule to the `:root` state that is intended to match a method definition. Although the regular expression indicates that the return type of the method may not match anything, it was nevertheless passing the result to `RegexLexer#recurse` regardless of whether it was nil or not.

If this occurred with an untyped instance method, the output would insert an additional `-` in the output. Checking whether to call `RegexLexer#recurse` on the basis of whether the value was non-nil fixed the problem. This fixes #1076.