### PR TITLE
Map Open Shading Language to C Lexer

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -5,7 +5,7 @@ module Rouge
   module Lexers
     class C < RegexLexer
       tag 'c'
-      filenames '*.c', '*.h', '*.idc'
+      filenames '*.c', '*.h', '*.idc', '*.osl'
       mimetypes 'text/x-chdr', 'text/x-csrc'
 
       title "C"


### PR DESCRIPTION
Map Open Shading Language (https://github.com/imageworks/OpenShadingLanguage) to the C lexer. 

@pyrmont Can you review, please? 