### PR TITLE
Restore support for opts to Lexer.lex

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -419,7 +419,7 @@ module Rouge
     # an enumerator is returned.
     def lex(string, opts=nil, &b)
       warn 'The use of opts with Lexer.lex is deprecated' unless opts.nil?
-      return enum_for(:lex, string) unless block_given?
+      return enum_for(:lex, string, opts) unless block_given?
 
       if opts && opts[:continue]
         warn 'Use #continue_lex instead'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -417,17 +417,21 @@ module Rouge
 
     # Given a string, yield [token, chunk] pairs.  If no block is given,
     # an enumerator is returned.
-    def lex(string, opts=nil, &b)
-      warn 'The use of opts with Lexer.lex is deprecated' unless opts.nil?
-      return enum_for(:lex, string, opts) unless block_given?
-
-      if opts && opts[:continue]
-        warn 'Use #continue_lex instead'
-        return continue_lex(string, &b)
+    #
+    # @option opts :continue
+    #   Continue the lex from the previous state (i.e. don't call #reset!)
+    #
+    # @note The use of `opts` has been deprecated. A warning is issued if run
+    #   with `$VERBOSE` set to true.
+    def lex(string, opts={}, &b)
+      unless opts.nil?
+        warn 'The use of opts with Lexer.lex is deprecated' if $VERBOSE
       end
 
+      return enum_for(:lex, string, opts) unless block_given?
+
       Lexer.assert_utf8!(string)
-      reset!
+      reset! unless opts[:continue]
 
       continue_lex(string, &b)
     end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -418,7 +418,7 @@ module Rouge
     # Given a string, yield [token, chunk] pairs.  If no block is given,
     # an enumerator is returned.
     def lex(string, opts=nil, &b)
-      if opts
+      if opts && opts[:continue]
         warn 'the :continue option to Formatter#lex is deprecated, use #continue_lex instead.'
         return continue_lex(string, &b)
       end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -418,12 +418,13 @@ module Rouge
     # Given a string, yield [token, chunk] pairs.  If no block is given,
     # an enumerator is returned.
     def lex(string, opts=nil, &b)
+      warn 'The use of opts with Lexer.lex is deprecated' unless opts.nil?
+      return enum_for(:lex, string) unless block_given?
+
       if opts && opts[:continue]
-        warn 'the :continue option to Formatter#lex is deprecated, use #continue_lex instead.'
+        warn 'Use #continue_lex instead'
         return continue_lex(string, &b)
       end
-
-      return enum_for(:lex, string) unless block_given?
 
       Lexer.assert_utf8!(string)
       reset!

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -31,6 +31,18 @@ describe Rouge::Formatters::HTML do
     end
   end
 
+  describe 'format using lexer instance called with options' do
+    let(:text) { %(<meta name="description" content="foo">\n<script>alert("bar")</script>) }
+    let(:subject) { Rouge::Formatters::HTML.new }
+    let(:tokens) { Rouge::Lexers::HTML.new.lex text, {} }
+    let(:output) { subject.format(tokens) }
+
+    it 'should format token stream' do
+      assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
+<span class="nt">&lt;script&gt;</span><span class="nx">alert</span><span class="p">(</span><span class="dl">"</span><span class="s2">bar</span><span class="dl">"</span><span class="p">)</span><span class="nt">&lt;/script&gt;</span>' }
+    end
+  end
+
   describe 'tableized line numbers' do
     let(:options) { { :line_numbers => true } }
 

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -38,8 +38,12 @@ describe Rouge::Formatters::HTML do
     let(:output) { subject.format(tokens) }
 
     it 'should format token stream' do
-      assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
+      out, err  = capture_io do
+        assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
 <span class="nt">&lt;script&gt;</span><span class="nx">alert</span><span class="p">(</span><span class="dl">"</span><span class="s2">bar</span><span class="dl">"</span><span class="p">)</span><span class="nt">&lt;/script&gt;</span>' }
+      end
+
+      assert_match %r%deprecated%, err
     end
   end
 

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -38,12 +38,8 @@ describe Rouge::Formatters::HTML do
     let(:output) { subject.format(tokens) }
 
     it 'should format token stream' do
-      out, err  = capture_io do
-        assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
+      assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
 <span class="nt">&lt;script&gt;</span><span class="nx">alert</span><span class="p">(</span><span class="dl">"</span><span class="s2">bar</span><span class="dl">"</span><span class="p">)</span><span class="nt">&lt;/script&gt;</span>' }
-      end
-
-      assert_match %r%deprecated%, err
     end
   end
 


### PR DESCRIPTION
Version 3.4.0 of Rouge moved from passing `opts[:continue]` to the class method `.lex` to calling the new class method `.continue_lex`. As implemented, the change was breaking and could cause Rouge to crash (see #1175). This was not intentional and this commit reverts the change. Internally, Rouge still uses `.continue_lex` but `.lex` will function as it did in version 3.3.0. A warning is displayed for uses with `$VERBOSE` set to true.

This fixes #1175.