### PR TITLE
Fix whitespace tokenisation in Go lexer

### DIFF
--- a/lib/rouge/lexers/go.rb
+++ b/lib/rouge/lexers/go.rb
@@ -149,7 +149,7 @@ module Rouge
         rule(OPERATOR,              Operator)
         rule(SEPARATOR,             Punctuation)
         rule(IDENTIFIER,            Name)
-        rule(WHITE_SPACE,           Other)
+        rule(WHITE_SPACE,           Text)
       end
 
       state :root do


### PR DESCRIPTION
As discussed in #1097, the Go lexer tokenises whitespace using the `Other` token. This causes issues when rendering in HTML the code parsed by Rouge because:

1. the use of `Other` will result in the whitespace being wrapped in separate HTML tags, which in turn causes
2. all newlines to be collapsed (due to CSS rules that expect newlines not to be wrapped in seperate HTML tags).

The `Other` token's intended use is described as follows:

> Token for data not matched by a parser (e.g. HTML markup in PHP code)

This is not a correct characterisation of whitespace in Go and is not consistent with other lexers. This commit changes the token to `Text`, the token generally used by other lexers. It fixes #1097.