### PR TITLE
Fix unbalanced parenthesis crash in Common Lisp lexer

### DIFF
--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -320,7 +320,7 @@ module Rouge
 
         rule /\(/, Punctuation, :root
         rule /\)/, Punctuation do
-          if stack.empty?
+          if stack.size == 1
             token Error
           else
             token Punctuation

--- a/spec/lexers/common_lisp_spec.rb
+++ b/spec/lexers/common_lisp_spec.rb
@@ -18,4 +18,12 @@ describe Rouge::Lexers::CommonLisp do
       assert_guess :mimetype => 'text/x-common-lisp'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'does not crash on unbalanced parentheses' do
+      subject.lex(")\n").to_a
+    end
+  end
 end

--- a/spec/visual/samples/common_lisp
+++ b/spec/visual/samples/common_lisp
@@ -1,5 +1,8 @@
 #nil (commented (form ftw))
 
+; Unmatched closing parenthesis
+)
+
 ;;;; TYPEP und Verwandtes
 ;;;; Michael Stoll, 21. 10. 1988
 ;;;; Bruno Haible, 10.6.1989


### PR DESCRIPTION
The Common Lisp lexer attempted to guard against an unmatched closing parenthesis being used by checking whether the stack of states was empty.

This misunderstood the way the stack is used. The stack should always have at least one state (the bottom-most :root state). Popping this state will cause an empty stack error to be thrown (as noted in #1102).

The correct guard is to check whether the size of the stack is 1. If it is, then we have an unmatched closing parenthesis and should generate an error token. This fixes #1102.