### PR TITLE
Fix comments in CoffeeScript lexer

### DIFF
--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -43,7 +43,7 @@ module Rouge
 
       state :comments_and_whitespace do
         rule /\s+/m, Text
-        rule /###\s*\n.*?###/m, Comment::Multiline
+        rule /###[^#].*?###/m, Comment::Multiline
         rule /#.*$/, Comment::Single
       end
 

--- a/spec/visual/samples/coffeescript
+++ b/spec/visual/samples/coffeescript
@@ -2,6 +2,10 @@
 a multiline comment
 ###
 
+###*
+a multiline comment with extra characters
+###
+
 # The following line of hashes does not start a multiline comment
 #################
 


### PR DESCRIPTION
As discussed in #1045, the CoffeeScript lexer is not correctly lexing CoffeeScript comments that have a non-whitespace character after the `###` comment delimiter. This commit fixes the regular expression used by the appropriate rule to be consistent with how this code should be parsed. This fixes #1045.