### PR TITLE
Add 'lexer' and 'registered' DSL keywords

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -294,6 +294,11 @@ module Rouge
       @options = {}
       opts.each { |k, v| @options[k.to_s] = v }
 
+      unless self.class.lexer.nil?
+        self.class.lexer.call
+        self.class.remove_instance_variable :@lexer
+      end
+
       @debug = Lexer.debug_enabled? && bool_option(:debug)
     end
 
@@ -442,6 +447,16 @@ module Rouge
     #   the stream
     def stream_tokens(stream, &b)
       raise 'abstract'
+    end
+
+    # @abstract
+    #
+    # Sets or returns the lexing logic for this lexer.
+    #
+    # @param [Proc] b
+    #   the block defining the lexing logic
+    def self.lexer(&b)
+      return nil
     end
 
     # @abstract

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -149,6 +149,39 @@ module Rouge
       end
     end
 
+    # Specify or get this lexer's lexing logic.
+    def self.lexer(&b)
+      return @lexer if b.nil?
+
+      @lexer = b
+    end
+
+    # Specify a group of registered words for this lexer.
+    #
+    # This provides a DSL keyword for defining groups of registered words. It
+    # effectively "wraps" the array of words in a method (called the value of
+    # `name`) to avoid unnecessary object creation. The first time the method
+    # is called, it will call the block and memoise the result.
+    #
+    # @param [Symbol] name
+    #   the name of this group, an instance method will be created with this
+    #   name
+    # @param [Proc] b
+    #   the proc to call if no value has been initialised
+    #
+    # @example
+    #   registered :keywords do
+    #     %w(if else)
+    #   end
+    def self.registered(name, &b)
+      ivar_name = "@#{name}"
+
+      define_method name do
+        instance_variable_get(ivar_name) ||
+        instance_variable_set(ivar_name, b.call)
+      end
+    end
+
     # The states hash for this lexer.
     # @see state
     def self.states


### PR DESCRIPTION
As discussed in #1135 and #1147, the large number of lexers provided by Rouge causes the loading of the library to use a substantial amount of memory. This is particularly wasteful given that most uses of Rouge will only be to highlight a handful of languages.

This PR proposes the addition of two new keywords to the DSLs used in Rouge to help alleviate this problem:

- The first keyword is the **`lexer` keyword**. It forms part of the generic lexer DSL and is intended to be used to wrap the lexing logic of a given lexer. By putting the logic inside a block, we defer the instantiation of objects defined in that block until an instance of the lexer is actually created.

   An abstract implementation is defined in `Rouge::Lexer` and a concrete implementation is defined in `Rouge::RegexLexer`. The basic idea is that the logic in the block is saved into an instance variable on the lexer's class itself. When a lexer of this class is initialised, the block is called if present. After being called the first time, the block is no longer required and is removed (to avoid repeated calls for future instantiations).

- The second keyword is the **`registered` keyword**. It forms part of the regular expression lexer DSL and is intended to be used to wrap registered words used by a given lexer. By putting these strings inside a block, we defer their instantiation until the registered words are required. 

   The implementation is defined in `Rouge::RegexLexer`. The basic idea is to create an instance method on the lexer's class that memoises the value of the registered words. This is equivalent to the following pattern:

   ```rb
   def self.keywords
     @keywords ||= %w(some example keywords)
   end
   ```

   One of the advantages of using `registered` is that the method created is available to instances without needing to preface calls with `self.class`.

The use of both the `lexer` keyword and the `registered` keyword is optional and does not break existing lexers. This will allow the progressive enhancement of lexers in Rouge while being immediately available for use by new lexer authors.

An example of how they could be used is below:

```rb
module Rouge
  module Lexers
    class WrappedLexer < RegexLexer
      title 'Wrapped'
      tag 'wrapped'

      lexer do
        registered :keywords do
          %w(some example keywords)
        end

        state :root do
          rule /\s+/, Text

          rule /(\w+)/ do |m|
            if keywords.include? m[0]
              token Keyword
            else
              token Text
            end
          end
        end
      end
    end
  end
end
```