### PR TITLE
Fix backtracking issues, add string interpolation in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -179,21 +179,21 @@ module Rouge
       end
 
       state :sq do
-        rule /\\[']/, Str::Single
+        rule /\\[']/, Str::Escape
         rule /[^\\']+/, Str::Single
         rule /'/, Punctuation, :pop!
       end
 
       state :dq do
         mixin :string_intp
-        rule /\\[\\tnr"]/, Str::Double
+        rule /\\[\\tnr"]/, Str::Escape
         rule /[^\\"]+?/, Str::Double
         rule /"/, Punctuation, :pop!
       end
 
       state :bq do
         mixin :string_intp
-        rule /\\[\\tnr`]/, Str::Backtick
+        rule /\\[\\tnr`]/, Str::Escape
         rule /[^\\`]+?/, Str::Backtick
         rule /`/, Punctuation, :pop!
       end

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -150,6 +150,12 @@ $p =~ s%
   %bar%x;
 print $p, "\n";
 
+my $str1 = "This is a ${ string } with fancy interpolation."
+my $cmd1 = `So is @{ this } one.`
+my $str2 = "This is a $string with plain interpolation."
+my $cmd2 = `So is @this one.`
+my $str3 = 'A boring $string.'
+
 ###### perl_misc ########
 
 # from http://gist.github.com/485595


### PR DESCRIPTION
The previous rules for strings used a regular expression that combined different elements of the string. This could, in a pathological case, cause Rouge to get stuck trying to lex the code. This problem can be fixed by lexing a quoted string in a separate state to `:root`.

In addition to adding states for quoted string, this commit also adds support for basic string interpolation. The basic logic is lifted from the Ruby lexer. This fixes #974.