### PR TITLE
Configure YARD to document protected code

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
 --no-private
+--protected
 --markup-provider=redcarpet
 --markup=markdown


### PR DESCRIPTION
By default, YARD does not document code marked private or protected. There are important elements of Rouge (such as the `Rouge::RegexLexer::StateDSL#rule` method) that are marked protected but are intended for broad use. This ensures that documentation is generated for those elements.