### PR TITLE
Slim Lexer: Fix multiline ruby code

### DIFF
--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -172,9 +172,9 @@ module Rouge
         # Need at top
         mixin :indented_block
 
-        rule(/,\s*\n/) { delegate ruby }
+        rule(/[,\\]\s*\n/) { delegate ruby }
         rule /[ ]\|[ \t]*\n/, Str::Escape
-        rule(/.*?(?=(,$| \|)?[ \t]*$)/) { delegate ruby }
+        rule(/.*?(?=([,\\]$| \|)?[ \t]*$)/) { delegate ruby }
       end
 
       state :filter_block do

--- a/spec/lexers/slim_spec.rb
+++ b/spec/lexers/slim_spec.rb
@@ -19,4 +19,28 @@ describe Rouge::Lexers::Slim do
     end
   end
 
+  describe 'multi line ruby code' do
+    it 'handles comma at the end of the line' do
+      assert_tokens_equal "= puts 1,\n2",
+        ['Punctuation', '='],
+        ['Text', ' '],
+        ['Name.Builtin', 'puts'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '1'],
+        ['Punctuation', ","],
+        ['Text', "\n"],
+        ['Literal.Number.Integer', '2']
+    end
+
+    it 'handles backslash at the end of the line' do
+      assert_tokens_equal "= puts \\\n1",
+        ['Punctuation', '='],
+        ['Text', ' '],
+        ['Name.Builtin', 'puts'],
+        ['Text', ' '],
+        ['Punctuation', "\\"],
+        ['Text', "\n"],
+        ['Literal.Number.Integer', '1']
+    end
+  end
 end

--- a/spec/visual/samples/slim
+++ b/spec/visual/samples/slim
@@ -9,7 +9,7 @@ html
 
     / Inline nested ruby expressions
     p Nested interp #{list.map { |x| x + 1 }.inject(&:+)} parses ok
-    
+
     /! HTML comment
     #content
       p This example shows you how a basic Slim file looks like.
@@ -61,6 +61,14 @@ html
             tr
               td.name = item.name
               td.price = item.price
+              td.spec
+                = render( \
+                    partial: 'item_spec',
+                    locals: { \
+                      item: item,
+                    },
+                  )
+
       - else
         p<
          | No items found.  Please add some inventory.


### PR DESCRIPTION
This change fixes lexing of multiline string using `\` at the end of the line.

Example:

```
= render( \
    partial: 'foo',
    locals: { \
      foo: :bar,
    },
  )
```