### PR TITLE
Fix arbitrary delimiter regular expressions in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -93,9 +93,10 @@ module Rouge
         rule %r(m?/(\\\\|\\/|[^/\n])*/[msixpodualngc]*), re_tok
         rule %r(m(?=[/!\\{<\[\(@%\$])), re_tok, :balanced_regex
 
-        # Perl allows any non-whitespace character to delimit
-        # a regex when `m` is used.
-        rule %r(m(\S).*\1[msixpodualngc]*), re_tok
+        # arbitrary non-whitespace delimiters
+        rule %r(m\s*([^\w\s])((\\\\|\\\1)|[^\1])*?\1[msixpodualngc]*)m, re_tok
+        rule %r(m\s+(\w)((\\\\|\\\1)|[^\1])*?\1[msixpodualngc]*)m, re_tok
+
         rule %r(((?<==~)|(?<=\())\s*/(\\\\|\\/|[^/])*/[msixpodualngc]*),
           re_tok, :balanced_regex
 

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -31,6 +31,19 @@ sub substitutionOperator
   s!\)!\\\)!g;
 }
 
+# arbitrary delimiters
+my $re_1 = m,This should match,;
+my $re_2 = m aSo should thisa;
+
+# Keys in hashes aren't match as regular expressions
+
+my %countries =  ( England => 'English',
+                   France => 'French',
+                   Spain => 'Spanish',
+                   China => 'Chinese',
+                   Germany => 'German',
+                   Mozambique => 'Mozambican');
+
 use strict;
 use warnings;
 

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -37,12 +37,12 @@ my $re_2 = m aSo should thisa;
 
 # Keys in hashes aren't match as regular expressions
 
-my %countries =  ( England => 'English',
-                   France => 'French',
-                   Spain => 'Spanish',
-                   China => 'Chinese',
-                   Germany => 'German',
-                   Mozambique => 'Mozambican');
+my %countries =  ( england => 'English',
+                   france => 'French',
+                   spain => 'Spanish',
+                   china => 'Chinese',
+                   germany => 'German',
+                   mozambique => 'Mozambican');
 
 use strict;
 use warnings;


### PR DESCRIPTION
Perl allows arbitrary non-whitespace delimiters in regular expressions. This commit fixes the rule to capture these regular expressions so that it does not capture identifiers, hash keys and other elements of syntax that begin with 'm' but are not regular expressions. It fixes #981.