### PR TITLE
Improve specificity of tokens in Java lexer

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -24,6 +24,8 @@ module Rouge
       types = %w(boolean byte char double float int long short var void)
 
       id = /[a-zA-Z_][a-zA-Z0-9_]*/
+      const_name = /[A-Z][A-Z0-9_]*\b/
+      class_name = /[A-Z][a-zA-Z]*\b/
 
       state :root do
         rule /[^\S\n]+/, Text
@@ -59,6 +61,8 @@ module Rouge
         end
 
         rule /#{id}:/, Name::Label
+        rule const_name, Name::Constant
+        rule class_name, Name::Class
         rule /\$?#{id}/, Name
         rule /[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
 

--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -25,7 +25,7 @@ module Rouge
 
       id = /[a-zA-Z_][a-zA-Z0-9_]*/
       const_name = /[A-Z][A-Z0-9_]*\b/
-      class_name = /[A-Z][a-zA-Z]*\b/
+      class_name = /[A-Z][a-zA-Z0-9]*\b/
 
       state :root do
         rule /[^\S\n]+/, Text


### PR DESCRIPTION
As discussed in #1043, the Java lexer does not attempt to differentiate between different types of identifiers (eg. constants, classes, variables). This commit uses the naming conventions in Java to provide more specific tokens for constants and classes. It fixes #1043.