### PR TITLE
Initialize a rule pattern for whitespace just once

### DIFF
--- a/lib/rouge/lexers/abap.rb
+++ b/lib/rouge/lexers/abap.rb
@@ -182,7 +182,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
 
         rule /".*/, Comment::Single
         rule %r(^\*.*), Comment::Multiline

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'application/x-actionscript'
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end

--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -31,7 +31,7 @@ module Rouge
 
       state :whitespace do
         rule /\#.*/, Comment
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
       end
 
       state :root do

--- a/lib/rouge/lexers/apple_script.rb
+++ b/lib/rouge/lexers/apple_script.rb
@@ -319,7 +319,7 @@ module Rouge
       identifiers = %r(\b([a-zA-Z]\w*)\b)
 
       state :root do
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
         rule /¬\n/, Literal::String::Escape
         rule /'s\s+/, Text
         rule /(--|#).*?$/, Comment::Single

--- a/lib/rouge/lexers/awk.rb
+++ b/lib/rouge/lexers/awk.rb
@@ -47,7 +47,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(#.*?$), Comment::Single
       end
 

--- a/lib/rouge/lexers/biml.rb
+++ b/lib/rouge/lexers/biml.rb
@@ -33,7 +33,7 @@ module Rouge
       end
 
       state :directive_tag do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[\w.:-]+\s*=/m, Name::Attribute, :attr
         rule /[\w]+\s*/m, Name::Attribute
         rule %r(/?\s*#>), Name::Tag, :pop!

--- a/lib/rouge/lexers/cfscript.rb
+++ b/lib/rouge/lexers/cfscript.rb
@@ -97,7 +97,7 @@ module Rouge
 
       # same as java, broken out
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
@@ -145,7 +145,7 @@ module Rouge
       end
 
       state :import do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
       end
 

--- a/lib/rouge/lexers/clojure.rb
+++ b/lib/rouge/lexers/clojure.rb
@@ -75,7 +75,7 @@ module Rouge
 
       state :root do
         rule /;.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
 
         rule /-?\d+\.\d+/, Num::Float
         rule /-?\d+/, Num::Integer

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -50,7 +50,7 @@ module Rouge
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/
 
       state :comments_and_whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /###[^#].*?###/m, Comment::Multiline
         rule /#.*$/, Comment::Single
       end

--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -215,7 +215,7 @@ module Rouge
       symbol = /(\|[^\|]+\||#{nonmacro}#{constituent}*)/
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /;.*$/, Comment::Single
         rule /#\|/, Comment::Multiline, :multiline_comment
 

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -91,7 +91,7 @@ module Rouge
 
       state :root do
         rule /[(][*](?![)])/, Comment, :comment
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
         rule module_type do |m|
           token Keyword , 'Module'
           token Text::Whitespace , m[1]

--- a/lib/rouge/lexers/crystal.rb
+++ b/lib/rouge/lexers/crystal.rb
@@ -275,7 +275,7 @@ module Rouge
       end
 
       state :funcname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\(/, Punctuation, :defexpr
         rule %r(
           (?:([a-zA-Z_][\w_]*)(\.))?
@@ -294,7 +294,7 @@ module Rouge
       end
 
       state :classname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\(/ do
           token Punctuation
           push :defexpr
@@ -377,7 +377,7 @@ module Rouge
 
         rule(%r((?=\s*/))) { pop! }
 
-        rule(/\s+/) { token Text; goto :expr_start }
+        rule(RegexLexer::WHITESPACE_RE) { token Text; goto :expr_start }
         rule(//) { pop! }
       end
 

--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -43,7 +43,7 @@ module Rouge
       )
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end

--- a/lib/rouge/lexers/css.rb
+++ b/lib/rouge/lexers/css.rb
@@ -240,7 +240,7 @@ module Rouge
       end
 
       state :basics do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule %r(/\*(?:.*?)\*/)m, Comment
       end
 

--- a/lib/rouge/lexers/d.rb
+++ b/lib/rouge/lexers/d.rb
@@ -42,7 +42,7 @@ module Rouge
 
       state :whitespace do
         rule /\n/m, Text
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
       end
 
       state :root do

--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -40,7 +40,7 @@ module Rouge
           token Punctuation, m[4]
         end
 
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
         rule /"/, Str, :dqs
@@ -69,7 +69,7 @@ module Rouge
       end
 
       state :class do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule id, Name::Class, :pop!
       end
 

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -18,7 +18,7 @@ module Rouge
       start { @shell = Shell.new(@options) }
 
       state :root do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do |m|
           groups Keyword, Text::Whitespace, Keyword, Str

--- a/lib/rouge/lexers/dot.rb
+++ b/lib/rouge/lexers/dot.rb
@@ -16,7 +16,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(#.*?\n), Comment::Single
         rule %r(//.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline

--- a/lib/rouge/lexers/eiffel.rb
+++ b/lib/rouge/lexers/eiffel.rb
@@ -48,7 +48,7 @@ module Rouge
 
         rule /[A-Z][\dA-Z_]*/, Name::Class
         rule /[A-Za-z][\dA-Za-z_]*/, Name
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
       end
 
       state :aligned_verbatim_string do

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -17,7 +17,7 @@ module Rouge
       mimetypes 'text/x-elixir', 'application/x-elixir'
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /#.*$/, Comment::Single
         rule %r{\b(case|cond|end|bc|lc|if|unless|try|loop|receive|fn|defmodule|
              defp?|defprotocol|defimpl|defrecord|defmacrop?|defdelegate|

--- a/lib/rouge/lexers/elm.rb
+++ b/lib/rouge/lexers/elm.rb
@@ -23,7 +23,7 @@ module Rouge
 
       state :root do
         # Whitespaces
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         # Single line comments
         rule /--.*/, Comment::Single
         # Multiline comments

--- a/lib/rouge/lexers/erlang.rb
+++ b/lib/rouge/lexers/erlang.rb
@@ -64,7 +64,7 @@ module Rouge
       base_re = %r{(?:[2-9]|[12][0-9]|3[0-6])}
 
       state :root do
-        rule(/\s+/, Text)
+        rule(RegexLexer::WHITESPACE_RE, Text)
         rule(/%.*\n/, Comment)
         rule(%r{(#{keywords.join('|')})\b}, Keyword)
         rule(%r{(#{builtins.join('|')})\b}, Name::Builtin)

--- a/lib/rouge/lexers/factor.rb
+++ b/lib/rouge/lexers/factor.rb
@@ -167,7 +167,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
 
         rule /(:|::|MACRO:|MEMO:|GENERIC:|HELP:)(\s+)(\S+)/m do
           groups Keyword, Text, Name::Function
@@ -279,7 +279,7 @@ module Rouge
       end
 
       state :stack_effect do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\(/, Name::Function, :stack_effect
         rule /\)/, Name::Function, :pop!
 
@@ -288,14 +288,14 @@ module Rouge
       end
 
       state :slots do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /;(?=\s)/, Keyword, :pop!
         rule /\S+/, Name::Variable
       end
 
       state :import do
         rule /;(?=\s)/, Keyword, :pop!
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\S+/, Name::Namespace
       end
     end

--- a/lib/rouge/lexers/fsharp.rb
+++ b/lib/rouge/lexers/fsharp.rb
@@ -46,7 +46,7 @@ module Rouge
       upper_id = /[A-Z][\w']*/
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
         rule /#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
         rule upper_id, Name::Class
@@ -108,7 +108,7 @@ module Rouge
       end
 
       state :dotted do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[.]/, Punctuation
         rule /#{upper_id}(?=\s*[.])/, Name::Namespace
         rule upper_id, Name::Class, :pop!

--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -37,7 +37,7 @@ module Rouge
       end
 
       state :basic do
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
         rule /#.*$/, Comment
 
         rule /[!,]/, Punctuation

--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -100,12 +100,12 @@ module Rouge
       end
 
       state :class do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\w[\w\d]*/, Name::Class, :pop!
       end
 
       state :import do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /[\w\d.]+[*]?/, Name::Namespace, :pop!
       end
     end

--- a/lib/rouge/lexers/haml.rb
+++ b/lib/rouge/lexers/haml.rb
@@ -169,14 +169,14 @@ module Rouge
       end
 
       state :html_attributes do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#{identifier}\s*=/, Name::Attribute, :html_attribute_value
         rule identifier, Name::Attribute
         rule /\)/, Text, :pop!
       end
 
       state :html_attribute_value do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule ruby_var, Name::Variable, :pop!
         rule /@#{ruby_var}/, Name::Variable::Instance, :pop!
         rule /\$#{ruby_var}/, Name::Variable::Global, :pop!

--- a/lib/rouge/lexers/handlebars.rb
+++ b/lib/rouge/lexers/handlebars.rb
@@ -43,7 +43,7 @@ module Rouge
 
       state :stache do
         rule /}}}?/, Keyword, :pop!
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[=]/, Operator
         rule /[\[\]]/, Punctuation
         rule /[.](?=[}\s])/, Name::Variable

--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -27,7 +27,7 @@ module Rouge
       )
 
       state :basic do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /{-#/, Comment::Preproc, :comment_preproc
         rule /{-/, Comment::Multiline, :comment
         rule /^--\s+\|.*?$/, Comment::Doc
@@ -95,7 +95,7 @@ module Rouge
       end
 
       state :import do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /"/, Str, :string
         rule /\bqualified\b/, Keyword
         # import X as Y
@@ -132,7 +132,7 @@ module Rouge
       end
 
       state :module do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         # module Foo (functions)
         rule /([A-Z][\w.]*)(\s+)(\()/ do
           groups Name::Namespace, Text, Punctuation

--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -16,7 +16,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(#.*?$), Comment::Single
         rule %r(/[*]), Comment::Multiline, :multiline_comment

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -60,12 +60,12 @@ module Rouge
       end
 
       state :tag_end_end do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule />/, Name::Tag, :pop!
       end
 
       state :tag_start do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /[a-zA-Z0-9:-]+/ do
           token Name::Tag
@@ -82,7 +82,7 @@ module Rouge
       end
 
       state :tag do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
         rule /[a-zA-Z0-9_:-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!

--- a/lib/rouge/lexers/hylang.rb
+++ b/lib/rouge/lexers/hylang.rb
@@ -55,7 +55,7 @@ module Rouge
 
       state :root do
         rule /;.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
 
         rule /-?\d+\.\d+/, Num::Float
         rule /-?\d+/, Num::Integer

--- a/lib/rouge/lexers/idlang.rb
+++ b/lib/rouge/lexers/idlang.rb
@@ -277,7 +277,7 @@ module Rouge
       state :funcname do
         rule /#{name}/, Name::Function
 
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
         rule /(:+|\$)/, Operator
         rule /;.*/, Comment::Single
 

--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -16,7 +16,7 @@ module Rouge
 
       state :basic do
         rule /[;#].*?\n/, Comment
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\\\n/, Str::Escape
       end
 

--- a/lib/rouge/lexers/io.rb
+++ b/lib/rouge/lexers/io.rb
@@ -26,7 +26,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule %r(//.*?\n), Comment::Single
         rule %r(#.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline

--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -79,12 +79,12 @@ module Rouge
       end
 
       state :class do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule id, Name::Class, :pop!
       end
 
       state :import do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
       end
     end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -32,7 +32,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /<!--/, Comment # really...?
         rule %r(//.*?$), Comment::Single
         rule %r(/[*]), Comment::Multiline, :multiline_comment

--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -69,7 +69,7 @@ module Rouge
       end
 
       state :text do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
       end
 
       state :literal do

--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -12,7 +12,7 @@ module Rouge
                 'application/hal+json'
 
       state :root do
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
         rule /"/, Str::Double, :string
         rule /(?:true|false|null)\b/, Keyword::Constant
         rule /[{},:\[\]]/, Punctuation

--- a/lib/rouge/lexers/jsonnet.rb
+++ b/lib/rouge/lexers/jsonnet.rb
@@ -93,7 +93,7 @@ module Rouge
       identifier = /[a-zA-Z_][a-zA-Z0-9_]*/
 
       state :root do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(#.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -50,7 +50,7 @@ module Rouge
       state :root do
         rule /^#![ \S]+lasso9\b/, Comment::Preproc, :lasso
         rule(/(?=\[|<)/) { push :delimiters }
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
         rule(//) { push :delimiters; push :lassofile }
       end
 
@@ -89,7 +89,7 @@ module Rouge
       end
 
       state :whitespacecomments do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?\n), Comment::Single
         rule %r(/\*\*!.*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline

--- a/lib/rouge/lexers/llvm.rb
+++ b/lib/rouge/lexers/llvm.rb
@@ -16,7 +16,7 @@ module Rouge
 
       state :basic do
         rule /;.*?$/, Comment::Single
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /#{identifier}\s*:/, Name::Label
 

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -89,7 +89,7 @@ module Rouge
       end
 
       state :function_name do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r((?:([A-Za-z_][A-Za-z0-9_]*)(\.))?([A-Za-z_][A-Za-z0-9_]*)) do
           groups Name::Class, Punctuation, Name::Function
           pop!

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -29,7 +29,7 @@ module Rouge
       start { @shell.reset! }
 
       state :root do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /#.*?\n/, Comment
 
@@ -59,7 +59,7 @@ module Rouge
       state :export do
         rule /[\w\${}-]/, Name::Variable
         rule /\n/, Text, :pop!
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
       end
 
       state :block_header do

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -147,7 +147,7 @@ module Rouge
 
       state :inline_url do
         rule /[^<\s)]+/, Str::Other, :pop!
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         mixin :url
       end
     end

--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -61,7 +61,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
         rule /\(\*/, Comment, :comment
         rule /#{base}\^\^#{number_base}#{precision}?(\*\^[+-]?\d+)?/, Num # a number with a base
         rule /(?:#{number}#{precision}?(?:\*\^[+-]?\d+)?)/, Num # all other numbers

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -24,7 +24,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text # Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text # Whitespace
         rule %r([{]%.*?%[}])m, Comment::Multiline
         rule /%.*$/, Comment::Single
         rule /([.][.][.])(.*?)$/ do

--- a/lib/rouge/lexers/mosel.rb
+++ b/lib/rouge/lexers/mosel.rb
@@ -166,7 +166,7 @@ module Rouge
 
       state :whitespace do
         # Spaces
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         # ! Comments
         rule %r((!).*$\n?), Comment::Single
         # (! Comments !)

--- a/lib/rouge/lexers/mxml.rb
+++ b/lib/rouge/lexers/mxml.rb
@@ -34,13 +34,13 @@ module Rouge
       end
 
       state :tag do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[\w.:-]+\s*=/m, Name::Attribute, :attribute
         rule %r(/?\s*>), Name::Tag, :root
       end
 
       state :attribute do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /(")({|@{)/m do
           groups Str, Punctuation
           push :actionscript_attribute

--- a/lib/rouge/lexers/nginx.rb
+++ b/lib/rouge/lexers/nginx.rb
@@ -39,7 +39,7 @@ module Rouge
       end
 
       state :base do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /#.*?\n/, Comment::Single
         rule /(?:on|off)\b/, Name::Constant

--- a/lib/rouge/lexers/nim.rb
+++ b/lib/rouge/lexers/nim.rb
@@ -144,7 +144,7 @@ module Rouge
         rule(/[0-9][0-9_]*/,                  Num::Integer, :intsuffix)
 
         # Whitespace
-        rule(/\s+/, Text)
+        rule(RegexLexer::WHITESPACE_RE, Text)
         rule(/.+$/, Error)
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -12,7 +12,7 @@ module Rouge
 
       state :whitespaces do
         rule /^\s*\n\s*$/m, Text
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
       end
 
       state :comment do

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -181,7 +181,7 @@ module Rouge
 
         mixin :inline_whitespace
         rule %r(//.*?\n), Comment::Single
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
 
         rule(//) { pop! }
       end

--- a/lib/rouge/lexers/ocaml.rb
+++ b/lib/rouge/lexers/ocaml.rb
@@ -33,7 +33,7 @@ module Rouge
       upper_id = /[A-Z][\w']*/
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
         rule /#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
         rule /`#{id}/, Name::Tag
@@ -89,7 +89,7 @@ module Rouge
       end
 
       state :dotted do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[.]/, Punctuation
         rule /#{upper_id}(?=\s*[.])/, Name::Namespace
         rule upper_id, Name::Class, :pop!

--- a/lib/rouge/lexers/pascal.rb
+++ b/lib/rouge/lexers/pascal.rb
@@ -40,7 +40,7 @@ module Rouge
 
       state :whitespace do
         # Spaces
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         # // Comments
         rule %r((//).*$\n?), Comment::Single
         # -- Comments

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -99,7 +99,7 @@ module Rouge
         rule %r(((?<==~)|(?<=\())\s*/(\\\\|\\/|[^/])*/[msixpodualngc]*),
           re_tok, :balanced_regex
 
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /(?:#{builtins.join('|')})\b/, Name::Builtin
         rule /((__(DATA|DIE|WARN)__)|(STD(IN|OUT|ERR)))\b/,
           Name::Builtin::Pseudo
@@ -149,7 +149,7 @@ module Rouge
       end
 
       state :varname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\{/, Punctuation, :pop! # hash syntax
         rule /\)|,/, Punctuation, :pop! # arg specifier
         mixin :name_common
@@ -167,7 +167,7 @@ module Rouge
 
       state :funcname do
         rule /[a-zA-Z_]\w*[!?]?/, Name::Function
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         # argument declaration
         rule /(\([$@%]*\))(\s*)/ do

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -99,7 +99,7 @@ module Rouge
         rule /\?>/, Comment::Preproc, :pop!
         # heredocs
         rule /<<<('?)(#{id})\1\n.*?\n\2;?\n/im, Str::Heredoc
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#.*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single
         # empty comment, otherwise seen as the start of a docstring
@@ -156,7 +156,7 @@ module Rouge
       end
 
       state :classname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#{nsid}/, Name::Class, :pop!
       end
 

--- a/lib/rouge/lexers/plist.rb
+++ b/lib/rouge/lexers/plist.rb
@@ -11,7 +11,7 @@ module Rouge
       mimetypes 'text/x-plist', 'application/x-plist'
 
       state :whitespace do
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
       end
 
       state :root do

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -649,7 +649,7 @@ module Rouge
 
       # Override from Shell
       state :data do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\$?"/, Str::Double, :double_quotes
         rule /\$'/, Str::Single, :ansi_string
 

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -105,9 +105,9 @@ module Rouge
           groups Text, Comment::Single
         end
 
-        rule /^#.*?$/,         Comment::Single
-        rule /;[^\n]*/,        Comment::Single
-        rule /\s+/,            Text
+        rule /^#.*?$/, Comment::Single
+        rule /;[^\n]*/, Comment::Single
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /(\bprocedure)(\s+)/ do
           groups Keyword, Text
@@ -200,7 +200,7 @@ module Rouge
       end
 
       state :function do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /(?::|\s*\()/ do
           token Text
@@ -216,7 +216,7 @@ module Rouge
 
         rule /\s*[\])\n]/, Text, :pop!
 
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /"/,   Literal::String, :string
         rule /\b(if|then|else|fi|endif)\b/, Keyword
 
@@ -308,7 +308,7 @@ module Rouge
           groups Text, Comment::Single
         end
 
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule /(optionmenu|choice)([ \t]+\S+:[ \t]+)/ do
           groups Keyword, Text

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'text/x-prolog'
 
       state :basic do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /^#.*/, Comment::Single
         rule /%.*/, Comment::Single
         rule /\/\*/, Comment::Multiline, :nested_comment

--- a/lib/rouge/lexers/properties.rb
+++ b/lib/rouge/lexers/properties.rb
@@ -15,7 +15,7 @@ module Rouge
 
       state :basic do
         rule /[!#].*?\n/, Comment
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\\\n/, Str::Escape
       end
 

--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -39,7 +39,7 @@ module Rouge
       qualname = /(::)?(#{id}::)*\w+/
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /#.*?\n/, Comment
       end
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -51,7 +51,7 @@ module Rouge
       state :root do
         rule /#'.*?$/, Comment::Doc
         rule /#.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
 
         rule /`[^`]+?`/, Name
         rule /'(\\.|.)*?'/m, Str::Single

--- a/lib/rouge/lexers/racket.rb
+++ b/lib/rouge/lexers/racket.rb
@@ -488,7 +488,7 @@ module Rouge
       state :root do
         # comments
         rule /;.*$/, Comment::Single
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
 
         rule /[+-]inf[.][f0]/, Num::Float
         rule /[+-]nan[.]0/, Num::Float

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -284,7 +284,7 @@ module Rouge
       end
 
       state :funcname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\(/, Punctuation, :defexpr
         rule %r(
           (?:([a-zA-Z_][\w_]*)(\.))?
@@ -303,7 +303,7 @@ module Rouge
       end
 
       state :classname do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\(/ do
           token Punctuation
           push :defexpr
@@ -386,7 +386,7 @@ module Rouge
 
         rule(%r((?=\s*/))) { pop! }
 
-        rule(/\s+/) { token Text; goto :expr_start }
+        rule(RegexLexer::WHITESPACE_RE) { token Text; goto :expr_start }
         rule(//) { pop! }
       end
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -62,7 +62,7 @@ module Rouge
 
       state :start_line do
         mixin :whitespace
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#\[/ do
           token Name::Decorator; push :attribute
         end
@@ -79,7 +79,7 @@ module Rouge
       end
 
       state :whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//[^\n]*), Comment
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end

--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -114,7 +114,7 @@ module Rouge
           push :typeparam
         end
 
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /{/, Operator, :pop!
         rule /\(/, Operator, :pop!
         rule %r(//.*?\n), Comment::Single, :pop!
@@ -122,7 +122,7 @@ module Rouge
       end
 
       state :type do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /<[%:]|>:|[#_\u21D2]|forSome|type/, Keyword
         rule /([,\);}]|=>|=)(\s*)/ do
           groups Operator, Text

--- a/lib/rouge/lexers/scheme.rb
+++ b/lib/rouge/lexers/scheme.rb
@@ -62,7 +62,7 @@ module Rouge
       state :root do
         # comments
         rule /;.*$/, Comment::Single
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /-?\d+\.\d+/, Num::Float
         rule /-?\d+/, Num::Integer
 

--- a/lib/rouge/lexers/scss.rb
+++ b/lib/rouge/lexers/scss.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'text/x-scss'
 
       state :root do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
         rule /@import\b/, Keyword, :value

--- a/lib/rouge/lexers/sed.rb
+++ b/lib/rouge/lexers/sed.rb
@@ -60,7 +60,7 @@ module Rouge
       start { regex.reset!; replacement.reset! }
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule(/#.*?\n/) { token Comment; reset_stack }
         rule(/\n/) { token Text; reset_stack }
         rule(/;/) { token Punctuation; reset_stack }

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -110,7 +110,7 @@ module Rouge
       end
 
       state :data do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\\./, Str::Escape
         rule /\$?"/, Str::Double, :double_quotes
         rule /\$'/, Str::Single, :ansi_string

--- a/lib/rouge/lexers/sieve.rb
+++ b/lib/rouge/lexers/sieve.rb
@@ -57,7 +57,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule %r(#.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -165,7 +165,7 @@ module Rouge
         rule(/(#{ruby_chars}+\(.*?\))/) { |m| delegate ruby, m[1]; pop! }
         rule(/(#{ruby_chars}+)/) { |m| delegate ruby, m[1]; pop! }
 
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
       end
 
       state :ruby_line do

--- a/lib/rouge/lexers/smalltalk.rb
+++ b/lib/rouge/lexers/smalltalk.rb
@@ -86,7 +86,7 @@ module Rouge
 
       state :whitespaces do
         rule /! !$/, Keyword # squeak chunk delimiter
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /".*?"/m, Comment
       end
 

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -59,7 +59,7 @@ module Rouge
         end
 
         rule /}/, Keyword, :pop!
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule %r([~!%^&*()+=|\[\]:;,.<>/@?-]), Operator
         rule /#[a-zA-Z_]\w*#/, Name::Variable
         rule /\$[a-zA-Z_]\w*(\.\w+)*/, Name::Variable

--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -30,7 +30,7 @@ module Rouge
       symbol = %r([!%&$#/:<=>?@\\~`^|*+-]+)
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[(][*]/, Comment, :comment
       end
 

--- a/lib/rouge/lexers/sql.rb
+++ b/lib/rouge/lexers/sql.rb
@@ -89,7 +89,7 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /--.*/, Comment::Single
         rule %r(/\*), Comment::Multiline, :multiline_comments
         rule /\d+/, Num::Integer

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -42,7 +42,7 @@ module Rouge
       end
 
       state :inline_whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         mixin :has_comments
       end
 

--- a/lib/rouge/lexers/tcl.rb
+++ b/lib/rouge/lexers/tcl.rb
@@ -147,7 +147,7 @@ module Rouge
 
       state :whitespace do
         # not a multiline regex because we want to capture \n sometimes
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
       end
 
       state :interp do

--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -77,7 +77,7 @@ module Rouge
 
       state :expression do
         mixin :primitives
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
 
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | == | != )x, Operator
         rule %r([-<>+*%&|\^/!=?:]=?), Operator

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -14,7 +14,7 @@ module Rouge
       identifier = /[\w.\S]+/
 
       state :basic do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#.*?$/, Comment
         rule /(true|false)/, Keyword::Constant
         rule /(?<!=)\s*\[[\w\d\S]+\]/, Name::Namespace

--- a/lib/rouge/lexers/tulip.rb
+++ b/lib/rouge/lexers/tulip.rb
@@ -19,7 +19,7 @@ module Rouge
       upper_id = /[A-Z][\w-]*/
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /#.*?$/, Comment
       end
 

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -54,7 +54,7 @@ module Rouge
         rule /GRAPH\b/, Keyword
         rule /a\b/, Keyword
 
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
 
         rule /[^:;<>#\@"\(\).\[\]\{\} ]+:/, Name::Namespace
         rule /[^:;<>#\@"\(\).\[\]\{\} ]+/, Name

--- a/lib/rouge/lexers/vala.rb
+++ b/lib/rouge/lexers/vala.rb
@@ -29,7 +29,7 @@ module Rouge
       )
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end

--- a/lib/rouge/lexers/vb.rb
+++ b/lib/rouge/lexers/vb.rb
@@ -54,7 +54,7 @@ module Rouge
       upper_id = /[A-Z]\w*/
 
       state :whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\n/, Text, :bol
         rule /rem\b.*?$/i, Comment::Single
         rule %r(%\{.*?%\})m, Comment::Multiline
@@ -62,7 +62,7 @@ module Rouge
       end
 
       state :bol do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /<.*?>/, Name::Attribute
         rule(//) { :pop! }
       end

--- a/lib/rouge/lexers/vhdl.rb
+++ b/lib/rouge/lexers/vhdl.rb
@@ -41,7 +41,7 @@ module Rouge
       id = /[a-zA-Z][a-zA-Z0-9_]*/
 
       state :whitespace do
-        rule /\s+/, Text
+        rule RegexLexer::WHITESPACE_RE, Text
         rule /\n/, Text
         # Find Comments (VHDL doesn't support multiline comments)
         rule /--.*$/, Comment::Single

--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -17,7 +17,7 @@ module Rouge
       entities = []
 
       state :whitespaces_and_comments do
-        rule /\s+/m, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text::Whitespace
         rule /$+/m, Text::Whitespace
         rule %r(//.*$), Comment::Single
         rule %r(/\*(.|\s)*?\*/)m, Comment::Multiline

--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -44,13 +44,13 @@ module Rouge
       end
 
       state :tag do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /[\w.:-]+\s*=/m, Name::Attribute, :attr
         rule %r(/?\s*>), Name::Tag, :pop!
       end
 
       state :attr do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         rule /".*?"|'.*?'|[^\s>]+/m, Str, :pop!
       end
     end

--- a/lib/rouge/lexers/xojo.rb
+++ b/lib/rouge/lexers/xojo.rb
@@ -34,7 +34,7 @@ module Rouge
         )
 
       state :root do
-        rule /\s+/, Text::Whitespace
+        rule RegexLexer::WHITESPACE_RE, Text::Whitespace
 
         rule /rem\b.*?$/i, Comment::Single
         rule /\/\/.*$/, Comment::Single

--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -194,7 +194,7 @@ module Rouge
       end
 
       state :flow_collection do
-        rule /\s+/m, Text
+        rule RegexLexer::WHITESPACE_RE_MULTILINE, Text
         mixin :basic
         rule /[?:,]/, Punctuation::Indicator
         mixin :descriptors

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -6,6 +6,9 @@ module Rouge
   # A stateful lexer that uses sets of regular expressions to
   # tokenize a string.  Most lexers are instances of RegexLexer.
   class RegexLexer < Lexer
+    WHITESPACE_RE = /\s+/.freeze
+    WHITESPACE_RE_MULTILINE = /\s+/m.freeze
+
     # A rule is a tuple of a regular expression to test, and a callback
     # to perform if the test succeeds.
     #


### PR DESCRIPTION
@pyrmont As a proof-of-concept, this was what I meant when I said stashing common patterns in constants in `RegexLexer` in https://github.com/rouge-ruby/rouge/issues/1135#issuecomment-497224797