### PR TITLE
replace the :continue option with a #continue_lex method

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -23,6 +23,14 @@ module Rouge
         new(opts).lex(stream, &b)
       end
 
+      # In case #continue_lex is called statically, we simply
+      # begin a new lex from the beginning, since there is no state.
+      #
+      # @see #continue_lex
+      def continue_lex(*a, &b)
+        lex(*a, &b)
+      end
+
       # Given a name in string, return the correct lexer class.
       # @param [String] name
       # @return [Class<Rouge::Lexer>,nil]
@@ -405,15 +413,18 @@ module Rouge
 
     # Given a string, yield [token, chunk] pairs.  If no block is given,
     # an enumerator is returned.
-    #
-    # @option opts :continue
-    #   Continue the lex from the previous state (i.e. don't call #reset!)
-    def lex(string, opts={}, &b)
-      return enum_for(:lex, string, opts) unless block_given?
+    def lex(string, &b)
+      return enum_for(:lex, string) unless block_given?
 
       Lexer.assert_utf8!(string)
+      reset!
 
-      reset! unless opts[:continue]
+      continue_lex(string, &b)
+    end
+
+    # Continue the lex from the the current state without resetting
+    def continue_lex(string, &b)
+      return enum_for(:continue_lex, string, &b) unless block_given?
 
       # consolidate consecutive tokens of the same type
       last_token = nil

--- a/lib/rouge/lexers/console.rb
+++ b/lib/rouge/lexers/console.rb
@@ -118,7 +118,7 @@ module Rouge
           $' =~ /\A\s*/
           yield Text, $& unless $&.empty?
 
-          lang_lexer.lex($', continue: true, &output)
+          lang_lexer.continue_lex($', &output)
         elsif comment_regex =~ input[0].strip
           puts "console: matched comment #{input[0].inspect}" if @debug
           output_lexer.reset!
@@ -129,7 +129,7 @@ module Rouge
           puts "console: matched output #{input[0].inspect}" if @debug
           lang_lexer.reset!
 
-          output_lexer.lex(input[0], continue: true, &output)
+          output_lexer.continue_lex(input[0], &output)
         end
       end
     end

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -352,10 +352,10 @@ module Rouge
       end
     end
 
-    # Delegate the lex to another lexer.  The #lex method will be called
-    # with `:continue` set to true, so that #reset! will not be called.
-    # In this way, a single lexer can be repeatedly delegated to while
-    # maintaining its own internal state stack.
+    # Delegate the lex to another lexer. We use the `continue_lex` method
+    # so that #reset! will not be called.  In this way, a single lexer
+    # can be repeatedly delegated to while maintaining its own internal
+    # state stack.
     #
     # @param [#lex] lexer
     #   The lexer or lexer class to delegate to
@@ -365,7 +365,7 @@ module Rouge
       puts "    delegating to #{lexer.inspect}" if @debug
       text ||= @current_stream[0]
 
-      lexer.lex(text, :continue => true) do |tok, val|
+      lexer.continue_lex(text) do |tok, val|
         puts "    delegated token: #{tok.inspect}, #{val.inspect}" if @debug
         yield_token(tok, val)
       end

--- a/spec/lexers/markdown_spec.rb
+++ b/spec/lexers/markdown_spec.rb
@@ -31,7 +31,7 @@ describe Rouge::Lexers::Markdown do
 
     it 'recognizes code block when lexer is continued' do
       subject.lex("```ruby\n").to_a
-      actual = subject.lex("@foo\n```\n",continue: true).map { |token, value| [ token.qualname, value ] }
+      actual = subject.continue_lex("@foo\n```\n").map { |token, value| [ token.qualname, value ] }
       assert { ["Name.Variable.Instance", "@foo"] == actual.first }
     end
 


### PR DESCRIPTION
This has the following advantages:

* reduces calls to `#assert_utf8!` (was previously called for every delegation!)

* avoids the hash object creation

* avoids the control coupling code smell of a special boolean parameter to avoid some parts of the processing.