### PR TITLE
Fix nested block comments in Kotlin lexer

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -73,7 +73,8 @@ module Rouge
         rule %r'[^\S\n]+', Text
         rule %r'\\\n', Text # line continuation
         rule %r'//.*?$', Comment::Single
-        rule %r'/[*].*?[*]/'m, Comment::Multiline
+        rule %r'/[*].*[*]/', Comment::Multiline # single line block comment
+        rule %r'/[*].*', Comment::Multiline, :comment # multiline block comment
         rule %r'\n', Text
         rule %r'::|!!|\?[:.]', Operator
         rule %r"(\.\.)", Operator
@@ -121,6 +122,12 @@ module Rouge
         rule %r'(\))', Punctuation, :pop!
         rule %r'(\s+)', Text
         rule id, Name::Property
+      end
+
+      state :comment do
+        rule %r'\s*/[*].*', Comment::Multiline, :comment
+        rule %r'.*[*]/', Comment::Multiline, :pop!
+        rule %r'.*', Comment::Multiline
       end
     end
   end

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -1,4 +1,11 @@
 /**
+ * Nested
+ /**
+  * Comments
+  */
+*/
+
+/**
  * This is a straightforward implementation of The Game of Life
  * See http://en.wikipedia.org/wiki/Conway's_Game_of_Life
  */


### PR DESCRIPTION
Kotlin supports nested block comments. As noted in #1049, the Kotlin lexer does not handle these comments properly. This commit allows for arbitrarily nested comments. It fixes #1049.