### PR TITLE
Update Travis to check Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - "2.3"
   - "2.4"
   - "2.5"
+  - "2.6"
 cache:
   bundler: true
 bundler_args: --without development


### PR DESCRIPTION
This updates the Travis configuration file to check against Ruby 2.6.