### PR TITLE
Avoid creating a new array of strings simply to be checked against

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -254,12 +254,11 @@ module Rouge
         (@mimetypes ||= []).concat(mts)
       end
 
-      VALID_ENCODINGS = %w(US-ASCII UTF-8 ASCII-8BIT).freeze
-      private_constant :VALID_ENCODINGS
-
       # @private
       def assert_utf8!(str)
-        return if VALID_ENCODINGS.include? str.encoding.name
+        encoding = str.encoding.name
+        return if encoding == 'US-ASCII' || encoding == 'UTF-8' || encoding == 'ASCII-8BIT'
+
         raise EncodingError.new(
           "Bad encoding: #{str.encoding.names.join(',')}. " +
           "Please convert your string to UTF-8."

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -254,9 +254,12 @@ module Rouge
         (@mimetypes ||= []).concat(mts)
       end
 
+      VALID_ENCODINGS = %w(US-ASCII UTF-8 ASCII-8BIT).freeze
+      private_constant :VALID_ENCODINGS
+
       # @private
       def assert_utf8!(str)
-        return if %w(US-ASCII UTF-8 ASCII-8BIT).include? str.encoding.name
+        return if VALID_ENCODINGS.include? str.encoding.name
         raise EncodingError.new(
           "Bad encoding: #{str.encoding.names.join(',')}. " +
           "Please convert your string to UTF-8."


### PR DESCRIPTION
Instead, stash the array in a class constant or simply use the double-pipe (`||`) operator.