### PR TITLE
Fix escaping backslash in javascript lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -197,25 +197,21 @@ module Rouge
         rule /0b[01][01_]*/i, Num::Bin
         rule /[0-9]+/, Num::Integer
 
-        rule /"/, Str::Double, :dq
-        rule /'/, Str::Single, :sq
+        rule /"/, Str::Delimiter, :dq
+        rule /'/, Str::Delimiter, :sq
         rule /:/, Punctuation
       end
 
       state :dq do
+        rule /\\[\\nrt"]?/, Str::Escape
         rule /[^\\"]+/, Str::Double
-        rule /\\[^nrt]/, Str::Escape
-        rule /\\n/, Str::Escape
-        rule /\\r/, Str::Escape
-        rule /\\t/, Str::Escape
-        rule /\\"/, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule /"/, Str::Delimiter, :pop!
       end
 
       state :sq do
+        rule /\\[\\nrt']?/, Str::Escape
         rule /[^\\']+/, Str::Single
-        rule /\\'/, Str::Escape
-        rule /'/, Str::Single, :pop!
+        rule /'/, Str::Delimiter, :pop!
       end
 
       # braced parts that aren't object literals

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -205,6 +205,9 @@ module Rouge
       state :dq do
         rule /[^\\"]+/, Str::Double
         rule /\\n/, Str::Escape
+        rule /\\t/, Str::Escape
+        rule /\\r/, Str::Escape
+        rule /\\/, Str::Escape
         rule /\\"/, Str::Escape
         rule /"/, Str::Double, :pop!
       end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -204,10 +204,10 @@ module Rouge
 
       state :dq do
         rule /[^\\"]+/, Str::Double
+        rule /\\[^nrt]/, Str::Escape
         rule /\\n/, Str::Escape
-        rule /\\t/, Str::Escape
         rule /\\r/, Str::Escape
-        rule /\\/, Str::Escape
+        rule /\\t/, Str::Escape
         rule /\\"/, Str::Escape
         rule /"/, Str::Double, :pop!
       end

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -16,7 +16,8 @@ var foo = {
   c: "\\test",
   d: "\\nest",
   e: "\\",
-  f: "\\"
+  f: "Using \\ in a string",
+  g: "\error"
 };
 
 switch(test) {

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -10,6 +10,15 @@ someText += "\nthere";
 
 var test = 123
 
+var foo = {
+  a: "\test",
+  b: "\nest",
+  c: "\\test",
+  d: "\\nest",
+  e: "\\",
+  f: "\\"
+};
+
 switch(test) {
 case 123:
   console.log(123)


### PR DESCRIPTION
An attempt to resolve #828 

Testing with the following code:
```
var foo = {
  a: "\test",
  b: "\nest",
  c: "\\test",
  d: "\\nest",
  e: "\\",
  f: "\\"
};
```
yields:
![javascript Visual Test](https://user-images.githubusercontent.com/12479464/59213897-907d4580-8bd3-11e9-89a0-826b655da695.png)


/cc @fireattack, @pyrmont,  @dblessing 