### PR TITLE
Coerce state names into symbols instead of strings

### DIFF
--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -183,18 +183,18 @@ module Rouge
     # Define a new state for this lexer with the given name.
     # The block will be evaluated in the context of a {StateDSL}.
     def self.state(name, &b)
-      name = name.to_s
+      name = name.to_sym
       state_definitions[name] = StateDSL.new(name, &b)
     end
 
     def self.prepend(name, &b)
-      name = name.to_s
+      name = name.to_sym
       dsl = state_definitions[name] or raise "no such state #{name.inspect}"
       replace_state(name, dsl.prepended(&b))
     end
 
     def self.append(name, &b)
-      name = name.to_s
+      name = name.to_sym
       dsl = state_definitions[name] or raise "no such state #{name.inspect}"
       replace_state(name, dsl.appended(&b))
     end
@@ -204,7 +204,7 @@ module Rouge
       return name if name.is_a? State
 
       states[name.to_sym] ||= begin
-        defn = state_definitions[name.to_s] or raise "unknown state: #{name.inspect}"
+        defn = state_definitions[name.to_sym] or raise "unknown state: #{name.inspect}"
         defn.to_state(self)
       end
     end
@@ -421,15 +421,15 @@ module Rouge
 
     # Check if `state_name` is in the state stack.
     def in_state?(state_name)
-      state_name = state_name.to_s
+      state_name = state_name.to_sym
       stack.any? do |state|
-        state.name == state_name.to_s
+        state.name == state_name.to_sym
       end
     end
 
     # Check if `state_name` is the state on top of the state stack.
     def state?(state_name)
-      state_name.to_s == state.name
+      state_name.to_sym == state.name
     end
 
   private


### PR DESCRIPTION
Based on https://github.com/rouge-ruby/rouge/issues/1135#issuecomment-497524595 and https://github.com/rouge-ruby/rouge/issues/1135#issuecomment-497524996

## Summary
*If state name is already a Symbol, use that directly. Otherwise, convert the String name into a Symbol*

## Gotcha
Unhandled exception if state name doesn't respond to `:to_sym`