### PR TITLE
Avoid creating a new array on every Lexer.all call

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -198,6 +198,8 @@ module Rouge
     protected
       # @private
       def register(name, lexer)
+        # reset an existing list of lexers
+        @all = nil if @all
         registry[name.to_s] = lexer
       end
 

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -118,7 +118,7 @@ module Rouge
 
       # @return a list of all lexers.
       def all
-        registry.values.uniq
+        @all ||= registry.values.uniq
       end
 
       # Guess which lexer to use based on a hash of info.


### PR DESCRIPTION
- Memoizing `Lexer.all` since every call to `registry.values.uniq` will return a new array for the same contents 
 (same `#hash` value but different `#object_id` values)

Note: This is under the assumption that the `Lexer.all` list shouldn't change for the lifetime and all user-defined lexers have been *registered* by this point.