### PR TITLE
Add Rake task for generating changelog entries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,15 @@ if RUBY_VERSION >= '2.3.0'
   gem 'memory_profiler', :require => false
 end
 
+# Needed for a Rake task
+gem 'git'
+
 group :development do
   gem 'pry'
 
   # docs
   gem 'yard'
   gem 'github-markup'
-  gem 'git'
 
   # for visual tests
   if RUBY_VERSION < '2.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development do
   # docs
   gem 'yard'
   gem 'github-markup'
+  gem 'git'
 
   # for visual tests
   if RUBY_VERSION < '2.2.0'

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -14,14 +14,14 @@ module Rouge
       end
       
       def prev_version
-        @prev_version ||= @repo.
-          tags.
-          select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }.
-          map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }.
-          sort { |a,b| sort_versions(a, b) }.
-          last.
-          join(".").
-          prepend("v")
+        @prev_version ||= @repo
+          .tags
+          .select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }
+          .map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }
+          .sort { |a,b| sort_versions(a, b) }
+          .last
+          .join(".")
+          .prepend("v")
       end
 
       def sort_versions(a, b)

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -3,8 +3,6 @@ require 'git'
 module Rouge
   module Tasks
     class Git
-      attr_reader :remote
-
       def initialize(dir, remote)
         @repo = ::Git.open(dir)
         @remote = remote

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,0 +1,84 @@
+require 'git'
+
+module Rouge
+  class Gitlog
+    class Message
+      def initialize(original, author)
+        @subject = original.match(/.*/)[0]
+        @author = author
+      end
+
+      def formatted(remote)
+        "   - " + @subject.gsub(/\(#(\d+)\)/,
+                                "([#\\1](https://#{remote}/pr/\\1/) by #{@author})")
+      end
+    end
+
+    def initialize(dir, remote, beg_sha, end_sha = nil)
+      @repo = Git.open(dir)
+      @remote = remote
+      @log = @repo.log(100).between(beg_sha, end_sha)
+      @msgs = @log.map { |l| Message.new(l.message, l.author.name) }
+    end
+
+    def converted
+      @msgs.map { |m| m.formatted(@remote) }
+    end
+
+    def prev_version
+      @prev_version ||= @repo.tags.select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }.
+                                   map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }.
+                                   sort { |a,b| sort_versions(a, b) }.
+                                   map { |t| "v" + t.join(".") }.
+                                   last
+    end
+
+    def sort_versions(a, b)
+      if a[0] == b[0] && a[1] == b[1]
+        a[2] <=> b[2]
+      elsif a[0] == b[0]
+        a[1] <=> b[1]
+      else
+        a[0] <=> b[0]
+      end
+    end
+  end
+end
+
+def version_line(version)
+  "## version #{version}: (#{Time.now.strftime("%Y/%m/%d")})\n\n"
+end
+
+def comparison_line(remote, previous, current)
+  "https://#{remote}/compare/#{previous}...#{current}\n\n"
+end
+
+namespace :changelog do
+  desc "Insert lines in CHANGELOG.md for commits between SHAs (inclusive)" 
+  task :insert, [:beg_sha, :end_sha] do |t, args|
+    args.with_defaults(:end_sha => nil)
+
+    remote = "github.com/rouge-ruby/rouge"
+    changelog = "CHANGELOG.md"
+    working_dir = "."
+
+    gitlog = Rouge::Gitlog.new(working_dir, remote, args.beg_sha, args.end_sha)
+    
+    text = ''
+    not_inserted = true
+
+    File.readlines(changelog).each do |l|
+      if not_inserted && l.start_with?("##")
+        text += version_line(Rouge.version)
+        text += comparison_line(remote, gitlog.prev_version, "v" + Rouge.version)
+        text += gitlog.converted.join("\n")
+        text += "\n\n"
+        not_inserted = false
+      end
+      
+      text += l
+    end
+
+    File.write(changelog, text)
+  end
+end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -25,13 +25,9 @@ module Rouge
       end
 
       def sort_versions(a, b)
-        if a[0] == b[0] && a[1] == b[1]
-          a[2] <=> b[2]
-        elsif a[0] == b[0]
-          a[1] <=> b[1]
-        else
-          a[0] <=> b[0]
-        end
+        return a[2] <=> b[2] if a[0] == b[0] && a[1] == b[1]
+        return a[1] <=> b[1] if a[0] == b[0]
+        return a[0] <=> b[0]
       end
       
       class Log 
@@ -63,7 +59,7 @@ module Rouge
     end
 
     def self.link_line(remote, author)
-      "([#\\1](https://#{remote}/pr/\\1/) by #{author})"
+      "([#\\1](https://#{remote}/pull/\\1/) by #{author})"
     end
 
     def self.message_line(message)
@@ -71,7 +67,7 @@ module Rouge
     end
     
     def self.version_line(version)
-      "## version #{version}: (#{Time.now.strftime("%Y/%m/%d")})\n\n"
+      "## version #{version}: #{Time.now.strftime("%Y/%m/%d")}\n\n"
     end
   end
 end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -2,37 +2,28 @@ require 'git'
 
 module Rouge
   module Tasks
-    class Gitlog
-      class Message
-        def initialize(original, author)
-          @subject = original.match(/.*/)[0]
-          @author = author
-        end
+    class Git
+      attr_reader :remote
 
-        def formatted(remote)
-          "   - " + @subject.gsub(/\(#(\d+)\)/,
-                                  "([#\\1](https://#{remote}/pr/\\1/) by #{@author})")
-        end
+      def initialize(dir, remote)
+        @repo = ::Git.open(dir)
+        @remote = remote
       end
 
-      def initialize(dir, beg_sha, end_sha = nil)
-        @repo = Git.open(dir)
-        @log = @repo.log(100).between(beg_sha, end_sha)
-        @msgs = @log.map { |l| Message.new(l.message, l.author.name) }
+      def log(beg_sha, end_sha = nil)
+        commits = @repo.log(100).between(beg_sha, end_sha)
+        Log.new(@remote, commits)
       end
-
-      def converted(remote)
-        @msgs.map { |m| m.formatted(remote) }
-      end
-
+      
       def prev_version
         @prev_version ||= @repo.
           tags.
           select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }.
           map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }.
           sort { |a,b| sort_versions(a, b) }.
-          map { |t| "v" + t.join(".") }.
-          last
+          last.
+          join(".").
+          prepend("v")
       end
 
       def sort_versions(a, b)
@@ -44,14 +35,45 @@ module Rouge
           a[0] <=> b[0]
         end
       end
+      
+      class Log 
+        def initialize(remote, commits)
+          @remote = remote
+          @msgs = commits.map { |c| Message.new(c.message, c.author.name) }
+        end
+
+        def converted
+          @msgs.map { |m| m.formatted(@remote) }
+        end
+
+        class Message
+          def initialize(original, author)
+            @subject = original.match(/.*/)[0]
+            @author = author
+          end
+
+          def formatted(remote)
+            msg = @subject.gsub(/\(#(\d+)\)/, Tasks.link_line(remote, @author))
+            Tasks.message_line(msg)
+          end
+        end
+      end
+    end
+    
+    def self.comparison_line(remote, previous, current)
+      "[Comparison against the previous version](https://#{remote}/compare/#{previous}...#{current})\n\n"
+    end
+
+    def self.link_line(remote, author)
+      "([#\\1](https://#{remote}/pr/\\1/) by #{author})"
+    end
+
+    def self.message_line(message)
+      "   - #{message}\n"
     end
     
     def self.version_line(version)
       "## version #{version}: (#{Time.now.strftime("%Y/%m/%d")})\n\n"
-    end
-
-    def self.comparison_line(remote, previous, current)
-      "[Comparison against the previous version](https://#{remote}/compare/#{previous}...#{current})\n\n"
     end
   end
 end
@@ -61,13 +83,12 @@ namespace :changelog do
   task :insert, [:beg_sha, :end_sha] do |t, args|
     args.with_defaults(:end_sha => nil)
 
-    remote = "github.com/rouge-ruby/rouge"
     changelog = "CHANGELOG.md"
-    working_dir = "."
 
-    gitlog = Rouge::Tasks::Gitlog.new(working_dir, 
-                                      args.beg_sha, 
-                                      args.end_sha)
+    remote = "github.com/rouge-ruby/rouge"
+    working_dir = "."
+    repo = Rouge::Tasks::Git.new(working_dir, remote)
+    gitlog = repo.log(args.beg_sha, args.end_sha)
     
     text = ''
     not_inserted = true
@@ -76,10 +97,9 @@ namespace :changelog do
       if not_inserted && l.start_with?("##")
         text += Rouge::Tasks.version_line(Rouge.version)
         text += Rouge::Tasks.comparison_line(remote, 
-                                             gitlog.prev_version, 
+                                             repo.prev_version, 
                                              "v" + Rouge.version)
-        text += gitlog.converted(remote).join("\n")
-        text += "\n\n"
+        text += gitlog.converted.join("") + "\n"
         not_inserted = false
       end
       

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,56 +1,59 @@
 require 'git'
 
 module Rouge
-  class Gitlog
-    class Message
-      def initialize(original, author)
-        @subject = original.match(/.*/)[0]
-        @author = author
+  module Tasks
+    class Gitlog
+      class Message
+        def initialize(original, author)
+          @subject = original.match(/.*/)[0]
+          @author = author
+        end
+
+        def formatted(remote)
+          "   - " + @subject.gsub(/\(#(\d+)\)/,
+                                  "([#\\1](https://#{remote}/pr/\\1/) by #{@author})")
+        end
       end
 
-      def formatted(remote)
-        "   - " + @subject.gsub(/\(#(\d+)\)/,
-                                "([#\\1](https://#{remote}/pr/\\1/) by #{@author})")
+      def initialize(dir, beg_sha, end_sha = nil)
+        @repo = Git.open(dir)
+        @log = @repo.log(100).between(beg_sha, end_sha)
+        @msgs = @log.map { |l| Message.new(l.message, l.author.name) }
+      end
+
+      def converted(remote)
+        @msgs.map { |m| m.formatted(remote) }
+      end
+
+      def prev_version
+        @prev_version ||= @repo.
+          tags.
+          select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }.
+          map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }.
+          sort { |a,b| sort_versions(a, b) }.
+          map { |t| "v" + t.join(".") }.
+          last
+      end
+
+      def sort_versions(a, b)
+        if a[0] == b[0] && a[1] == b[1]
+          a[2] <=> b[2]
+        elsif a[0] == b[0]
+          a[1] <=> b[1]
+        else
+          a[0] <=> b[0]
+        end
       end
     end
-
-    def initialize(dir, remote, beg_sha, end_sha = nil)
-      @repo = Git.open(dir)
-      @remote = remote
-      @log = @repo.log(100).between(beg_sha, end_sha)
-      @msgs = @log.map { |l| Message.new(l.message, l.author.name) }
+    
+    def self.version_line(version)
+      "## version #{version}: (#{Time.now.strftime("%Y/%m/%d")})\n\n"
     end
 
-    def converted
-      @msgs.map { |m| m.formatted(@remote) }
-    end
-
-    def prev_version
-      @prev_version ||= @repo.tags.select { |t| t.name.match?(/^v\d+\.\d+\.\d$/) }.
-                                   map { |t| t.name.slice(1..-1).split(".").map(&:to_i) }.
-                                   sort { |a,b| sort_versions(a, b) }.
-                                   map { |t| "v" + t.join(".") }.
-                                   last
-    end
-
-    def sort_versions(a, b)
-      if a[0] == b[0] && a[1] == b[1]
-        a[2] <=> b[2]
-      elsif a[0] == b[0]
-        a[1] <=> b[1]
-      else
-        a[0] <=> b[0]
-      end
+    def self.comparison_line(remote, previous, current)
+      "[Comparison against the previous version](https://#{remote}/compare/#{previous}...#{current})\n\n"
     end
   end
-end
-
-def version_line(version)
-  "## version #{version}: (#{Time.now.strftime("%Y/%m/%d")})\n\n"
-end
-
-def comparison_line(remote, previous, current)
-  "https://#{remote}/compare/#{previous}...#{current}\n\n"
 end
 
 namespace :changelog do
@@ -62,16 +65,20 @@ namespace :changelog do
     changelog = "CHANGELOG.md"
     working_dir = "."
 
-    gitlog = Rouge::Gitlog.new(working_dir, remote, args.beg_sha, args.end_sha)
+    gitlog = Rouge::Tasks::Gitlog.new(working_dir, 
+                                      args.beg_sha, 
+                                      args.end_sha)
     
     text = ''
     not_inserted = true
 
     File.readlines(changelog).each do |l|
       if not_inserted && l.start_with?("##")
-        text += version_line(Rouge.version)
-        text += comparison_line(remote, gitlog.prev_version, "v" + Rouge.version)
-        text += gitlog.converted.join("\n")
+        text += Rouge::Tasks.version_line(Rouge.version)
+        text += Rouge::Tasks.comparison_line(remote, 
+                                             gitlog.prev_version, 
+                                             "v" + Rouge.version)
+        text += gitlog.converted(remote).join("\n")
         text += "\n\n"
         not_inserted = false
       end

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -67,7 +67,7 @@ module Rouge
     end
     
     def self.version_line(version)
-      "## version #{version}: #{Time.now.strftime("%Y/%m/%d")}\n\n"
+      "## version #{version}: #{Time.now.strftime("%Y-%m-%d")}\n\n"
     end
   end
 end


### PR DESCRIPTION
This commit adds a Rake task to assist in writing CHANGELOG updates. The task generates messages using the first line of the commit message. It automatically inserts links for references that begin with `#` as well as providing a heading and a link to compare against the previous version.