### PR TITLE
Fix shebang regex in Python lexer

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)
-        return true if text.shebang?(/pythonw?(3|2(\.\d)?)?/)
+        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?$/)
       end
 
       def self.keywords

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)
-        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?$/)
+        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?/)
       end
 
       def self.keywords

--- a/spec/lexers/python_spec.rb
+++ b/spec/lexers/python_spec.rb
@@ -23,9 +23,11 @@ describe Rouge::Lexers::Python do
 
     it 'guesses by source' do
       assert_guess :source => '#!/usr/bin/env python'
-      assert_guess :source => '#!/usr/local/bin/python3'
       assert_guess :source => '#!/usr/bin/python2'
       assert_guess :source => '#!/usr/bin/python2.7'
+      assert_guess :source => '#!/usr/local/bin/python3'
+      assert_guess :source => '#!/usr/local/bin/python3.5'
+      assert_guess :source => '#!/usr/local/bin/python3.14'
       deny_guess   :source => '#!/usr/bin/env python4'
     end
   end


### PR DESCRIPTION
The Python lexer only supported minor version numbers for shebangs involving `python2`. Minor versions of Python 3 should also be included. This commit corrects that problem and supports minor version numbers higher than 9. This fixes #945.