### PR TITLE
Fix wording and indentation in changelog Rake task

### DIFF
--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -55,7 +55,7 @@ module Rouge
     end
     
     def self.comparison_line(remote, previous, current)
-      "[Comparison against the previous version](https://#{remote}/compare/#{previous}...#{current})\n\n"
+      "[Comparison with the previous version](https://#{remote}/compare/#{previous}...#{current})\n\n"
     end
 
     def self.link_line(remote, author)
@@ -63,7 +63,7 @@ module Rouge
     end
 
     def self.message_line(message)
-      "   - #{message}\n"
+      "  - #{message}\n"
     end
     
     def self.version_line(version)


### PR DESCRIPTION
The Rake task for generating changelog entries has an older version of the wording for the comparison link text. It also has an incorrect number of spaces in the indentation of the entries. This commit fixes both.