### PR TITLE
Use predefined string when Lexer.debug_enabled?

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -365,8 +365,10 @@ module Rouge
     end
 
     def bool_option(name, &default)
-      if @options.key?(name.to_s)
-        as_bool(@options[name.to_s])
+      name_str = name == :debug ? "debug" : name.to_s
+
+      if @options.key?(name_str)
+        as_bool(@options[name_str])
       else
         default ? default.call : false
       end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -310,7 +310,7 @@ module Rouge
       @options = {}
       opts.each { |k, v| @options[k.to_s] = v }
 
-      @debug = Lexer.debug_enabled? && bool_option(:debug)
+      @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
     def as_bool(val)
@@ -365,7 +365,7 @@ module Rouge
     end
 
     def bool_option(name, &default)
-      name_str = name == :debug ? "debug" : name.to_s
+      name_str = name.to_s
 
       if @options.key?(name_str)
         as_bool(@options[name_str])


### PR DESCRIPTION
Based on the following code:
https://github.com/rouge-ruby/rouge/blob/f494b53d9b04321032b9dc8a754e9f61198ec5f3/lib/rouge/lexer.rb#L309-L314

When `Lexer.debug_enabled?`, `bool_option(:debug)`will be called each time the Lexer is initialized, which in turn causes `"debug"` to be allocated for each instance. This can be *avoided by using `"debug"` directly* since that is the one globally supported option and other allocations can be *reduced by caching into a local variable.*