### PR TITLE
Fix escape sequences in Rust lexer

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -56,7 +56,7 @@ module Rouge
       id = /[a-z_]\w*/i
       hex = /[0-9a-f]/i
       escapes = %r(
-        \\ ([nrt'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
+        \\ ([nrt'"\\0] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
       )x
       size = /8|16|32|64/
 

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -18,6 +18,11 @@ fn main() {
 
 let mut f = File::open("username.txt")?;
 
+println!("a\\");
+println!("a\n");
+println!("a\"b");
+println!("a\'");
+
 debug!("test %?", a.b);
 debug!("test %u", a.c);
 debug!("test %i", a.d);


### PR DESCRIPTION
As discussed in #1075, escaped double quotes were not being interpreted correctly. This was due to an escaped double quote not being included in the escape sequence regex in the Rust lexer.

This commit adds the double quote and the numeral zero (the null character). See:
https://static.rust-lang.org/doc/master/reference.html#characters-and-strings

This fixes #1075.