### PR TITLE
Enable Rubocop ambiguity warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,10 +41,8 @@ Lint/UnneededSplatExpansion:
 Lint/IneffectiveAccessModifier:
   Enabled: false
 
-# TODO: enable it in a future because `ruby -w` warns it
 Lint/AmbiguousRegexpLiteral:
-  Enabled: false
+  Enabled: true
 
-# TODO: enable it in a future because `ruby -w` warns it
 Lint/AmbiguousOperator:
-  Enabled: false
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,9 +40,3 @@ Lint/UnneededSplatExpansion:
 
 Lint/IneffectiveAccessModifier:
   Enabled: false
-
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
-
-Lint/AmbiguousOperator:
-  Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ matrix:
     - rvm   : *latest_ruby
       name  : Profile Memory Allocation
       script: bundle exec rake profile_memory
+    - rvm   : *latest_ruby
+      name  : Interpreter Warnings Test
+      env   : RUBYOPT=-w
+      script: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require "rake/testtask"
 Rake::TestTask.new(:spec) do |t|
   t.libs << "lib"
   t.ruby_opts << "-r./spec/spec_helper"
-  t.warning = false # TODO: true
+  t.warning = !!$VERBOSE
   t.pattern = FileList['spec/**/*_spec.rb']
 end
 

--- a/lib/rouge/demos/brainfuck
+++ b/lib/rouge/demos/brainfuck
@@ -1,0 +1,5 @@
+[
+	This is a sample
+	comment.
+]
+.[>+<-]>,

--- a/lib/rouge/formatter.rb
+++ b/lib/rouge/formatter.rb
@@ -94,7 +94,7 @@ module Rouge
 
       out = []
       tokens.each do |tok, val|
-        val.scan /\n|[^\n]+/ do |s|
+        val.scan %r/\n|[^\n]+/ do |s|
           if s == "\n"
             yield out
             out = []

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -213,7 +213,7 @@ module Rouge
       # @private
       def register(name, lexer)
         # reset an existing list of lexers
-        @all = nil if @all
+        @all = nil if defined?(@all)
         registry[name.to_s] = lexer
       end
 

--- a/lib/rouge/lexers/abap.rb
+++ b/lib/rouge/lexers/abap.rb
@@ -182,16 +182,16 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
 
-        rule /".*/, Comment::Single
+        rule %r/".*/, Comment::Single
         rule %r(^\*.*), Comment::Multiline
-        rule /\d+/, Num::Integer
-        rule /('|`)/, Str::Single, :single_string
-        rule /[\[\]\(\)\{\}\[\]\.,:\|]/, Punctuation
+        rule %r/\d+/, Num::Integer
+        rule %r/('|`)/, Str::Single, :single_string
+        rule %r/[\[\]\(\)\{\}\[\]\.,:\|]/, Punctuation
 
         # builtins / new ABAP 7.40 keywords (@DATA(), ...)
-        rule /(->|=>)?([A-Za-z][A-Za-z0-9_\-]*)(\()/ do |m|
+        rule %r/(->|=>)?([A-Za-z][A-Za-z0-9_\-]*)(\()/ do |m|
           if m[1] != ''
             token Operator, m[1]
           end
@@ -207,7 +207,7 @@ module Rouge
         end
 
         # keywords, types and normal text
-        rule /\w[\w\d]*/ do |m|
+        rule %r/\w[\w\d]*/ do |m|
           if self.class.keywords.include? m[0].upcase
             token Keyword
           elsif self.class.types.include? m[0].downcase
@@ -229,10 +229,10 @@ module Rouge
       end
 
       state :single_string do
-        rule /\\./, Str::Escape
-        rule /(''|``)/, Str::Escape
-        rule /['`]/, Str::Single, :pop!
-        rule /[^\\'`]+/, Str::Single
+        rule %r/\\./, Str::Escape
+        rule %r/(''|``)/, Str::Escape
+        rule %r/['`]/, Str::Single, :pop!
+        rule %r/[^\\'`]+/, Str::Single
       end
 
     end

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -57,7 +57,7 @@ module Rouge
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule %r/\//, Str::Escape
+        rule %r(/), Str::Escape
 
         rule %r([^/]\n) do
           token Error

--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'application/x-actionscript'
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
@@ -26,9 +26,9 @@ module Rouge
           goto :regex
         end
 
-        rule /[{]/, Punctuation, :object
+        rule %r/[{]/, Punctuation, :object
 
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :regex do
@@ -39,38 +39,38 @@ module Rouge
 
         rule %r([^/]\n), Error, :pop!
 
-        rule /\n/, Error, :pop!
-        rule /\[\^/, Str::Escape, :regex_group
-        rule /\[/, Str::Escape, :regex_group
-        rule /\\./, Str::Escape
+        rule %r/\n/, Error, :pop!
+        rule %r/\[\^/, Str::Escape, :regex_group
+        rule %r/\[/, Str::Escape, :regex_group
+        rule %r/\\./, Str::Escape
         rule %r{[(][?][:=<!]}, Str::Escape
-        rule /[{][\d,]+[}]/, Str::Escape
-        rule /[()?]/, Str::Escape
-        rule /./, Str::Regex
+        rule %r/[{][\d,]+[}]/, Str::Escape
+        rule %r/[()?]/, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :regex_end do
-        rule /[gim]+/, Str::Regex, :pop!
+        rule %r/[gim]+/, Str::Regex, :pop!
         rule(//) { pop! }
       end
 
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule /\//, Str::Escape
+        rule %r/\//, Str::Escape
 
         rule %r([^/]\n) do
           token Error
           pop! 2
         end
 
-        rule /\]/, Str::Escape, :pop!
-        rule /\\./, Str::Escape
-        rule /./, Str::Regex
+        rule %r/\]/, Str::Escape, :pop!
+        rule %r/\\./, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :bad_regex do
-        rule /[^\n]+/, Error, :pop!
+        rule %r/[^\n]+/, Error, :pop!
       end
 
       def self.keywords
@@ -109,25 +109,25 @@ module Rouge
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/
 
       state :root do
-        rule /\A\s*#!.*?\n/m, Comment::Preproc, :statement
-        rule /\n/, Text, :statement
+        rule %r/\A\s*#!.*?\n/m, Comment::Preproc, :statement
+        rule %r/\n/, Text, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===
                | !== )x,
           Operator, :expr_start
         rule %r([:-<>+*%&|\^/!=]=?), Operator, :expr_start
-        rule /[(\[,]/, Punctuation, :expr_start
-        rule /;/, Punctuation, :statement
-        rule /[)\].]/, Punctuation
+        rule %r/[(\[,]/, Punctuation, :expr_start
+        rule %r/;/, Punctuation, :statement
+        rule %r/[)\].]/, Punctuation
 
-        rule /[?]/ do
+        rule %r/[?]/ do
           token Punctuation
           push :ternary
           push :expr_start
         end
 
-        rule /[{}]/, Punctuation, :statement
+        rule %r/[{}]/, Punctuation, :statement
 
         rule id do |m|
           if self.class.keywords.include? m[0]
@@ -147,20 +147,20 @@ module Rouge
           end
         end
 
-        rule /\-?[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
-        rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /\-?[0-9]+/, Num::Integer
-        rule /"(\\\\|\\"|[^"])*"/, Str::Double
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
+        rule %r/\-?[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
+        rule %r/0x[0-9a-fA-F]+/, Num::Hex
+        rule %r/\-?[0-9]+/, Num::Integer
+        rule %r/"(\\\\|\\"|[^"])*"/, Str::Double
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Single
       end
 
       # braced parts that aren't object literals
       state :statement do
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/(#{id})(\s*)(:)/ do
           groups Name::Label, Text, Punctuation
         end
 
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
 
         mixin :expr_start
       end
@@ -168,23 +168,23 @@ module Rouge
       # object literals
       state :object do
         mixin :comments_and_whitespace
-        rule /[}]/ do
+        rule %r/[}]/ do
           token Punctuation
           goto :statement
         end
 
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/(#{id})(\s*)(:)/ do
           groups Name::Attribute, Text, Punctuation
           push :expr_start
         end
 
-        rule /:/, Punctuation
+        rule %r/:/, Punctuation
         mixin :root
       end
 
       # ternary expressions, where <id>: is not a label!
       state :ternary do
-        rule /:/ do
+        rule %r/:/ do
           token Punctuation
           goto :expr_start
         end

--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -30,19 +30,19 @@ module Rouge
       end
 
       state :whitespace do
-        rule /\#.*/, Comment
-        rule /\s+/m, Text
+        rule %r/\#.*/, Comment
+        rule %r/\s+/m, Text
       end
 
       state :root do
         mixin :whitespace
 
-        rule /(<\/?)(\w+)/ do |m|
+        rule %r/(<\/?)(\w+)/ do |m|
           groups Punctuation, name_for_token(m[2].downcase, :sections, Name::Label)
           push :section
         end
 
-        rule /\w+/ do |m|
+        rule %r/\w+/ do |m|
           token name_for_token(m[0].downcase, :directives, Name::Class)
           push :directive
         end
@@ -50,7 +50,7 @@ module Rouge
 
       state :section do
         # Match section arguments
-        rule /([^>]+)?(>(?:\r\n?|\n)?)/ do |m|
+        rule %r/([^>]+)?(>(?:\r\n?|\n)?)/ do |m|
           groups Literal::String::Regex, Punctuation
           pop!
         end
@@ -60,11 +60,11 @@ module Rouge
 
       state :directive do
         # Match value literals and other directive arguments
-        rule /\r\n?|\n/, Text, :pop!
+        rule %r/\r\n?|\n/, Text, :pop!
 
         mixin :whitespace
 
-        rule /\S+/ do |m|
+        rule %r/\S+/ do |m|
           token name_for_token(m[0], :values, Literal::String::Symbol)
         end
       end

--- a/lib/rouge/lexers/apple_script.rb
+++ b/lib/rouge/lexers/apple_script.rb
@@ -319,28 +319,28 @@ module Rouge
       identifiers = %r(\b([a-zA-Z]\w*)\b)
 
       state :root do
-        rule /\s+/, Text::Whitespace
-        rule /¬\n/, Literal::String::Escape
-        rule /'s\s+/, Text
-        rule /(--|#).*?$/, Comment::Single
-        rule /\(\*/, Comment::Multiline
-        rule /[\(\){}!,.:]/, Punctuation
-        rule /(«)([^»]+)(»)/ do |match|
+        rule %r/\s+/, Text::Whitespace
+        rule %r/¬\n/, Literal::String::Escape
+        rule %r/'s\s+/, Text
+        rule %r/(--|#).*?$/, Comment::Single
+        rule %r/\(\*/, Comment::Multiline
+        rule %r/[\(\){}!,.:]/, Punctuation
+        rule %r/(«)([^»]+)(»)/ do |match|
           token Text, match[1]
           token Name::Builtin, match[2]
           token Text, match[3]
         end
-        rule /\b((?:considering|ignoring)\s*)(application responses|case|diacriticals|hyphens|numeric strings|punctuation|white space)/ do |match|
+        rule %r/\b((?:considering|ignoring)\s*)(application responses|case|diacriticals|hyphens|numeric strings|punctuation|white space)/ do |match|
           token Keyword, match[1]
           token Name::Builtin, match[2]
         end
-        rule /(-|\*|\+|&|≠|>=?|<=?|=|≥|≤|\/|÷|\^)/, Operator
+        rule %r/(-|\*|\+|&|≠|>=?|<=?|=|≥|≤|\/|÷|\^)/, Operator
         rule operators, Operator::Word
-        rule /^(\s*(?:on|end)\s+)'r'(%s)/ do |match|
+        rule %r/^(\s*(?:on|end)\s+)'r'(%s)/ do |match|
           token Keyword, match[1]
           token Name::Function, match[2]
         end
-        rule /^(\s*)(in|on|script|to)(\s+)/ do |match|
+        rule %r/^(\s*)(in|on|script|to)(\s+)/ do |match|
           token Text, match[1]
           token Keyword, match[2]
           token Text, match[3]
@@ -359,10 +359,10 @@ module Rouge
         rule studio_classes, Name::Builtin
         rule studio_commands, Name::Builtin
         rule references, Name::Builtin
-        rule /"(\\\\|\\"|[^"])*"/, Literal::String::Double
+        rule %r/"(\\\\|\\"|[^"])*"/, Literal::String::Double
         rule identifiers, Name::Variable
-        rule /[-+]?(\d+\.\d*|\d*\.\d+)(E[-+][0-9]+)?/, Literal::Number::Float
-        rule /[-+]?\d+/, Literal::Number::Integer
+        rule %r/[-+]?(\d+\.\d*|\d*\.\d+)(E[-+][0-9]+)?/, Literal::Number::Float
+        rule %r/[-+]?\d+/, Literal::Number::Integer
       end
     end
   end

--- a/lib/rouge/lexers/awk.rb
+++ b/lib/rouge/lexers/awk.rb
@@ -85,7 +85,7 @@ module Rouge
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule %r/\//, Str::Escape
+        rule %r(/), Str::Escape
 
         rule %r([^/]\n) do
           token Error

--- a/lib/rouge/lexers/awk.rb
+++ b/lib/rouge/lexers/awk.rb
@@ -47,7 +47,7 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(#.*?$), Comment::Single
       end
 
@@ -57,7 +57,7 @@ module Rouge
           token Str::Regex
           goto :regex
         end
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :regex do
@@ -68,14 +68,14 @@ module Rouge
 
         rule %r([^/]\n), Error, :pop!
 
-        rule /\n/, Error, :pop!
-        rule /\[\^/, Str::Escape, :regex_group
-        rule /\[/, Str::Escape, :regex_group
-        rule /\\./, Str::Escape
+        rule %r/\n/, Error, :pop!
+        rule %r/\[\^/, Str::Escape, :regex_group
+        rule %r/\[/, Str::Escape, :regex_group
+        rule %r/\\./, Str::Escape
         rule %r{[(][?][:=<!]}, Str::Escape
-        rule /[{][\d,]+[}]/, Str::Escape
-        rule /[()?]/, Str::Escape
-        rule /./, Str::Regex
+        rule %r/[{][\d,]+[}]/, Str::Escape
+        rule %r/[()?]/, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :regex_end do
@@ -85,20 +85,20 @@ module Rouge
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule /\//, Str::Escape
+        rule %r/\//, Str::Escape
 
         rule %r([^/]\n) do
           token Error
           pop! 2
         end
 
-        rule /\]/, Str::Escape, :pop!
-        rule /\\./, Str::Escape
-        rule /./, Str::Regex
+        rule %r/\]/, Str::Escape, :pop!
+        rule %r/\\./, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :bad_regex do
-        rule /[^\n]+/, Error, :pop!
+        rule %r/[^\n]+/, Error, :pop!
       end
 
       state :root do
@@ -106,17 +106,17 @@ module Rouge
         rule %r((?<=\n)(?=\s|/)), Text, :expr_start
         rule %r([-<>+*/%\^!=]=?|in\b|\+\+|--|\|), Operator, :expr_start
         rule %r(&&|\|\||~!?), Operator, :expr_start
-        rule /[(\[,]/, Punctuation, :expr_start
-        rule /;/, Punctuation, :statement
-        rule /[)\].]/, Punctuation
+        rule %r/[(\[,]/, Punctuation, :expr_start
+        rule %r/;/, Punctuation, :statement
+        rule %r/[)\].]/, Punctuation
 
-        rule /[?]/ do
+        rule %r/[?]/ do
           token Punctuation
           push :ternary
           push :expr_start
         end
 
-        rule /[{}]/, Punctuation, :statement
+        rule %r/[{}]/, Punctuation, :statement
 
         rule id do |m|
           if self.class.keywords.include? m[0]
@@ -138,19 +138,19 @@ module Rouge
           end
         end
 
-        rule /[0-9]+\.[0-9]+/, Num::Float
-        rule /[0-9]+/, Num::Integer
-        rule /"(\\[\\"]|[^"])*"/, Str::Double
-        rule /:/, Punctuation
+        rule %r/[0-9]+\.[0-9]+/, Num::Float
+        rule %r/[0-9]+/, Num::Integer
+        rule %r/"(\\[\\"]|[^"])*"/, Str::Double
+        rule %r/:/, Punctuation
       end
 
       state :statement do
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
         mixin :expr_start
       end
 
       state :ternary do
-        rule /:/ do
+        rule %r/:/ do
           token Punctuation
           goto :expr_start
         end

--- a/lib/rouge/lexers/biml.rb
+++ b/lib/rouge/lexers/biml.rb
@@ -26,16 +26,16 @@ module Rouge
       end
 
       state :directive_as_csharp do
-        rule /\s*#>\s*/m, Name::Tag, :pop!
+        rule %r/\s*#>\s*/m, Name::Tag, :pop!
         rule %r(.*?(?=\s*#>\s*))m do
           delegate CSharp
         end
       end
 
       state :directive_tag do
-        rule /\s+/m, Text
-        rule /[\w.:-]+\s*=/m, Name::Attribute, :attr
-        rule /[\w]+\s*/m, Name::Attribute
+        rule %r/\s+/m, Text
+        rule %r/[\w.:-]+\s*=/m, Name::Attribute, :attr
+        rule %r/[\w]+\s*/m, Name::Attribute
         rule %r(/?\s*#>), Name::Tag, :pop!
       end
     end

--- a/lib/rouge/lexers/brainfuck.rb
+++ b/lib/rouge/lexers/brainfuck.rb
@@ -14,39 +14,39 @@ module Rouge
       start { push :bol }
 
       state :bol do
-        rule /\s+/m, Text
-        rule /\[/, Comment::Multiline, :comment_multi
+        rule %r/\s+/m, Text
+        rule %r/\[/, Comment::Multiline, :comment_multi
         rule(//) { pop! }
       end
 
       state :root do
-        rule /\]/, Error
-        rule /\[/, Punctuation, :loop
+        rule %r/\]/, Error
+        rule %r/\[/, Punctuation, :loop
 
         mixin :comment_single
         mixin :commands
       end
 
       state :comment_multi do
-        rule /\[/, Comment::Multiline, :comment_multi
-        rule /\]/, Comment::Multiline, :pop!
-        rule /[^\[\]]+?/m, Comment::Multiline
+        rule %r/\[/, Comment::Multiline, :comment_multi
+        rule %r/\]/, Comment::Multiline, :pop!
+        rule %r/[^\[\]]+?/m, Comment::Multiline
       end
 
       state :comment_single do
-        rule /[^><+\-.,\[\]]+/, Comment::Single
+        rule %r/[^><+\-.,\[\]]+/, Comment::Single
       end
 
       state :loop do
-        rule /\[/, Punctuation, :loop
-        rule /\]/, Punctuation, :pop!
+        rule %r/\[/, Punctuation, :loop
+        rule %r/\]/, Punctuation, :pop!
         mixin :comment_single
         mixin :commands
       end
 
       state :commands do
-        rule /[><]+/, Name::Builtin
-        rule /[+\-.,]+/, Name::Function
+        rule %r/[><]+/, Name::Builtin
+        rule %r/[+\-.,]+/, Name::Function
       end
     end
   end

--- a/lib/rouge/lexers/brainfuck.rb
+++ b/lib/rouge/lexers/brainfuck.rb
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Brainfuck < RegexLexer
+      tag 'brainfuck'
+      filenames '*.b', '*.bf'
+      mimetypes 'text/x-brainfuck'
+
+      title "Brainfuck"
+      desc "The Brainfuck programming language"
+
+      start { push :bol }
+
+      state :bol do
+        rule /\s+/m, Text
+        rule /\[/, Comment::Multiline, :comment_multi
+        rule(//) { pop! }
+      end
+
+      state :root do
+        rule /\]/, Error
+        rule /\[/, Punctuation, :loop
+
+        mixin :comment_single
+        mixin :commands
+      end
+
+      state :comment_multi do
+        rule /\[/, Comment::Multiline, :comment_multi
+        rule /\]/, Comment::Multiline, :pop!
+        rule /[^\[\]]+?/m, Comment::Multiline
+      end
+
+      state :comment_single do
+        rule /[^><+\-.,\[\]]+/, Comment::Single
+      end
+
+      state :loop do
+        rule /\[/, Punctuation, :loop
+        rule /\]/, Punctuation, :pop!
+        mixin :comment_single
+        mixin :commands
+      end
+
+      state :commands do
+        rule /[><]+/, Name::Builtin
+        rule /[+\-.,]+/, Name::Function
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/bsl.rb
+++ b/lib/rouge/lexers/bsl.rb
@@ -62,7 +62,7 @@ module Rouge
       state :root do
         rule %r/\n/, Text
         rule %r/[^\S\n]+/, Text
-        rule %r/\/\/.*$/, Comment::Single
+        rule %r(//.*$), Comment::Single
         rule %r/[\[\]:(),;]/, Punctuation
         rule %r/(?<=[^\wа-яё]|^)\&.*$/, Keyword::Declaration
         rule %r/[-+\/=<>*%=<>.?&]/, Operator

--- a/lib/rouge/lexers/bsl.rb
+++ b/lib/rouge/lexers/bsl.rb
@@ -60,22 +60,22 @@ module Rouge
                     )\s*(?=\()/ix
 
       state :root do
-        rule /\n/, Text
-        rule /[^\S\n]+/, Text
-        rule /\/\/.*$/, Comment::Single
-        rule /[\[\]:(),;]/, Punctuation
-        rule /(?<=[^\wа-яё]|^)\&.*$/, Keyword::Declaration
-        rule /[-+\/=<>*%=<>.?&]/, Operator
-        rule /(?<=[^\wа-яё]|^)\#.*$/, Keyword::Declaration
+        rule %r/\n/, Text
+        rule %r/[^\S\n]+/, Text
+        rule %r/\/\/.*$/, Comment::Single
+        rule %r/[\[\]:(),;]/, Punctuation
+        rule %r/(?<=[^\wа-яё]|^)\&.*$/, Keyword::Declaration
+        rule %r/[-+\/=<>*%=<>.?&]/, Operator
+        rule %r/(?<=[^\wа-яё]|^)\#.*$/, Keyword::Declaration
         rule KEYWORDS, Keyword
         rule BUILTINS, Name::Builtin
-        rule /[\wа-яё_][\wа-яё0-9_]*/i, Name::Variable
+        rule %r/[\wа-яё_][\wа-яё0-9_]*/i, Name::Variable
 
         #literals
-        rule /\b((\h{8}-(\h{4}-){3}\h{12})|\d+\.?\d*)\b/, Literal::Number
-        rule /\'.*\'/, Literal::Date
-        rule /".*?("|$)/, Literal::String::Single
-        rule /(?<=[^\wа-яё]|^)\|((?!\"\").)*?(\"|$)/, Literal::String
+        rule %r/\b((\h{8}-(\h{4}-){3}\h{12})|\d+\.?\d*)\b/, Literal::Number
+        rule %r/\'.*\'/, Literal::Date
+        rule %r/".*?("|$)/, Literal::String::Single
+        rule %r/(?<=[^\wа-яё]|^)\|((?!\"\").)*?(\"|$)/, Literal::String
       end
     end
   end

--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -65,8 +65,8 @@ module Rouge
       state :expr_bol do
         mixin :inline_whitespace
 
-        rule /#if\s0/, Comment, :if_0
-        rule /#/, Comment::Preproc, :macro
+        rule %r/#if\s0/, Comment, :if_0
+        rule %r/#/, Comment::Preproc, :macro
 
         rule(//) { pop! }
       end
@@ -74,41 +74,41 @@ module Rouge
       # :expr_bol is the same as :bol but without labels, since
       # labels can only appear at the beginning of a statement.
       state :bol do
-        rule /#{id}:(?!:)/, Name::Label
+        rule %r/#{id}:(?!:)/, Name::Label
         mixin :expr_bol
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
-        rule /\\\n/, Text # line continuation
+        rule %r/[ \t\r]+/, Text
+        rule %r/\\\n/, Text # line continuation
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :bol
+        rule %r/\n+/m, Text, :bol
         rule %r(//(\\.|.)*?$), Comment::Single, :bol
         mixin :inline_whitespace
       end
 
       state :expr_whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         mixin :whitespace
       end
 
       state :statements do
         mixin :whitespace
-        rule /(u8|u|U|L)?"/, Str, :string
+        rule %r/(u8|u|U|L)?"/, Str, :string
         rule %r((u8|u|U|L)?'(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
         rule %r((\d+[.]\d*|[.]?\d+)e[+-]?\d+[lu]*)i, Num::Float
         rule %r(\d+e[+-]?\d+[lu]*)i, Num::Float
-        rule /0x[0-9a-f]+[lu]*/i, Num::Hex
-        rule /0[0-7]+[lu]*/i, Num::Oct
-        rule /\d+[lu]*/i, Num::Integer
+        rule %r/0x[0-9a-f]+[lu]*/i, Num::Hex
+        rule %r/0[0-7]+[lu]*/i, Num::Oct
+        rule %r/\d+[lu]*/i, Num::Integer
         rule %r(\*/), Error
         rule %r([~!%^&*+=\|?:<>/-]), Operator
-        rule /[()\[\],.;]/, Punctuation
-        rule /\bcase\b/, Keyword, :case
-        rule /(?:true|false|NULL)\b/, Name::Builtin
+        rule %r/[()\[\],.;]/, Punctuation
+        rule %r/\bcase\b/, Keyword, :case
+        rule %r/(?:true|false|NULL)\b/, Name::Builtin
         rule id do |m|
           name = m[0]
 
@@ -127,7 +127,7 @@ module Rouge
       end
 
       state :case do
-        rule /:/, Punctuation, :pop!
+        rule %r/:/, Punctuation, :pop!
         mixin :statements
       end
 
@@ -149,41 +149,41 @@ module Rouge
             push :function
           end
         end
-        rule /\{/, Punctuation, :function
+        rule %r/\{/, Punctuation, :function
         mixin :statements
       end
 
       state :function do
         mixin :whitespace
         mixin :statements
-        rule /;/, Punctuation
-        rule /{/, Punctuation, :function
-        rule /}/, Punctuation, :pop!
+        rule %r/;/, Punctuation
+        rule %r/{/, Punctuation, :function
+        rule %r/}/, Punctuation, :pop!
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\\n/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/"/, Str, :pop!
+        rule %r/\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\\n/, Str
+        rule %r/\\/, Str # stray backslash
       end
 
       state :macro do
         # NB: pop! goes back to :bol
-        rule /\n/, Comment::Preproc, :pop!
+        rule %r/\n/, Comment::Preproc, :pop!
         rule %r([^/\n\\]+), Comment::Preproc
-        rule /\\./m, Comment::Preproc
+        rule %r/\\./m, Comment::Preproc
         mixin :inline_whitespace
         rule %r(/), Comment::Preproc
       end
 
       state :if_0 do
         # NB: no \b here, to cover #ifdef and #ifndef
-        rule /^\s*#if/, Comment, :if_0
-        rule /^\s*#\s*el(?:se|if)/, Comment, :pop!
-        rule /^\s*#\s*endif\b.*?(?<!\\)\n/m, Comment, :pop!
-        rule /.*?\n/, Comment
+        rule %r/^\s*#if/, Comment, :if_0
+        rule %r/^\s*#\s*el(?:se|if)/, Comment, :pop!
+        rule %r/^\s*#\s*endif\b.*?(?<!\\)\n/m, Comment, :pop!
+        rule %r/.*?\n/, Comment
       end
     end
   end

--- a/lib/rouge/lexers/cfscript.rb
+++ b/lib/rouge/lexers/cfscript.rb
@@ -37,30 +37,30 @@ module Rouge
 
       state :root do
         mixin :comments_and_whitespace
-        rule /(?:#{operators.join('|')}|does not contain|greater than(?: or equal to)?|less than(?: or equal to)?)\b/i, Operator, :expr_start
+        rule %r/(?:#{operators.join('|')}|does not contain|greater than(?: or equal to)?|less than(?: or equal to)?)\b/i, Operator, :expr_start
         rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start
 
-        rule /[(\[,]/, Punctuation, :expr_start
-        rule /;/, Punctuation, :statement
-        rule /[)\].]/, Punctuation
+        rule %r/[(\[,]/, Punctuation, :expr_start
+        rule %r/;/, Punctuation, :statement
+        rule %r/[)\].]/, Punctuation
 
-        rule /[?]/ do
+        rule %r/[?]/ do
           token Punctuation
           push :ternary
           push :expr_start
         end
 
-        rule /[{}]/, Punctuation, :statement
+        rule %r/[{}]/, Punctuation, :statement
 
-        rule /(?:#{constants.join('|')})\b/, Name::Constant
-        rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /import\b/, Keyword::Namespace, :import
-        rule /(#{dotted_id})(\s*)(:)(\s*)/ do
+        rule %r/(?:#{constants.join('|')})\b/, Name::Constant
+        rule %r/(?:true|false|null)\b/, Keyword::Constant
+        rule %r/import\b/, Keyword::Namespace, :import
+        rule %r/(#{dotted_id})(\s*)(:)(\s*)/ do
           groups Name, Text, Punctuation, Text
           push :expr_start
         end
 
-        rule /([A-Za-z_$][\w.]*)(\s*)(\()/ do |m|
+        rule %r/([A-Za-z_$][\w.]*)(\s*)(\()/ do |m|
           if self.class.keywords.include? m[1]
             token Keyword, m[1]
             token Text, m[2]
@@ -87,17 +87,17 @@ module Rouge
           end
         end
 
-        rule /[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
-        rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /[0-9]+/, Num::Integer
-        rule /"(\\\\|\\"|[^"])*"/, Str::Double
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
+        rule %r/[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
+        rule %r/0x[0-9a-fA-F]+/, Num::Hex
+        rule %r/[0-9]+/, Num::Integer
+        rule %r/"(\\\\|\\"|[^"])*"/, Str::Double
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Single
 
       end
 
       # same as java, broken out
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
       end
@@ -105,14 +105,14 @@ module Rouge
       state :expr_start do
         mixin :comments_and_whitespace
 
-        rule /[{]/, Punctuation, :object
+        rule %r/[{]/, Punctuation, :object
 
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :statement do
 
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
 
         mixin :expr_start
       end
@@ -120,23 +120,23 @@ module Rouge
       # object literals
       state :object do
         mixin :comments_and_whitespace
-        rule /[}]/ do
+        rule %r/[}]/ do
           token Punctuation
           push :expr_start
         end
 
-        rule /(#{dotted_id})(\s*)(:)/ do
+        rule %r/(#{dotted_id})(\s*)(:)/ do
           groups Name::Other, Text, Punctuation
           push :expr_start
         end
 
-        rule /:/, Punctuation
+        rule %r/:/, Punctuation
         mixin :root
       end
 
       # ternary expressions, where <dotted_id>: is not a label!
       state :ternary do
-        rule /:/ do
+        rule %r/:/ do
           token Punctuation
           goto :expr_start
         end
@@ -145,8 +145,8 @@ module Rouge
       end
 
       state :import do
-        rule /\s+/m, Text
-        rule /[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
+        rule %r/\s+/m, Text
+        rule %r/[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
       end
 
     end

--- a/lib/rouge/lexers/clojure.rb
+++ b/lib/rouge/lexers/clojure.rb
@@ -74,22 +74,22 @@ module Rouge
       end
 
       state :root do
-        rule /;.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule %r/;.*?$/, Comment::Single
+        rule %r/\s+/m, Text::Whitespace
 
-        rule /-?\d+\.\d+/, Num::Float
-        rule /-?\d+/, Num::Integer
-        rule /0x-?[0-9a-fA-F]+/, Num::Hex
+        rule %r/-?\d+\.\d+/, Num::Float
+        rule %r/-?\d+/, Num::Integer
+        rule %r/0x-?[0-9a-fA-F]+/, Num::Hex
 
-        rule /"(\\.|[^"])*"/, Str
-        rule /'#{keyword}/, Str::Symbol
-        rule /::?#{keyword}/, Name::Constant
-        rule /\\(.|[a-z]+)/i, Str::Char
+        rule %r/"(\\.|[^"])*"/, Str
+        rule %r/'#{keyword}/, Str::Symbol
+        rule %r/::?#{keyword}/, Name::Constant
+        rule %r/\\(.|[a-z]+)/i, Str::Char
 
 
-        rule /~@|[`\'#^~&@]/, Operator
+        rule %r/~@|[`\'#^~&@]/, Operator
 
-        rule /(\()(\s*)(#{identifier})/m do |m|
+        rule %r/(\()(\s*)(#{identifier})/m do |m|
           token Punctuation, m[1]
           token Text::Whitespace, m[2]
           token(name_token(m[3]) || Name::Function, m[3])
@@ -100,13 +100,13 @@ module Rouge
         end
 
         # vectors
-        rule /[\[\]]/, Punctuation
+        rule %r/[\[\]]/, Punctuation
 
         # maps
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
 
         # parentheses
-        rule /[()]/, Punctuation
+        rule %r/[()]/, Punctuation
       end
     end
   end

--- a/lib/rouge/lexers/cmake.rb
+++ b/lib/rouge/lexers/cmake.rb
@@ -125,23 +125,23 @@ module Rouge
       ]
 
       state :default do
-        rule /\r\n?|\n/ do
+        rule %r/\r\n?|\n/ do
           token STATES_MAP[state.name.to_sym]
         end
-        rule /./ do
+        rule %r/./ do
           token STATES_MAP[state.name.to_sym]
         end
       end
 
       state :variable_interpolation do
-        rule /\$\{/ do
+        rule %r/\$\{/ do
           token Str::Interpol
           push :variable_reference
         end
       end
 
       state :bracket_close do
-        rule /\]=*\]/ do |m|
+        rule %r/\]=*\]/ do |m|
           token STATES_MAP[state.name.to_sym]
           goto :root if m[0].length == @bracket_len
         end
@@ -150,27 +150,27 @@ module Rouge
       state :root do
         mixin :variable_interpolation
 
-        rule /#{SPACE}/, Text
-        rule /[()]/, Punctuation
+        rule %r/#{SPACE}/, Text
+        rule %r/[()]/, Punctuation
 
-        rule /##{BRACKET_OPEN}/ do |m|
+        rule %r/##{BRACKET_OPEN}/ do |m|
           token Comment::Multiline
           @bracket_len = m[0].length - 1 # decount '#'
           goto :bracket_comment
         end
-        rule /#{BRACKET_OPEN}/ do |m|
+        rule %r/#{BRACKET_OPEN}/ do |m|
           token Str::Double
           @bracket_len = m[0].length
           goto :bracket_string
         end
 
-        rule /"/, Str::Double, :quoted_argument
+        rule %r/"/, Str::Double, :quoted_argument
 
-        rule /([A-Za-z_][A-Za-z0-9_]*)(#{SPACE}*)(\()/ do |m|
+        rule %r/([A-Za-z_][A-Za-z0-9_]*)(#{SPACE}*)(\()/ do |m|
           groups BUILTIN_COMMANDS.include?(m[1]) ? Name::Builtin : Name::Function, Text, Punctuation
         end
 
-        rule /#.*/, Comment::Single
+        rule %r/#.*/, Comment::Single
 
         mixin :default
       end
@@ -189,7 +189,7 @@ module Rouge
       state :variable_reference do
         mixin :variable_interpolation
 
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
 
         mixin :default
       end
@@ -197,8 +197,8 @@ module Rouge
       state :quoted_argument do
         mixin :variable_interpolation
 
-        rule /"/, Str::Double, :root
-        rule /\\[()#" \\$@^trn;]/, Str::Escape
+        rule %r/"/, Str::Double, :root
+        rule %r/\\[()#" \\$@^trn;]/, Str::Escape
 
         mixin :default
       end

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -50,9 +50,9 @@ module Rouge
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/
 
       state :comments_and_whitespace do
-        rule /\s+/m, Text
-        rule /###[^#].*?###/m, Comment::Multiline
-        rule /#.*$/, Comment::Single
+        rule %r/\s+/m, Text
+        rule %r/###[^#].*?###/m, Comment::Multiline
+        rule %r/#.*$/, Comment::Single
       end
 
       state :multiline_regex do
@@ -89,21 +89,21 @@ module Rouge
           [?]|:|=|[|][|]|\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*`%&|^/])=?
         )x, Operator, :slash_starts_regex
 
-        rule /[-=]>/, Name::Function
+        rule %r/[-=]>/, Name::Function
 
-        rule /(@)([ \t]*)(#{id})/ do
+        rule %r/(@)([ \t]*)(#{id})/ do
           groups Name::Variable::Instance, Text, Name::Attribute
           push :slash_starts_regex
         end
 
-        rule /([.])([ \t]*)(#{id})/ do
+        rule %r/([.])([ \t]*)(#{id})/ do
           groups Punctuation, Text, Name::Attribute
           push :slash_starts_regex
         end
 
-        rule /#{id}(?=\s*:)/, Name::Attribute, :slash_starts_regex
+        rule %r/#{id}(?=\s*:)/, Name::Attribute, :slash_starts_regex
 
-        rule /#{id}/ do |m|
+        rule %r/#{id}/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           elsif self.class.constants.include? m[0]
@@ -117,65 +117,65 @@ module Rouge
           push :slash_starts_regex
         end
 
-        rule /[{(\[;,]/, Punctuation, :slash_starts_regex
-        rule /[})\].]/, Punctuation
+        rule %r/[{(\[;,]/, Punctuation, :slash_starts_regex
+        rule %r/[})\].]/, Punctuation
 
-        rule /\d+[.]\d+([eE]\d+)?[fd]?/, Num::Float
-        rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /\d+/, Num::Integer
-        rule /"""/, Str, :tdqs
-        rule /'''/, Str, :tsqs
-        rule /"/, Str, :dqs
-        rule /'/, Str, :sqs
+        rule %r/\d+[.]\d+([eE]\d+)?[fd]?/, Num::Float
+        rule %r/0x[0-9a-fA-F]+/, Num::Hex
+        rule %r/\d+/, Num::Integer
+        rule %r/"""/, Str, :tdqs
+        rule %r/'''/, Str, :tsqs
+        rule %r/"/, Str, :dqs
+        rule %r/'/, Str, :sqs
       end
 
       state :strings do
         # all coffeescript strings are multi-line
-        rule /[^#\\'"]+/m, Str
+        rule %r/[^#\\'"]+/m, Str
 
-        rule /\\./, Str::Escape
-        rule /#/, Str
+        rule %r/\\./, Str::Escape
+        rule %r/#/, Str
       end
 
       state :double_strings do
-        rule /'/, Str
+        rule %r/'/, Str
         mixin :has_interpolation
         mixin :strings
       end
 
       state :single_strings do
-        rule /"/, Str
+        rule %r/"/, Str
         mixin :strings
       end
 
       state :interpolation do
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
         mixin :root
       end
 
       state :has_interpolation do
-        rule /[#][{]/, Str::Interpol, :interpolation
+        rule %r/[#][{]/, Str::Interpol, :interpolation
       end
 
       state :dqs do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         mixin :double_strings
       end
 
       state :tdqs do
-        rule /"""/, Str, :pop!
-        rule /"/, Str
+        rule %r/"""/, Str, :pop!
+        rule %r/"/, Str
         mixin :double_strings
       end
 
       state :sqs do
-        rule /'/, Str, :pop!
+        rule %r/'/, Str, :pop!
         mixin :single_strings
       end
 
       state :tsqs do
-        rule /'''/, Str, :pop!
-        rule /'/, Str
+        rule %r/'''/, Str, :pop!
+        rule %r/'/, Str
         mixin :single_strings
       end
     end

--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -215,19 +215,19 @@ module Rouge
       symbol = /(\|[^\|]+\||#{nonmacro}#{constituent}*)/
 
       state :root do
-        rule /\s+/m, Text
-        rule /;.*$/, Comment::Single
-        rule /#\|/, Comment::Multiline, :multiline_comment
+        rule %r/\s+/m, Text
+        rule %r/;.*$/, Comment::Single
+        rule %r/#\|/, Comment::Multiline, :multiline_comment
 
         # encoding comment
-        rule /#\d*Y.*$/, Comment::Special
-        rule /"(\\.|[^"\\])*"/, Str
+        rule %r/#\d*Y.*$/, Comment::Special
+        rule %r/"(\\.|[^"\\])*"/, Str
 
-        rule /[:']#{symbol}/, Str::Symbol
-        rule /['`]/, Operator
+        rule %r/[:']#{symbol}/, Str::Symbol
+        rule %r/['`]/, Operator
 
         # numbers
-        rule /[-+]?\d+\.?#{terminated}/, Num::Integer
+        rule %r/[-+]?\d+\.?#{terminated}/, Num::Integer
         rule %r([-+]?\d+/\d+#{terminated}), Num::Integer
         rule %r(
           [-+]?
@@ -237,65 +237,65 @@ module Rouge
         )x, Num::Float
 
         # sharpsign strings and characters
-        rule /#\\.#{terminated}/, Str::Char
-        rule /#\\#{symbol}/, Str::Char
+        rule %r/#\\.#{terminated}/, Str::Char
+        rule %r/#\\#{symbol}/, Str::Char
 
-        rule /#\(/, Operator, :root
+        rule %r/#\(/, Operator, :root
 
         # bitstring
-        rule /#\d*\*[01]*/, Other
+        rule %r/#\d*\*[01]*/, Other
 
         # uninterned symbol
-        rule /#:#{symbol}/, Str::Symbol
+        rule %r/#:#{symbol}/, Str::Symbol
 
         # read-time and load-time evaluation
-        rule /#[.,]/, Operator
+        rule %r/#[.,]/, Operator
 
         # function shorthand
-        rule /#'/, Name::Function
+        rule %r/#'/, Name::Function
 
         # binary rational
-        rule /#b[+-]?[01]+(\/[01]+)?/i, Num
+        rule %r/#b[+-]?[01]+(\/[01]+)?/i, Num
 
         # octal rational
-        rule /#o[+-]?[0-7]+(\/[0-7]+)?/i, Num::Oct
+        rule %r/#o[+-]?[0-7]+(\/[0-7]+)?/i, Num::Oct
 
         # hex rational
-        rule /#x[+-]?[0-9a-f]+(\/[0-9a-f]+)?/i, Num
+        rule %r/#x[+-]?[0-9a-f]+(\/[0-9a-f]+)?/i, Num
 
         # complex
-        rule /(#c)(\()/i do
+        rule %r/(#c)(\()/i do
           groups Num, Punctuation
           push :root
         end
 
         # arrays and structures
-        rule /(#(?:\d+a|s))(\()/i do
+        rule %r/(#(?:\d+a|s))(\()/i do
           groups Str::Other, Punctuation
           push :root
         end
 
         # path
-        rule /#p?"(\\.|[^"])*"/i, Str::Symbol
+        rule %r/#p?"(\\.|[^"])*"/i, Str::Symbol
 
         # reference
-        rule /#\d+[=#]/, Operator
+        rule %r/#\d+[=#]/, Operator
 
         # read-time comment
-        rule /#+nil#{terminated}\s*\(/, Comment, :commented_form
+        rule %r/#+nil#{terminated}\s*\(/, Comment, :commented_form
 
         # read-time conditional
-        rule /#[+-]/, Operator
+        rule %r/#[+-]/, Operator
 
         # special operators that should have been parsed already
-        rule /(,@|,|\.)/, Operator
+        rule %r/(,@|,|\.)/, Operator
 
         # special constants
-        rule /(t|nil)#{terminated}/, Name::Constant
+        rule %r/(t|nil)#{terminated}/, Name::Constant
 
         # functions and variables
         # note that these get filtered through in stream_tokens
-        rule /\*#{symbol}\*/, Name::Variable::Global
+        rule %r/\*#{symbol}\*/, Name::Variable::Global
         rule symbol do |m|
           sym = m[0]
 
@@ -318,8 +318,8 @@ module Rouge
           end
         end
 
-        rule /\(/, Punctuation, :root
-        rule /\)/, Punctuation do
+        rule %r/\(/, Punctuation, :root
+        rule %r/\)/, Punctuation do
           if stack.size == 1
             token Error
           else
@@ -330,16 +330,16 @@ module Rouge
       end
 
       state :multiline_comment do
-        rule /#\|/, Comment::Multiline, :multiline_comment
-        rule /\|#/, Comment::Multiline, :pop!
-        rule /[^\|#]+/, Comment::Multiline
-        rule /[\|#]/, Comment::Multiline
+        rule %r/#\|/, Comment::Multiline, :multiline_comment
+        rule %r/\|#/, Comment::Multiline, :pop!
+        rule %r/[^\|#]+/, Comment::Multiline
+        rule %r/[\|#]/, Comment::Multiline
       end
 
       state :commented_form do
-        rule /\(/, Comment, :commented_form
-        rule /\)/, Comment, :pop!
-        rule /[^()]+/, Comment
+        rule %r/\(/, Comment, :commented_form
+        rule %r/\)/, Comment, :pop!
+        rule %r/[^()]+/, Comment
       end
     end
   end

--- a/lib/rouge/lexers/conf.rb
+++ b/lib/rouge/lexers/conf.rb
@@ -13,12 +13,12 @@ module Rouge
 
       # short and sweet
       state :root do
-        rule /#.*?\n/, Comment
-        rule /".*?"/, Str::Double
-        rule /'.*?'/, Str::Single
-        rule /[a-z]\w*/i, Name
-        rule /\d+/, Num
-        rule /[^\d\w#"']+/, Text
+        rule %r/#.*?\n/, Comment
+        rule %r/".*?"/, Str::Double
+        rule %r/'.*?'/, Str::Single
+        rule %r/[a-z]\w*/i, Name
+        rule %r/\d+/, Num
+        rule %r/[^\d\w#"']+/, Text
       end
     end
   end

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -113,7 +113,7 @@ module Rouge
           @continue = false
           push :continue_id
         end
-        rule %r/\/\\/, Operator
+        rule %r(/\\), Operator
         rule %r/\\\//, Operator
         rule operator do |m|
           match = m[0]

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -90,8 +90,8 @@ module Rouge
       set_options = /(Set|Unset)(\s+)(Universe|Printing|Implicit|Strict)(\s+)(Polymorphism|All|Notations|Arguments|Universes|Implicit)(\s*)\./m
 
       state :root do
-        rule /[(][*](?![)])/, Comment, :comment
-        rule /\s+/m, Text::Whitespace
+        rule %r/[(][*](?![)])/, Comment, :comment
+        rule %r/\s+/m, Text::Whitespace
         rule module_type do |m|
           token Keyword , 'Module'
           token Text::Whitespace , m[1]
@@ -113,8 +113,8 @@ module Rouge
           @continue = false
           push :continue_id
         end
-        rule /\/\\/, Operator
-        rule /\\\//, Operator
+        rule %r/\/\\/, Operator
+        rule %r/\\\//, Operator
         rule operator do |m|
           match = m[0]
           if self.class.keyopts.include? match
@@ -124,31 +124,31 @@ module Rouge
           end
         end
 
-        rule /-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
-        rule /\d[\d_]*/, Num::Integer
+        rule %r/-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
+        rule %r/\d[\d_]*/, Num::Integer
 
-        rule /'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
-        rule /'/, Keyword
-        rule /"/, Str::Double, :string
-        rule /[~?]#{id}/, Name::Variable
+        rule %r/'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
+        rule %r/'/, Keyword
+        rule %r/"/, Str::Double, :string
+        rule %r/[~?]#{id}/, Name::Variable
       end
 
       state :comment do
-        rule /[^(*)]+/, Comment
+        rule %r/[^(*)]+/, Comment
         rule(/[(][*]/) { token Comment; push }
-        rule /[*][)]/, Comment, :pop!
-        rule /[(*)]/, Comment
+        rule %r/[*][)]/, Comment, :pop!
+        rule %r/[(*)]/, Comment
       end
 
       state :string do
-        rule /(?:\\")+|[^"]/, Str::Double
+        rule %r/(?:\\")+|[^"]/, Str::Double
         mixin :escape_sequence
-        rule /\\\n/, Str::Double
-        rule /"/, Str::Double, :pop!
+        rule %r/\\\n/, Str::Double
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :escape_sequence do
-        rule /\\[\\"'ntbr]/, Str::Escape
+        rule %r/\\[\\"'ntbr]/, Str::Escape
       end
 
       state :continue_id do
@@ -171,7 +171,7 @@ module Rouge
           @continue = false
           pop!
         end
-        rule // do
+        rule %r// do
           if @continue
             token Name::Constant , @name
           else

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -49,7 +49,7 @@ module Rouge
 
       prepend :root do
         # Offload C++ extensions, http://offload.codeplay.com/
-        rule /(?:__offload|__blockingoffload|__outer)\b/, Keyword::Pseudo
+        rule %r/(?:__offload|__blockingoffload|__outer)\b/, Keyword::Pseudo
       end
 
       # digits with optional inner quotes
@@ -57,21 +57,21 @@ module Rouge
       dq = /\d('?\d)*/
 
       prepend :statements do
-        rule /class\b/, Keyword, :classname
+        rule %r/class\b/, Keyword, :classname
         rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
         rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float
-        rule /0x\h('?\h)*[lu]*/i, Num::Hex
-        rule /0[0-7]('?[0-7])*[lu]*/i, Num::Oct
-        rule /#{dq}[lu]*/i, Num::Integer
-        rule /\bnullptr\b/, Name::Builtin
-        rule /(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
+        rule %r/0x\h('?\h)*[lu]*/i, Num::Hex
+        rule %r/0[0-7]('?[0-7])*[lu]*/i, Num::Oct
+        rule %r/#{dq}[lu]*/i, Num::Integer
+        rule %r/\bnullptr\b/, Name::Builtin
+        rule %r/(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
       end
 
       state :classname do
         rule id, Name::Class, :pop!
 
         # template specification
-        rule /\s*(?=>)/m, Text, :pop!
+        rule %r/\s*(?=>)/m, Text, :pop!
         mixin :whitespace
       end
     end

--- a/lib/rouge/lexers/crystal.rb
+++ b/lib/rouge/lexers/crystal.rb
@@ -28,15 +28,15 @@ module Rouge
         rule %r(:(?:\*\*|[-+]@|[/\%&\|^`~]|\[\]=?|<<|>>|<=?>|<=?|===?)),
           Str::Symbol
 
-        rule /:'(\\\\|\\'|[^'])*'/, Str::Symbol
-        rule /:"/, Str::Symbol, :simple_sym
+        rule %r/:'(\\\\|\\'|[^'])*'/, Str::Symbol
+        rule %r/:"/, Str::Symbol, :simple_sym
       end
 
       state :sigil_strings do
         # %-sigiled strings
         # %(abc), %[abc], %<abc>, %.abc., %r.abc., etc
         delimiter_map = { '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
-        rule /%([rqswQWxiI])?([^\w\s])/ do |m|
+        rule %r/%([rqswQWxiI])?([^\w\s])/ do |m|
           open = Regexp.escape(m[2])
           close = Regexp.escape(delimiter_map[m[2]] || m[2])
           interp = /[rQWxI]/ === m[1]
@@ -54,38 +54,38 @@ module Rouge
           token toktype
 
           push do
-            rule /\\[##{open}#{close}\\]/, Str::Escape
+            rule %r/\\[##{open}#{close}\\]/, Str::Escape
             # nesting rules only with asymmetric delimiters
             if open != close
-              rule /#{open}/ do
+              rule %r/#{open}/ do
                 token toktype
                 push
               end
             end
-            rule /#{close}/, toktype, :pop!
+            rule %r/#{close}/, toktype, :pop!
 
             if interp
               mixin :string_intp_escaped
-              rule /#/, toktype
+              rule %r/#/, toktype
             else
-              rule /[\\#]/, toktype
+              rule %r/[\\#]/, toktype
             end
 
-            rule /[^##{open}#{close}\\]+/m, toktype
+            rule %r/[^##{open}#{close}\\]+/m, toktype
           end
         end
       end
 
       state :strings do
         mixin :symbols
-        rule /\b[a-z_]\w*?[?!]?:\s+/, Str::Symbol, :expr_start
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
-        rule /"/, Str::Double, :simple_string
-        rule /(?<!\.)`/, Str::Backtick, :simple_backtick
+        rule %r/\b[a-z_]\w*?[?!]?:\s+/, Str::Symbol, :expr_start
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Single
+        rule %r/"/, Str::Double, :simple_string
+        rule %r/(?<!\.)`/, Str::Backtick, :simple_backtick
       end
 
       state :regex_flags do
-        rule /[mixounse]*/, Str::Regex, :pop!
+        rule %r/[mixounse]*/, Str::Regex, :pop!
       end
 
       # double-quoted string and symbol
@@ -94,9 +94,9 @@ module Rouge
        [:backtick, Str::Backtick, '`']].each do |name, tok, fin|
         state :"simple_#{name}" do
           mixin :string_intp_escaped
-          rule /[^\\#{fin}#]+/m, tok
-          rule /[\\#]/, tok
-          rule /#{fin}/, tok, :pop!
+          rule %r/[^\\#{fin}#]+/m, tok
+          rule %r/[\\#]/, tok
+          rule %r/#{fin}/, tok, :pop!
         end
       end
 
@@ -140,40 +140,40 @@ module Rouge
 
       state :whitespace do
         mixin :inline_whitespace
-        rule /\n\s*/m, Text, :expr_start
-        rule /#.*$/, Comment::Single
+        rule %r/\n\s*/m, Text, :expr_start
+        rule %r/#.*$/, Comment::Single
 
         rule %r(=begin\b.*?\n=end\b)m, Comment::Multiline
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
+        rule %r/[ \t\r]+/, Text
       end
 
       state :root do
         mixin :whitespace
-        rule /__END__/, Comment::Preproc, :end_part
+        rule %r/__END__/, Comment::Preproc, :end_part
 
-        rule /0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
-        rule /0b[01]+(?:_[01]+)*/, Num::Bin
-        rule /\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
-        rule /[\d]+(?:_\d+)*/, Num::Integer
+        rule %r/0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
+        rule %r/0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
+        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
+        rule %r/\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
+        rule %r/[\d]+(?:_\d+)*/, Num::Integer
 
-        rule /@\[([^\]]+)\]/, Name::Decorator
+        rule %r/@\[([^\]]+)\]/, Name::Decorator
 
         # names
-        rule /@@[a-z_]\w*/i, Name::Variable::Class
-        rule /@[a-z_]\w*/i, Name::Variable::Instance
-        rule /\$\w+/, Name::Variable::Global
+        rule %r/@@[a-z_]\w*/i, Name::Variable::Class
+        rule %r/@[a-z_]\w*/i, Name::Variable::Instance
+        rule %r/\$\w+/, Name::Variable::Global
         rule %r(\$[!@&`'+~=/\\,;.<>_*\$?:"]), Name::Variable::Global
-        rule /\$-[0adFiIlpvw]/, Name::Variable::Global
-        rule /::/, Operator
+        rule %r/\$-[0adFiIlpvw]/, Name::Variable::Global
+        rule %r/::/, Operator
 
         mixin :strings
 
-        rule /(?:#{keywords.join('|')})\b/, Keyword, :expr_start
-        rule /(?:#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo, :expr_start
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword, :expr_start
+        rule %r/(?:#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo, :expr_start
 
         rule %r(
           (module)
@@ -183,52 +183,52 @@ module Rouge
           groups Keyword, Text, Name::Namespace
         end
 
-        rule /(def\b)(\s*)/ do
+        rule %r/(def\b)(\s*)/ do
           groups Keyword, Text
           push :funcname
         end
 
-        rule /(class\b)(\s*)/ do
+        rule %r/(class\b)(\s*)/ do
           groups Keyword, Text
           push :classname
         end
 
-        rule /(?:#{builtins_q.join('|')})[?]/, Name::Builtin, :expr_start
-        rule /(?:#{builtins_b.join('|')})!/,  Name::Builtin, :expr_start
-        rule /(?<!\.)(?:#{builtins_g.join('|')})\b/,
+        rule %r/(?:#{builtins_q.join('|')})[?]/, Name::Builtin, :expr_start
+        rule %r/(?:#{builtins_b.join('|')})!/,  Name::Builtin, :expr_start
+        rule %r/(?<!\.)(?:#{builtins_g.join('|')})\b/,
           Name::Builtin, :method_call
 
         mixin :has_heredocs
 
         # `..` and `...` for ranges must have higher priority than `.`
         # Otherwise, they will be parsed as :method_call
-        rule /\.{2,3}/, Operator, :expr_start
+        rule %r/\.{2,3}/, Operator, :expr_start
 
-        rule /[A-Z][a-zA-Z0-9_]*/, Name::Constant, :method_call
-        rule /(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
+        rule %r/[A-Z][a-zA-Z0-9_]*/, Name::Constant, :method_call
+        rule %r/(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
           groups Punctuation, Text, Name::Function
           push :method_call
         end
 
-        rule /[a-zA-Z_]\w*[?!]/, Name, :expr_start
-        rule /[a-zA-Z_]\w*/, Name, :method_call
-        rule /\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
+        rule %r/[a-zA-Z_]\w*[?!]/, Name, :expr_start
+        rule %r/[a-zA-Z_]\w*/, Name, :method_call
+        rule %r/\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
-        rule /[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
+        rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
         rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }
         rule %r<[\[({,:\\;/]>, Punctuation, :expr_start
         rule %r<[\])}]>, Punctuation
       end
 
       state :has_heredocs do
-        rule /(?<!\w)(<<[-~]?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
+        rule %r/(?<!\w)(<<[-~]?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
           @heredoc_queue << [['<<-', '<<~'].include?(m[1]), m[3]]
           push :heredoc_queue unless state? :heredoc_queue
         end
 
-        rule /(<<[-~]?)(["'])(\2)/ do |m|
+        rule %r/(<<[-~]?)(["'])(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
           @heredoc_queue << [['<<-', '<<~'].include?(m[1]), '']
@@ -237,7 +237,7 @@ module Rouge
       end
 
       state :heredoc_queue do
-        rule /(?=\n)/ do
+        rule %r/(?=\n)/ do
           goto :resolve_heredocs
         end
 
@@ -247,13 +247,13 @@ module Rouge
       state :resolve_heredocs do
         mixin :string_intp_escaped
 
-        rule /\n/, Str::Heredoc, :test_heredoc
-        rule /[#\\\n]/, Str::Heredoc
-        rule /[^#\\\n]+/, Str::Heredoc
+        rule %r/\n/, Str::Heredoc, :test_heredoc
+        rule %r/[#\\\n]/, Str::Heredoc
+        rule %r/[^#\\\n]+/, Str::Heredoc
       end
 
       state :test_heredoc do
-        rule /[^#\\\n]*$/ do |m|
+        rule %r/[^#\\\n]*$/ do |m|
           tolerant, heredoc_name = @heredoc_queue.first
           check = tolerant ? m[0].strip : m[0].rstrip
 
@@ -275,8 +275,8 @@ module Rouge
       end
 
       state :funcname do
-        rule /\s+/, Text
-        rule /\(/, Punctuation, :defexpr
+        rule %r/\s+/, Text
+        rule %r/\(/, Punctuation, :defexpr
         rule %r(
           (?:([a-zA-Z_][\w_]*)(\.))?
           (
@@ -294,20 +294,20 @@ module Rouge
       end
 
       state :classname do
-        rule /\s+/, Text
-        rule /\(/ do
+        rule %r/\s+/, Text
+        rule %r/\(/ do
           token Punctuation
           push :defexpr
           push :expr_start
         end
 
         # class << expr
-        rule /<</ do
+        rule %r/<</ do
           token Operator
           goto :expr_start
         end
 
-        rule /[A-Z_]\w*/, Name::Class, :pop!
+        rule %r/[A-Z_]\w*/, Name::Class, :pop!
 
         rule(//) { pop! }
       end
@@ -319,11 +319,11 @@ module Rouge
       end
 
       state :defexpr do
-        rule /(\))(\.|::)?/ do
+        rule %r/(\))(\.|::)?/ do
           groups Punctuation, Operator
           pop!
         end
-        rule /\(/ do
+        rule %r/\(/ do
           token Punctuation
           push :defexpr
           push :expr_start
@@ -333,20 +333,20 @@ module Rouge
       end
 
       state :in_interp do
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
         mixin :root
       end
 
       state :string_intp do
-        rule /[#][{]/, Str::Interpol, :in_interp
-        rule /#(@@?|\$)[a-z_]\w*/i, Str::Interpol
+        rule %r/[#][{]/, Str::Interpol, :in_interp
+        rule %r/#(@@?|\$)[a-z_]\w*/i, Str::Interpol
       end
 
       state :string_intp_escaped do
         mixin :string_intp
-        rule /\\([\\abefnrstv#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})/,
+        rule %r/\\([\\abefnrstv#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})/,
           Str::Escape
-        rule /\\./, Str::Escape
+        rule %r/\\./, Str::Escape
       end
 
       state :method_call do
@@ -399,7 +399,7 @@ module Rouge
 
         # special case for using a single space.  Ruby demands that
         # these be in a single line, otherwise it would make no sense.
-        rule /(\s*)(%[rqswQWxiI]? \S* )/ do
+        rule %r/(\s*)(%[rqswQWxiI]? \S* )/ do
           groups Text, Str::Other
           pop!
         end
@@ -423,7 +423,7 @@ module Rouge
 
       state :end_part do
         # eat up the rest of the stream as Comment::Preproc
-        rule /.+/m, Comment::Preproc, :pop!
+        rule %r/.+/m, Comment::Preproc, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -43,58 +43,58 @@ module Rouge
       )
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end
 
       state :nest do
-        rule /{/, Punctuation, :nest
-        rule /}/, Punctuation, :pop!
+        rule %r/{/, Punctuation, :nest
+        rule %r/}/, Punctuation, :pop!
         mixin :root
       end
 
       state :splice_string do
-        rule /\\./, Str
-        rule /{/, Punctuation, :nest
-        rule /"|\n/, Str, :pop!
-        rule /./, Str
+        rule %r/\\./, Str
+        rule %r/{/, Punctuation, :nest
+        rule %r/"|\n/, Str, :pop!
+        rule %r/./, Str
       end
 
       state :splice_literal do
-        rule /""/, Str
-        rule /{/, Punctuation, :nest
-        rule /"/, Str, :pop!
-        rule /./, Str
+        rule %r/""/, Str
+        rule %r/{/, Punctuation, :nest
+        rule %r/"/, Str, :pop!
+        rule %r/./, Str
       end
 
       state :root do
         mixin :whitespace
 
-        rule /[$]\s*"/, Str, :splice_string
-        rule /[$]@\s*"/, Str, :splice_literal
+        rule %r/[$]\s*"/, Str, :splice_string
+        rule %r/[$]@\s*"/, Str, :splice_literal
 
-        rule /(<\[)\s*(#{id}:)?/, Keyword
-        rule /\]>/, Keyword
+        rule %r/(<\[)\s*(#{id}:)?/, Keyword
+        rule %r/\]>/, Keyword
 
-        rule /[~!%^&*()+=|\[\]{}:;,.<>\/?-]/, Punctuation
-        rule /@"(""|[^"])*"/m, Str
-        rule /"(\\.|.)*?["\n]/, Str
-        rule /'(\\.|.)'/, Str::Char
-        rule /0x[0-9a-f]+[lu]?/i, Num
+        rule %r/[~!%^&*()+=|\[\]{}:;,.<>\/?-]/, Punctuation
+        rule %r/@"(""|[^"])*"/m, Str
+        rule %r/"(\\.|.)*?["\n]/, Str
+        rule %r/'(\\.|.)'/, Str::Char
+        rule %r/0x[0-9a-f]+[lu]?/i, Num
         rule %r(
           [0-9]
           ([.][0-9]*)? # decimal
           (e[+-][0-9]+)? # exponent
           [fldu]? # type
         )ix, Num
-        rule /\b(?:class|struct|interface)\b/, Keyword, :class
-        rule /\b(?:namespace|using)\b/, Keyword, :namespace
-        rule /^#[ \t]*(#{cpp_keywords.join('|')})\b.*?\n/,
+        rule %r/\b(?:class|struct|interface)\b/, Keyword, :class
+        rule %r/\b(?:namespace|using)\b/, Keyword, :namespace
+        rule %r/^#[ \t]*(#{cpp_keywords.join('|')})\b.*?\n/,
           Comment::Preproc
-        rule /\b(#{keywords.join('|')})\b/, Keyword
-        rule /\b(#{keywords_type.join('|')})\b/, Keyword::Type
-        rule /#{id}(?=\s*[(])/, Name::Function
+        rule %r/\b(#{keywords.join('|')})\b/, Keyword
+        rule %r/\b(#{keywords_type.join('|')})\b/, Keyword::Type
+        rule %r/#{id}(?=\s*[(])/, Name::Function
         rule id, Name
       end
 
@@ -105,8 +105,8 @@ module Rouge
 
       state :namespace do
         mixin :whitespace
-        rule /(?=[(])/, Text, :pop!
-        rule /(#{id}|[.])+/, Name::Namespace, :pop!
+        rule %r/(?=[(])/, Text, :pop!
+        rule %r/(#{id}|[.])+/, Name::Namespace, :pop!
       end
 
     end

--- a/lib/rouge/lexers/css.rb
+++ b/lib/rouge/lexers/css.rb
@@ -185,25 +185,25 @@ module Rouge
 
       state :root do
         mixin :basics
-        rule /{/, Punctuation, :stanza
-        rule /:[:]?#{identifier}/, Name::Decorator
-        rule /\.#{identifier}/, Name::Class
-        rule /##{identifier}/, Name::Function
-        rule /@#{identifier}/, Keyword, :at_rule
+        rule %r/{/, Punctuation, :stanza
+        rule %r/:[:]?#{identifier}/, Name::Decorator
+        rule %r/\.#{identifier}/, Name::Class
+        rule %r/##{identifier}/, Name::Function
+        rule %r/@#{identifier}/, Keyword, :at_rule
         rule identifier, Name::Tag
         rule %r([~^*!%&\[\]()<>|+=@:;,./?-]), Operator
-        rule /"(\\\\|\\"|[^"])*"/, Str::Single
-        rule /'(\\\\|\\'|[^'])*'/, Str::Double
+        rule %r/"(\\\\|\\"|[^"])*"/, Str::Single
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Double
       end
 
       state :value do
         mixin :basics
-        rule /url\(.*?\)/, Str::Other
-        rule /#[0-9a-f]{1,6}/i, Num # colors
-        rule /#{number}(?:%|(?:em|px|pt|pc|in|mm|cm|ex|rem|ch|vw|vh|vmin|vmax|dpi|dpcm|dppx|deg|grad|rad|turn|s|ms|Hz|kHz)\b)?/, Num
-        rule /[\[\]():\/.,]/, Punctuation
-        rule /"(\\\\|\\"|[^"])*"/, Str::Single
-        rule /'(\\\\|\\'|[^'])*'/, Str::Double
+        rule %r/url\(.*?\)/, Str::Other
+        rule %r/#[0-9a-f]{1,6}/i, Num # colors
+        rule %r/#{number}(?:%|(?:em|px|pt|pc|in|mm|cm|ex|rem|ch|vw|vh|vmin|vmax|dpi|dpcm|dppx|deg|grad|rad|turn|s|ms|Hz|kHz)\b)?/, Num
+        rule %r/[\[\]():\/.,]/, Punctuation
+        rule %r/"(\\\\|\\"|[^"])*"/, Str::Single
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Double
         rule(identifier) do |m|
           if self.class.constants.include? m[0]
             token Name::Constant
@@ -216,9 +216,9 @@ module Rouge
       end
 
       state :at_rule do
-        rule /{(?=\s*#{identifier}\s*:)/m, Punctuation, :at_stanza
-        rule /{/, Punctuation, :at_body
-        rule /;/, Punctuation, :pop!
+        rule %r/{(?=\s*#{identifier}\s*:)/m, Punctuation, :at_stanza
+        rule %r/{/, Punctuation, :at_body
+        rule %r/;/, Punctuation, :pop!
         mixin :value
       end
 
@@ -233,21 +233,21 @@ module Rouge
       end
 
       state :at_content do
-        rule /}/ do
+        rule %r/}/ do
           token Punctuation
           pop! 2
         end
       end
 
       state :basics do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule %r(/\*(?:.*?)\*/)m, Comment
       end
 
       state :stanza do
         mixin :basics
-        rule /}/, Punctuation, :pop!
-        rule /(#{identifier})(\s*)(:)/m do |m|
+        rule %r/}/, Punctuation, :pop!
+        rule %r/(#{identifier})(\s*)(:)/m do |m|
           name_tok = if self.class.attributes.include? m[1]
             Name::Label
           elsif self.class.vendor_prefixes.any? { |p| m[1].start_with?(p) }
@@ -263,10 +263,10 @@ module Rouge
       end
 
       state :stanza_value do
-        rule /;/, Punctuation, :pop!
+        rule %r/;/, Punctuation, :pop!
         rule(/(?=})/) { pop! }
-        rule /!\s*important\b/, Comment::Preproc
-        rule /^@.*?$/, Comment::Preproc
+        rule %r/!\s*important\b/, Comment::Preproc
+        rule %r/^@.*?$/, Comment::Preproc
         mixin :value
       end
     end

--- a/lib/rouge/lexers/d.rb
+++ b/lib/rouge/lexers/d.rb
@@ -41,8 +41,8 @@ module Rouge
       )
 
       state :whitespace do
-        rule /\n/m, Text
-        rule /\s+/m, Text
+        rule %r/\n/m, Text
+        rule %r/\s+/m, Text
       end
 
       state :root do
@@ -52,58 +52,58 @@ module Rouge
         rule %r(/(\\\n)?[*](.|\n)*?[*](\\\n)?/), Comment::Multiline
         rule %r(/\+), Comment::Multiline, :nested_comment
         # Keywords
-        rule /(#{keywords.join('|')})\b/, Keyword
-        rule /(#{keywords_type.join('|')})\b/, Keyword::Type
-        rule /(false|true|null)\b/, Keyword::Constant
-        rule /(#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo
-        rule /macro\b/, Keyword::Reserved
-        rule /(string|wstring|dstring|size_t|ptrdiff_t)\b/, Name::Builtin
+        rule %r/(#{keywords.join('|')})\b/, Keyword
+        rule %r/(#{keywords_type.join('|')})\b/, Keyword::Type
+        rule %r/(false|true|null)\b/, Keyword::Constant
+        rule %r/(#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo
+        rule %r/macro\b/, Keyword::Reserved
+        rule %r/(string|wstring|dstring|size_t|ptrdiff_t)\b/, Name::Builtin
         # Literals
         # HexFloat
-        rule /0[xX]([0-9a-fA-F_]*\.[0-9a-fA-F_]+|[0-9a-fA-F_]+)[pP][+\-]?[0-9_]+[fFL]?[i]?/, Num::Float
+        rule %r/0[xX]([0-9a-fA-F_]*\.[0-9a-fA-F_]+|[0-9a-fA-F_]+)[pP][+\-]?[0-9_]+[fFL]?[i]?/, Num::Float
         # DecimalFloat
-        rule /[0-9_]+(\.[0-9_]+[eE][+\-]?[0-9_]+|\.[0-9_]*|[eE][+\-]?[0-9_]+)[fFL]?[i]?/, Num::Float
-        rule /\.(0|[1-9][0-9_]*)([eE][+\-]?[0-9_]+)?[fFL]?[i]?/, Num::Float
+        rule %r/[0-9_]+(\.[0-9_]+[eE][+\-]?[0-9_]+|\.[0-9_]*|[eE][+\-]?[0-9_]+)[fFL]?[i]?/, Num::Float
+        rule %r/\.(0|[1-9][0-9_]*)([eE][+\-]?[0-9_]+)?[fFL]?[i]?/, Num::Float
         # IntegerLiteral
         # Binary
-        rule /0[Bb][01_]+/, Num::Bin
+        rule %r/0[Bb][01_]+/, Num::Bin
         # Octal
         # TODO: 0[0-7] isn't supported use octal![0-7] instead
-        rule /0[0-7_]+/, Num::Oct
+        rule %r/0[0-7_]+/, Num::Oct
         # Hexadecimal
-        rule /0[xX][0-9a-fA-F_]+/, Num::Hex
+        rule %r/0[xX][0-9a-fA-F_]+/, Num::Hex
         # Decimal
-        rule /(0|[1-9][0-9_]*)([LUu]|Lu|LU|uL|UL)?/, Num::Integer
+        rule %r/(0|[1-9][0-9_]*)([LUu]|Lu|LU|uL|UL)?/, Num::Integer
         # CharacterLiteral
-        rule /'(\\['"?\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|\\&\w+;|.)'/, Str::Char
+        rule %r/'(\\['"?\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|\\&\w+;|.)'/, Str::Char
         # StringLiteral
         # WysiwygString
-        rule /r"[^"]*"[cwd]?/, Str
+        rule %r/r"[^"]*"[cwd]?/, Str
         # Alternate WysiwygString
-        rule /`[^`]*`[cwd]?/, Str
+        rule %r/`[^`]*`[cwd]?/, Str
         # DoubleQuotedString
-        rule /"(\\\\|\\"|[^"])*"[cwd]?/, Str
+        rule %r/"(\\\\|\\"|[^"])*"[cwd]?/, Str
         # EscapeSequence
-        rule /\\(['\"?\\abfnrtv]|x[0-9a-fA-F]{2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|&\w+;)/, Str
+        rule %r/\\(['\"?\\abfnrtv]|x[0-9a-fA-F]{2}|[0-7]{1,3}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8}|&\w+;)/, Str
         # HexString
-        rule /x"[0-9a-fA-F_\s]*"[cwd]?/, Str
+        rule %r/x"[0-9a-fA-F_\s]*"[cwd]?/, Str
         # DelimitedString
-        rule /q"\[/, Str, :delimited_bracket
-        rule /q"\(/, Str, :delimited_parenthesis
-        rule /q"</, Str, :delimited_angle
-        rule /q"\{/, Str, :delimited_curly
-        rule /q"([a-zA-Z_]\w*)\n.*?\n\1"/, Str
-        rule /q"(.).*?\1"/, Str
+        rule %r/q"\[/, Str, :delimited_bracket
+        rule %r/q"\(/, Str, :delimited_parenthesis
+        rule %r/q"</, Str, :delimited_angle
+        rule %r/q"\{/, Str, :delimited_curly
+        rule %r/q"([a-zA-Z_]\w*)\n.*?\n\1"/, Str
+        rule %r/q"(.).*?\1"/, Str
         # TokenString
-        rule /q\{/, Str, :token_string
+        rule %r/q\{/, Str, :token_string
         # Attributes
-        rule /@([a-zA-Z_]\w*)?/, Name::Decorator
+        rule %r/@([a-zA-Z_]\w*)?/, Name::Decorator
         # Tokens
         rule %r`(~=|\^=|%=|\*=|==|!>=|!<=|!<>=|!<>|!<|!>|!=|>>>=|>>>|>>=|>>|>=|<>=|<>|<<=|<<|<=|\+\+|\+=|--|-=|\|\||\|=|&&|&=|\.\.\.|\.\.|/=)|[/.&|\-+<>!()\[\]{}?,;:$=*%^~]`, Punctuation
         # Identifier
-        rule /[a-zA-Z_]\w*/, Name
+        rule %r/[a-zA-Z_]\w*/, Name
         # Line
-        rule /#line\s.*\n/, Comment::Special
+        rule %r/#line\s.*\n/, Comment::Special
       end
 
       state :nested_comment do
@@ -114,63 +114,63 @@ module Rouge
       end
 
       state :token_string do
-        rule /\{/, Punctuation, :token_string_nest
-        rule /\}/, Str, :pop!
+        rule %r/\{/, Punctuation, :token_string_nest
+        rule %r/\}/, Str, :pop!
         mixin :root
       end
 
       state :token_string_nest do
-        rule /\{/, Punctuation, :push
-        rule /\}/, Punctuation, :pop!
+        rule %r/\{/, Punctuation, :push
+        rule %r/\}/, Punctuation, :pop!
         mixin :root
       end
 
       state :delimited_bracket do
-        rule /[^\[\]]+/, Str
-        rule /\[/, Str, :delimited_inside_bracket
-        rule /\]"/, Str, :pop!
+        rule %r/[^\[\]]+/, Str
+        rule %r/\[/, Str, :delimited_inside_bracket
+        rule %r/\]"/, Str, :pop!
       end
 
       state :delimited_inside_bracket do
-        rule /[^\[\]]+/, Str
-        rule /\[/, Str, :push
-        rule /\]/, Str, :pop!
+        rule %r/[^\[\]]+/, Str
+        rule %r/\[/, Str, :push
+        rule %r/\]/, Str, :pop!
       end
 
       state :delimited_parenthesis do
-        rule /[^()]+/, Str
-        rule /\(/, Str, :delimited_inside_parenthesis
-        rule /\)"/, Str, :pop!
+        rule %r/[^()]+/, Str
+        rule %r/\(/, Str, :delimited_inside_parenthesis
+        rule %r/\)"/, Str, :pop!
       end
 
       state :delimited_inside_parenthesis do
-        rule /[^()]+/, Str
-        rule /\(/, Str, :push
-        rule /\)/, Str, :pop!
+        rule %r/[^()]+/, Str
+        rule %r/\(/, Str, :push
+        rule %r/\)/, Str, :pop!
       end
 
       state :delimited_angle do
-        rule /[^<>]+/, Str
-        rule /</, Str, :delimited_inside_angle
-        rule />"/, Str, :pop!
+        rule %r/[^<>]+/, Str
+        rule %r/</, Str, :delimited_inside_angle
+        rule %r/>"/, Str, :pop!
       end
 
       state :delimited_inside_angle do
-        rule /[^<>]+/, Str
-        rule /</, Str, :push
-        rule />/, Str, :pop!
+        rule %r/[^<>]+/, Str
+        rule %r/</, Str, :push
+        rule %r/>/, Str, :pop!
       end
 
       state :delimited_curly do
-        rule /[^{}]+/, Str
-        rule /\{/, Str, :delimited_inside_curly
-        rule /\}"/, Str, :pop!
+        rule %r/[^{}]+/, Str
+        rule %r/\{/, Str, :delimited_inside_curly
+        rule %r/\}"/, Str, :pop!
       end
 
       state :delimited_inside_curly do
-        rule /[^{}]+/, Str
-        rule /\{/, Str, :push
-        rule /\}/, Str, :pop!
+        rule %r/[^{}]+/, Str
+        rule %r/\{/, Str, :push
+        rule %r/\}/, Str, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -40,65 +40,65 @@ module Rouge
           token Punctuation, m[4]
         end
 
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
-        rule /"/, Str, :dqs
-        rule /'/, Str, :sqs
-        rule /r"[^"]*"/, Str::Other
-        rule /r'[^']*'/, Str::Other
-        rule /##{id}*/i, Str::Symbol
-        rule /@#{id}/, Name::Decorator
-        rule /(?:#{keywords.join('|')})\b/, Keyword
-        rule /(?:#{declarations.join('|')})\b/, Keyword::Declaration
-        rule /(?:#{types.join('|')})\b/, Keyword::Type
-        rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /(?:class|interface)\b/, Keyword::Declaration, :class
-        rule /(?:#{imports.join('|')})\b/, Keyword::Namespace, :import
-        rule /(\.)(#{id})/ do
+        rule %r/"/, Str, :dqs
+        rule %r/'/, Str, :sqs
+        rule %r/r"[^"]*"/, Str::Other
+        rule %r/r'[^']*'/, Str::Other
+        rule %r/##{id}*/i, Str::Symbol
+        rule %r/@#{id}/, Name::Decorator
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
+        rule %r/(?:#{types.join('|')})\b/, Keyword::Type
+        rule %r/(?:true|false|null)\b/, Keyword::Constant
+        rule %r/(?:class|interface)\b/, Keyword::Declaration, :class
+        rule %r/(?:#{imports.join('|')})\b/, Keyword::Namespace, :import
+        rule %r/(\.)(#{id})/ do
           groups Operator, Name::Attribute
         end
 
-        rule /#{id}:/, Name::Label
-        rule /\$?#{id}/, Name
-        rule /[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
-        rule /\d*\.\d+([eE]\-?\d+)?/, Num::Float
-        rule /0x[\da-fA-F]+/, Num::Hex
-        rule /\d+L?/, Num::Integer
-        rule /\n/, Text
+        rule %r/#{id}:/, Name::Label
+        rule %r/\$?#{id}/, Name
+        rule %r/[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
+        rule %r/\d*\.\d+([eE]\-?\d+)?/, Num::Float
+        rule %r/0x[\da-fA-F]+/, Num::Hex
+        rule %r/\d+L?/, Num::Integer
+        rule %r/\n/, Text
       end
 
       state :class do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule id, Name::Class, :pop!
       end
 
       state :dqs do
-        rule /"/, Str, :pop!
-        rule /[^\\\$"]+/, Str
+        rule %r/"/, Str, :pop!
+        rule %r/[^\\\$"]+/, Str
         mixin :string
       end
 
       state :sqs do
-        rule /'/, Str, :pop!
-        rule /[^\\\$']+/, Str
+        rule %r/'/, Str, :pop!
+        rule %r/[^\\\$']+/, Str
         mixin :string
       end
 
       state :import do
-        rule /;/, Operator, :pop!
-        rule /(?:show|hide)\b/, Keyword::Declaration
+        rule %r/;/, Operator, :pop!
+        rule %r/(?:show|hide)\b/, Keyword::Declaration
         mixin :root
       end
 
       state :string do
         mixin :interpolation
-        rule /\\[nrt\"\'\\]/, Str::Escape
+        rule %r/\\[nrt\"\'\\]/, Str::Escape
       end
 
       state :interpolation do
-        rule /\$#{id}/, Str::Interpol
-        rule /\$\{[^\}]+\}/, Str::Interpol
+        rule %r/\$#{id}/, Str::Interpol
+        rule %r/\$\{[^\}]+\}/, Str::Interpol
       end
     end
   end

--- a/lib/rouge/lexers/digdag.rb
+++ b/lib/rouge/lexers/digdag.rb
@@ -60,7 +60,7 @@ module Rouge
       ))
 
       prepend :block_nodes do
-        rule /(#{KEYWORD_PATTERN})(:)(?=\s|$)/ do |m|
+        rule %r/(#{KEYWORD_PATTERN})(:)(?=\s|$)/ do |m|
           groups Keyword::Reserved, Punctuation::Indicator
           set_indent m[0], :implicit => true
         end

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -18,32 +18,32 @@ module Rouge
       start { @shell = Shell.new(@options) }
 
       state :root do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do |m|
+        rule %r/^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do |m|
           groups Keyword, Text::Whitespace, Keyword, Str
         end
 
-        rule /^(#{KEYWORDS})\b(.*)/io do |m|
+        rule %r/^(#{KEYWORDS})\b(.*)/io do |m|
           groups Keyword, Str
         end
 
-        rule /#.*?$/, Comment
+        rule %r/#.*?$/, Comment
 
-        rule /^(ONBUILD\s+)?RUN(\s+)/i do
+        rule %r/^(ONBUILD\s+)?RUN(\s+)/i do
           token Keyword
           push :run
           @shell.reset!
         end
 
-        rule /\w+/, Text
-        rule /[^\w]+/, Text
-        rule /./, Text
+        rule %r/\w+/, Text
+        rule %r/[^\w]+/, Text
+        rule %r/./, Text
       end
 
       state :run do
-        rule /\n/, Text, :pop!
-        rule /\\./m, Str::Escape
+        rule %r/\n/, Text, :pop!
+        rule %r/\\./m, Str::Escape
         rule(/(\\.|[^\n\\])+/) { delegate @shell }
       end
     end

--- a/lib/rouge/lexers/dot.rb
+++ b/lib/rouge/lexers/dot.rb
@@ -16,33 +16,33 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(#.*?\n), Comment::Single
         rule %r(//.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end
 
       state :html do
-        rule /[^<>]+/ do
+        rule %r/[^<>]+/ do
           delegate @html
         end
-        rule /<.+?>/m do
+        rule %r/<.+?>/m do
           delegate @html
         end
-        rule />/, Punctuation, :pop!
+        rule %r/>/, Punctuation, :pop!
       end
 
       state :ID do
-        rule /([a-zA-Z][a-zA-Z_0-9]*)(\s*)(=)/ do |m|
+        rule %r/([a-zA-Z][a-zA-Z_0-9]*)(\s*)(=)/ do |m|
           token Name, m[1]
           token Text, m[2]
           token Punctuation, m[3]
         end
-        rule /[a-zA-Z][a-zA-Z_0-9]*/, Name::Variable
-        rule /([0-9]+)?\.[0-9]+/, Num::Float
-        rule /[0-9]+/, Num::Integer
-        rule /"(\\"|[^"])*"/, Str::Double
-        rule /</ do
+        rule %r/[a-zA-Z][a-zA-Z_0-9]*/, Name::Variable
+        rule %r/([0-9]+)?\.[0-9]+/, Num::Float
+        rule %r/[0-9]+/, Num::Integer
+        rule %r/"(\\"|[^"])*"/, Str::Double
+        rule %r/</ do
           token Punctuation
           @html.reset!
           push :html
@@ -52,16 +52,16 @@ module Rouge
       state :a_list do
         mixin :comments_and_whitespace
         mixin :ID
-        rule /[=;,]/, Punctuation
-        rule /\]/, Operator, :pop!
+        rule %r/[=;,]/, Punctuation
+        rule %r/\]/, Operator, :pop!
       end
 
       state :root do
         mixin :comments_and_whitespace
-        rule /\b(strict|graph|digraph|subgraph|node|edge)\b/i, Keyword
-        rule /[{};:=]/, Punctuation
-        rule /-[->]/, Operator
-        rule /\[/, Operator, :a_list
+        rule %r/\b(strict|graph|digraph|subgraph|node|edge)\b/i, Keyword
+        rule %r/[{};:=]/, Punctuation
+        rule %r/-[->]/, Operator
+        rule %r/\[/, Operator, :a_list
         mixin :ID
       end
     end

--- a/lib/rouge/lexers/eiffel.rb
+++ b/lib/rouge/lexers/eiffel.rb
@@ -27,37 +27,37 @@ module Rouge
       SimpleString = /(?:[^"%\b\f\v]|%[A-DFHLNQR-V%'"()<>]|%\/(?:0[xX][\da-fA-F](?:_*[\da-fA-F])*|0[cC][0-7](?:_*[0-7])*|0[bB][01](?:_*[01])*|\d(?:_*\d)*)\/)+?/
 
       state :root do
-        rule /"\[/, Str::Other, :aligned_verbatim_string
-        rule /"\{/, Str::Other, :non_aligned_verbatim_string
-        rule /"(?:[^%\b\f\n\r\v]|%[A-DFHLNQR-V%'"()<>]|%\/(?:0[xX][\da-fA-F](?:_*[\da-fA-F])*|0[cC][0-7](?:_*[0-7])*|0[bB][01](?:_*[01])*|\d(?:_*\d)*)\/)*?"/, Str::Double
-        rule /--.*/, Comment::Single
-        rule /'(?:[^%\b\f\n\r\t\v]|%[A-DFHLNQR-V%'"()<>]|%\/(?:0[xX][\da-fA-F](?:_*[\da-fA-F])*|0[cC][0-7](?:_*[0-7])*|0[bB][01](?:_*[01])*|\d(?:_*\d)*)\/)'/, Str::Char
+        rule %r/"\[/, Str::Other, :aligned_verbatim_string
+        rule %r/"\{/, Str::Other, :non_aligned_verbatim_string
+        rule %r/"(?:[^%\b\f\n\r\v]|%[A-DFHLNQR-V%'"()<>]|%\/(?:0[xX][\da-fA-F](?:_*[\da-fA-F])*|0[cC][0-7](?:_*[0-7])*|0[bB][01](?:_*[01])*|\d(?:_*\d)*)\/)*?"/, Str::Double
+        rule %r/--.*/, Comment::Single
+        rule %r/'(?:[^%\b\f\n\r\t\v]|%[A-DFHLNQR-V%'"()<>]|%\/(?:0[xX][\da-fA-F](?:_*[\da-fA-F])*|0[cC][0-7](?:_*[0-7])*|0[bB][01](?:_*[01])*|\d(?:_*\d)*)\/)'/, Str::Char
 
-        rule /(?:#{LanguageKeywords.join('|')})\b/, Keyword
-        rule /(?:#{LanguageVariables.join('|')})\b/, Keyword::Variable
-        rule /(?:#{BooleanConstants.join('|')})\b/, Keyword::Constant
+        rule %r/(?:#{LanguageKeywords.join('|')})\b/, Keyword
+        rule %r/(?:#{LanguageVariables.join('|')})\b/, Keyword::Variable
+        rule %r/(?:#{BooleanConstants.join('|')})\b/, Keyword::Constant
 
-        rule  /\b0[xX][\da-fA-F](?:_*[\da-fA-F])*b/, Num::Hex
-        rule /\b0[cC][0-7](?:_*[0-7])*\b/, Num::Oct
-        rule /\b0[bB][01](?:_*[01])*\b/, Num::Bin
-        rule /\d(?:_*\d)*/, Num::Integer
-        rule /(?:\d(?:_*\d)*)?\.(?:(?:\d(?:_*\d)*)?[eE][+-]?)?\d(?:_*\d)*|\d(?:_*\d)*\.?/, Num::Float
+        rule %r/\b0[xX][\da-fA-F](?:_*[\da-fA-F])*b/, Num::Hex
+        rule %r/\b0[cC][0-7](?:_*[0-7])*\b/, Num::Oct
+        rule %r/\b0[bB][01](?:_*[01])*\b/, Num::Bin
+        rule %r/\d(?:_*\d)*/, Num::Integer
+        rule %r/(?:\d(?:_*\d)*)?\.(?:(?:\d(?:_*\d)*)?[eE][+-]?)?\d(?:_*\d)*|\d(?:_*\d)*\.?/, Num::Float
 
-        rule /:=|<<|>>|\(\||\|\)|->|\.|[{}\[\];(),:?]/, Punctuation::Indicator
-        rule /\\\\|\|\.\.\||\.\.|\/[~\/]?|[><\/]=?|[-+*^=~]/, Operator
+        rule %r/:=|<<|>>|\(\||\|\)|->|\.|[{}\[\];(),:?]/, Punctuation::Indicator
+        rule %r/\\\\|\|\.\.\||\.\.|\/[~\/]?|[><\/]=?|[-+*^=~]/, Operator
 
-        rule /[A-Z][\dA-Z_]*/, Name::Class
-        rule /[A-Za-z][\dA-Za-z_]*/, Name
-        rule /\s+/, Text
+        rule %r/[A-Z][\dA-Z_]*/, Name::Class
+        rule %r/[A-Za-z][\dA-Za-z_]*/, Name
+        rule %r/\s+/, Text
       end
 
       state :aligned_verbatim_string do
-        rule /]"/, Str::Other, :pop!
+        rule %r/]"/, Str::Other, :pop!
         rule SimpleString, Str::Other
       end
 
       state :non_aligned_verbatim_string do
-        rule /}"/, Str::Other, :pop!
+        rule %r/}"/, Str::Other, :pop!
         rule SimpleString, Str::Other
       end
     end

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -17,14 +17,14 @@ module Rouge
       mimetypes 'text/x-elixir', 'application/x-elixir'
 
       state :root do
-        rule /\s+/m, Text
-        rule /#.*$/, Comment::Single
+        rule %r/\s+/m, Text
+        rule %r/#.*$/, Comment::Single
         rule %r{\b(case|cond|end|bc|lc|if|unless|try|loop|receive|fn|defmodule|
              defp?|defprotocol|defimpl|defrecord|defmacrop?|defdelegate|
              defexception|defguardp?|defstruct|exit|raise|throw|after|rescue|catch|else)\b(?![?!])|
              (?<!\.)\b(do|\-\>)\b}x, Keyword
-        rule /\b(import|require|use|recur|quote|unquote|super|refer)\b(?![?!])/, Keyword::Namespace
-        rule /(?<!\.)\b(and|not|or|when|xor|in)\b/, Operator::Word
+        rule %r/\b(import|require|use|recur|quote|unquote|super|refer)\b(?![?!])/, Keyword::Namespace
+        rule %r/(?<!\.)\b(and|not|or|when|xor|in)\b/, Operator::Word
         rule %r{%=|\*=|\*\*=|\+=|\-=|\^=|\|\|=|
              <=>|<(?!<|=)|>(?!<|=|>)|<=|>=|===|==|=~|!=|!~|(?=[\s\t])\?|
              (?<=[\s\t])!+|&(&&?|(?!\d))|\|\||\^|\*|\+|\-|/|
@@ -32,12 +32,12 @@ module Rouge
         rule %r{(?<!:)(:)([a-zA-Z_]\w*([?!]|=(?![>=]))?|\<\>|===?|>=?|<=?|
              <=>|&&?|%\(\)|%\[\]|%\{\}|\+\+?|\-\-?|\|\|?|\!|//|[%&`/\|]|
              \*\*?|=?~|<\-)|([a-zA-Z_]\w*([?!])?)(:)(?!:)}, Str::Symbol
-        rule /:"/, Str::Symbol, :interpoling_symbol
-        rule /\b(nil|true|false)\b(?![?!])|\b[A-Z]\w*\b/, Name::Constant
-        rule /\b(__(FILE|LINE|MODULE|MAIN|FUNCTION)__)\b(?![?!])/, Name::Builtin::Pseudo
-        rule /[a-zA-Z_!][\w_]*[!\?]?/, Name
+        rule %r/:"/, Str::Symbol, :interpoling_symbol
+        rule %r/\b(nil|true|false)\b(?![?!])|\b[A-Z]\w*\b/, Name::Constant
+        rule %r/\b(__(FILE|LINE|MODULE|MAIN|FUNCTION)__)\b(?![?!])/, Name::Builtin::Pseudo
+        rule %r/[a-zA-Z_!][\w_]*[!\?]?/, Name
         rule %r{::|[%(){};,/\|:\\\[\]]}, Punctuation
-        rule /@[a-zA-Z_]\w*|&\d/, Name::Variable
+        rule %r/@[a-zA-Z_]\w*|&\d/, Name::Variable
         rule %r{\b(0[xX][0-9A-Fa-f]+|\d(_?\d)*(\.(?![^\d\s])
              (_?\d)*)?([eE][-+]?\d(_?\d)*)?|0[bB][01]+)\b}x, Num
 
@@ -46,37 +46,37 @@ module Rouge
       end
 
       state :strings do
-        rule /(%[A-Ba-z])?"""(?:.|\n)*?"""/, Str::Doc
-        rule /'''(?:.|\n)*?'''/, Str::Doc
-        rule /"/, Str::Doc, :dqs
-        rule /'.*?'/, Str::Single
+        rule %r/(%[A-Ba-z])?"""(?:.|\n)*?"""/, Str::Doc
+        rule %r/'''(?:.|\n)*?'''/, Str::Doc
+        rule %r/"/, Str::Doc, :dqs
+        rule %r/'.*?'/, Str::Single
         rule %r{(?<!\w)\?(\\(x\d{1,2}|\h{1,2}(?!\h)\b|0[0-7]{0,2}(?![0-7])\b[^x0MC])|(\\[MC]-)+\w|[^\s\\])}, Str::Other
 
       end
 
       state :dqs do
-        rule /"/, Str::Double, :pop!
+        rule %r/"/, Str::Double, :pop!
         mixin :enddoublestr
       end
 
       state :interpoling do
-        rule /#\{/, Str::Interpol, :interpoling_string
+        rule %r/#\{/, Str::Interpol, :interpoling_string
       end
 
       state :interpoling_string do
-        rule /\}/, Str::Interpol, :pop!
+        rule %r/\}/, Str::Interpol, :pop!
         mixin :root
       end
 
       state :interpoling_symbol do
-        rule /"/, Str::Symbol, :pop!
+        rule %r/"/, Str::Symbol, :pop!
         mixin :interpoling
-        rule /[^#"]+/, Str::Symbol
+        rule %r/[^#"]+/, Str::Symbol
       end
 
       state :enddoublestr do
         mixin :interpoling
-        rule /[^#"]+/, Str::Double
+        rule %r/[^#"]+/, Str::Double
       end
 
       state :sigil_strings do
@@ -86,7 +86,7 @@ module Rouge
         delimiter_map = { '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
         # Match a-z for custom sigils too
         sigil_opens = Regexp.union(delimiter_map.keys + %w(| / ' "))
-        rule /~([A-Za-z])?(#{sigil_opens})/ do |m|
+        rule %r/~([A-Za-z])?(#{sigil_opens})/ do |m|
           open = Regexp.escape(m[2])
           close = Regexp.escape(delimiter_map[m[2]] || m[2])
           interp = /[SRCW]/ === m[1]
@@ -108,26 +108,26 @@ module Rouge
           token toktype
 
           push do
-            rule /#{close}/, toktype, :pop!
+            rule %r/#{close}/, toktype, :pop!
 
             if interp
               mixin :interpoling
-              rule /#/, toktype
+              rule %r/#/, toktype
             else
-              rule /[\\#]/, toktype
+              rule %r/[\\#]/, toktype
             end
 
-            rule /[^##{open}#{close}\\]+/m, toktype
+            rule %r/[^##{open}#{close}\\]+/m, toktype
           end
         end
       end
 
       state :regex_flags do
-        rule /[fgimrsux]*/, Str::Regex, :pop!
+        rule %r/[fgimrsux]*/, Str::Regex, :pop!
       end
 
       state :list_flags do
-        rule /[csa]?/, Str::Other, :pop!
+        rule %r/[csa]?/, Str::Other, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/elm.rb
+++ b/lib/rouge/lexers/elm.rb
@@ -23,66 +23,66 @@ module Rouge
 
       state :root do
         # Whitespaces
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         # Single line comments
-        rule /--.*/, Comment::Single
+        rule %r/--.*/, Comment::Single
         # Multiline comments
-        rule /{-/, Comment::Multiline, :multiline_comment
+        rule %r/{-/, Comment::Multiline, :multiline_comment
 
         # Keywords
-        rule /\b(#{keywords.join('|')})\b/, Keyword
+        rule %r/\b(#{keywords.join('|')})\b/, Keyword
 
         # Variable or a function
-        rule /[a-z][\w]*/, Name
+        rule %r/[a-z][\w]*/, Name
         # Underscore is a name for a variable, when it won't be used later
-        rule /_/, Name
+        rule %r/_/, Name
         # Type
-        rule /[A-Z][\w]*/, Keyword::Type        
+        rule %r/[A-Z][\w]*/, Keyword::Type        
 
         # Two symbol operators: -> :: // .. && || ++ |> <| << >> == /= <= >=
-        rule /(->|::|\/\/|\.\.|&&|\|\||\+\+|\|>|<\||>>|<<|==|\/=|<=|>=)/, Operator
+        rule %r/(->|::|\/\/|\.\.|&&|\|\||\+\+|\|>|<\||>>|<<|==|\/=|<=|>=)/, Operator
         # One symbol operators: + - / * % = < > ^ | !
-        rule /[+-\/*%=<>^\|!]/, Operator
+        rule %r/[+-\/*%=<>^\|!]/, Operator
         # Lambda operator
-        rule /\\/, Operator
+        rule %r/\\/, Operator
         # Not standard Elm operators, but these symbols can be used for custom inflix operators. We need to highlight them as operators as well.
-        rule /[@\#$&~?]/, Operator
+        rule %r/[@\#$&~?]/, Operator
 
         # Single, double quotes, and triple double quotes
-        rule /"""/, Str, :multiline_string
-        rule /'(\\.|.)'/, Str::Char        
-        rule /"/, Str, :double_quote
+        rule %r/"""/, Str, :multiline_string
+        rule %r/'(\\.|.)'/, Str::Char        
+        rule %r/"/, Str, :double_quote
 
         # Numbers
-        rule /0x[\da-f]+/i, Num::Hex
-        rule /\d+e[+-]?\d+/i, Num::Float
-        rule /\d+\.\d+(e[+-]?\d+)?/i, Num::Float
-        rule /\d+/, Num::Integer
+        rule %r/0x[\da-f]+/i, Num::Hex
+        rule %r/\d+e[+-]?\d+/i, Num::Float
+        rule %r/\d+\.\d+(e[+-]?\d+)?/i, Num::Float
+        rule %r/\d+/, Num::Integer
 
         # Punctuation: [ ] ( ) , ; ` { } :
-        rule /[\[\](),;`{}:]/, Punctuation
+        rule %r/[\[\](),;`{}:]/, Punctuation
       end
 
       # Multiline and nested commenting
       state :multiline_comment do
-        rule /-}/, Comment::Multiline, :pop!
-        rule /{-/, Comment::Multiline, :multiline_comment
-        rule /[^-{}]+/, Comment::Multiline
-        rule /[-{}]/, Comment::Multiline
+        rule %r/-}/, Comment::Multiline, :pop!
+        rule %r/{-/, Comment::Multiline, :multiline_comment
+        rule %r/[^-{}]+/, Comment::Multiline
+        rule %r/[-{}]/, Comment::Multiline
       end
 
       # Double quotes
       state :double_quote do
-        rule /[^\\"]+/, Str::Double
-        rule /\\"/, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/[^\\"]+/, Str::Double
+        rule %r/\\"/, Str::Escape
+        rule %r/"/, Str::Double, :pop!
       end
 
       # Multiple line string with tripple double quotes, e.g. """ multi """
       state :multiline_string do
-        rule /\s*"""/, Str, :pop!
-        rule /.*/, Str
-        rule /\s*/, Str
+        rule %r/\s*"""/, Str, :pop!
+        rule %r/.*/, Str
+        rule %r/\s*/, Str
       end
 
     end

--- a/lib/rouge/lexers/erb.rb
+++ b/lib/rouge/lexers/erb.rb
@@ -27,24 +27,24 @@ module Rouge
       close = /%%>|-%>|%>/
 
       state :root do
-        rule /<%#/, Comment, :comment
+        rule %r/<%#/, Comment, :comment
 
         rule open, Comment::Preproc, :ruby
 
-        rule /.+?(?=#{open})|.+/m do
+        rule %r/.+?(?=#{open})|.+/m do
           delegate parent
         end
       end
 
       state :comment do
         rule close, Comment, :pop!
-        rule /.+?(?=#{close})|.+/m, Comment
+        rule %r/.+?(?=#{close})|.+/m, Comment
       end
 
       state :ruby do
         rule close, Comment::Preproc, :pop!
 
-        rule /.+?(?=#{close})|.+/m do
+        rule %r/.+?(?=#{close})|.+/m do
           delegate @ruby_lexer
         end
       end

--- a/lib/rouge/lexers/factor.rb
+++ b/lib/rouge/lexers/factor.rb
@@ -167,35 +167,35 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
 
-        rule /(:|::|MACRO:|MEMO:|GENERIC:|HELP:)(\s+)(\S+)/m do
+        rule %r/(:|::|MACRO:|MEMO:|GENERIC:|HELP:)(\s+)(\S+)/m do
           groups Keyword, Text, Name::Function
         end
 
-        rule /(M:|HOOK:|GENERIC#)(\s+)(\S+)(\s+)(\S+)/m do
+        rule %r/(M:|HOOK:|GENERIC#)(\s+)(\S+)(\s+)(\S+)/m do
           groups Keyword, Text, Name::Class, Text, Name::Function
         end
 
-        rule /\((?=\s)/, Name::Function, :stack_effect
-        rule /;(?=\s)/, Keyword
+        rule %r/\((?=\s)/, Name::Function, :stack_effect
+        rule %r/;(?=\s)/, Keyword
 
-        rule /(USING:)((?:\s|\\\s)+)/m do
+        rule %r/(USING:)((?:\s|\\\s)+)/m do
           groups Keyword::Namespace, Text
           push :import
         end
 
-        rule /(IN:|USE:|UNUSE:|QUALIFIED:|QUALIFIED-WITH:)(\s+)(\S+)/m do
+        rule %r/(IN:|USE:|UNUSE:|QUALIFIED:|QUALIFIED-WITH:)(\s+)(\S+)/m do
           groups Keyword::Namespace, Text, Name::Namespace
         end
 
-        rule /(FROM:|EXCLUDE:)(\s+)(\S+)(\s+)(=>)/m do
+        rule %r/(FROM:|EXCLUDE:)(\s+)(\S+)(\s+)(=>)/m do
           groups Keyword::Namespace, Text, Name::Namespace, Text, Punctuation
         end
 
-        rule /(?:ALIAS|DEFER|FORGET|POSTPONE):/, Keyword::Namespace
+        rule %r/(?:ALIAS|DEFER|FORGET|POSTPONE):/, Keyword::Namespace
 
-        rule /(TUPLE:)(\s+)(\S+)(\s+)(<)(\s+)(\S+)/m do
+        rule %r/(TUPLE:)(\s+)(\S+)(\s+)(<)(\s+)(\S+)/m do
           groups(
             Keyword, Text,
             Name::Class, Text,
@@ -205,16 +205,16 @@ module Rouge
           push :slots
         end
 
-        rule /(TUPLE:)(\s+)(\S+)/m do
+        rule %r/(TUPLE:)(\s+)(\S+)/m do
           groups Keyword, Text, Name::Class
           push :slots
         end
 
-        rule /(UNION:|INTERSECTION:)(\s+)(\S+)/m do
+        rule %r/(UNION:|INTERSECTION:)(\s+)(\S+)/m do
           groups Keyword, Text, Name::Class
         end
 
-        rule /(PREDICATE:)(\s+)(\S+)(\s+)(<)(\s+)(\S+)/m do
+        rule %r/(PREDICATE:)(\s+)(\S+)(\s+)(<)(\s+)(\S+)/m do
           groups(
             Keyword, Text,
             Name::Class, Text,
@@ -223,7 +223,7 @@ module Rouge
           )
         end
 
-        rule /(C:)(\s+)(\S+)(\s+)(\S+)/m do
+        rule %r/(C:)(\s+)(\S+)(\s+)(\S+)/m do
           groups(
             Keyword, Text,
             Name::Function, Text,
@@ -236,38 +236,38 @@ module Rouge
            |ALIEN|TYPEDEF|FUNCTION|STRUCT):
         )x, Keyword
 
-        rule /(?:<PRIVATE|PRIVATE>)/, Keyword::Namespace
+        rule %r/(?:<PRIVATE|PRIVATE>)/, Keyword::Namespace
 
-        rule /(MAIN:)(\s+)(\S+)/ do
+        rule %r/(MAIN:)(\s+)(\S+)/ do
           groups Keyword::Namespace, Text, Name::Function
         end
 
         # strings
-        rule /"""\s+.*?\s+"""/, Str
-        rule /"(\\.|[^\\])*?"/, Str
-        rule /(CHAR:)(\s+)(\\[\\abfnrstv]*|\S)(?=\s)/, Str::Char
+        rule %r/"""\s+.*?\s+"""/, Str
+        rule %r/"(\\.|[^\\])*?"/, Str
+        rule %r/(CHAR:)(\s+)(\\[\\abfnrstv]*|\S)(?=\s)/, Str::Char
 
         # comments
-        rule /!\s+.*$/, Comment
-        rule /#!\s+.*$/, Comment
+        rule %r/!\s+.*$/, Comment
+        rule %r/#!\s+.*$/, Comment
 
         # booleans
-        rule /[tf](?=\s)/, Name::Constant
+        rule %r/[tf](?=\s)/, Name::Constant
 
         # numbers
-        rule /-?\d+\.\d+(?=\s)/, Num::Float
-        rule /-?\d+(?=\s)/, Num::Integer
+        rule %r/-?\d+\.\d+(?=\s)/, Num::Float
+        rule %r/-?\d+(?=\s)/, Num::Integer
 
-        rule /HEX:\s+[a-fA-F\d]+(?=\s)/m, Num::Hex
-        rule /BIN:\s+[01]+(?=\s)/, Num::Bin
-        rule /OCT:\s+[0-7]+(?=\s)/, Num::Oct
+        rule %r/HEX:\s+[a-fA-F\d]+(?=\s)/m, Num::Hex
+        rule %r/BIN:\s+[01]+(?=\s)/, Num::Bin
+        rule %r/OCT:\s+[0-7]+(?=\s)/, Num::Oct
 
         rule %r([-+/*=<>^](?=\s)), Operator
 
-        rule /(?:deprecated|final|foldable|flushable|inline|recursive)(?=\s)/,
+        rule %r/(?:deprecated|final|foldable|flushable|inline|recursive)(?=\s)/,
           Keyword
 
-        rule /\S+/ do |m|
+        rule %r/\S+/ do |m|
           name = m[0]
 
           if self.class.builtins.values.any? { |b| b.include? name }
@@ -279,24 +279,24 @@ module Rouge
       end
 
       state :stack_effect do
-        rule /\s+/, Text
-        rule /\(/, Name::Function, :stack_effect
-        rule /\)/, Name::Function, :pop!
+        rule %r/\s+/, Text
+        rule %r/\(/, Name::Function, :stack_effect
+        rule %r/\)/, Name::Function, :pop!
 
-        rule /--/, Name::Function
-        rule /\S+/, Name::Variable
+        rule %r/--/, Name::Function
+        rule %r/\S+/, Name::Variable
       end
 
       state :slots do
-        rule /\s+/, Text
-        rule /;(?=\s)/, Keyword, :pop!
-        rule /\S+/, Name::Variable
+        rule %r/\s+/, Text
+        rule %r/;(?=\s)/, Keyword, :pop!
+        rule %r/\S+/, Name::Variable
       end
 
       state :import do
-        rule /;(?=\s)/, Keyword, :pop!
-        rule /\s+/, Text
-        rule /\S+/, Name::Namespace
+        rule %r/;(?=\s)/, Keyword, :pop!
+        rule %r/\s+/, Text
+        rule %r/\S+/, Name::Namespace
       end
     end
   end

--- a/lib/rouge/lexers/fortran.rb
+++ b/lib/rouge/lexers/fortran.rb
@@ -88,21 +88,21 @@ module Rouge
       end
 
       state :root do
-        rule /[\s\n]+/, Text::Whitespace
-        rule /!.*$/, Comment::Single
-        rule /^#.*$/, Comment::Preproc
+        rule %r/[\s\n]+/, Text::Whitespace
+        rule %r/!.*$/, Comment::Single
+        rule %r/^#.*$/, Comment::Preproc
 
-        rule /::|[()\/;,:&\[\]]/, Punctuation
+        rule %r/::|[()\/;,:&\[\]]/, Punctuation
 
         # TODO: This does not take into account line continuation.
-        rule /^(\s*)([0-9]+)\b/m do |m|
+        rule %r/^(\s*)([0-9]+)\b/m do |m|
           token Text::Whitespace, m[1]
           token Name::Label, m[2]
         end
 
         # Format statements are quite a strange beast.
         # Better process them in their own state.
-        rule /\b(FORMAT)(\s*)(\()/mi do |m|
+        rule %r/\b(FORMAT)(\s*)(\()/mi do |m|
           token Keyword, m[1]
           token Text::Whitespace, m[2]
           token Punctuation, m[3]
@@ -118,25 +118,25 @@ module Rouge
           (_#{kind_param})? # kind parameter
         )xi, Num::Float
 
-        rule /[+-]?\d+(_#{kind_param})?/i, Num::Integer
-        rule /B'[01]+'|B"[01]+"/i, Num::Bin
-        rule /O'[0-7]+'|O"[0-7]+"/i, Num::Oct
-        rule /Z'[0-9A-F]+'|Z"[0-9A-F]+"/i, Num::Hex
-        rule /(#{kind_param}_)?'/, Str::Single, :string_single
-        rule /(#{kind_param}_)?"/, Str::Double, :string_double
-        rule /[.](TRUE|FALSE)[.](_#{kind_param})?/i, Keyword::Constant
+        rule %r/[+-]?\d+(_#{kind_param})?/i, Num::Integer
+        rule %r/B'[01]+'|B"[01]+"/i, Num::Bin
+        rule %r/O'[0-7]+'|O"[0-7]+"/i, Num::Oct
+        rule %r/Z'[0-9A-F]+'|Z"[0-9A-F]+"/i, Num::Hex
+        rule %r/(#{kind_param}_)?'/, Str::Single, :string_single
+        rule %r/(#{kind_param}_)?"/, Str::Double, :string_double
+        rule %r/[.](TRUE|FALSE)[.](_#{kind_param})?/i, Keyword::Constant
 
         rule %r{\*\*|//|==|/=|<=|>=|=>|[-+*/<>=%]}, Operator
-        rule /\.(?:EQ|NE|LT|LE|GT|GE|NOT|AND|OR|EQV|NEQV|[A-Z]+)\./i, Operator::Word
+        rule %r/\.(?:EQ|NE|LT|LE|GT|GE|NOT|AND|OR|EQV|NEQV|[A-Z]+)\./i, Operator::Word
 
         # Special rules for two-word keywords and types.
         # Note: "doubleprecision" is covered by the normal keyword rule.
-        rule /double\s+precision\b/i, Keyword::Type
-        rule /go\s+to\b/i, Keyword
-        rule /sync\s+(all|images|memory)\b/i, Keyword
-        rule /error\s+stop\b/i, Keyword
+        rule %r/double\s+precision\b/i, Keyword::Type
+        rule %r/go\s+to\b/i, Keyword
+        rule %r/sync\s+(all|images|memory)\b/i, Keyword
+        rule %r/error\s+stop\b/i, Keyword
 
-        rule /#{name}/m do |m|
+        rule %r/#{name}/m do |m|
           match = m[0].downcase
           if self.class.keywords.include? match
             token Keyword
@@ -152,26 +152,26 @@ module Rouge
       end
 
       state :string_single do
-        rule /[^']+/, Str::Single
-        rule /''/, Str::Escape
-        rule /'/, Str::Single, :pop!
+        rule %r/[^']+/, Str::Single
+        rule %r/''/, Str::Escape
+        rule %r/'/, Str::Single, :pop!
       end
 
       state :string_double do
-        rule /[^"]+/, Str::Double
-        rule /""/, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/[^"]+/, Str::Double
+        rule %r/""/, Str::Escape
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :format_spec do
-        rule /'/, Str::Single, :string_single
-        rule /"/, Str::Double, :string_double
-        rule /\(/, Punctuation, :format_spec
-        rule /\)/, Punctuation, :pop!
-        rule /,/, Punctuation
-        rule /[\s\n]+/, Text::Whitespace
+        rule %r/'/, Str::Single, :string_single
+        rule %r/"/, Str::Double, :string_double
+        rule %r/\(/, Punctuation, :format_spec
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/[\s\n]+/, Text::Whitespace
         # Edit descriptors could be seen as a kind of "format literal".
-        rule /[^\s'"(),]+/, Literal
+        rule %r/[^\s'"(),]+/, Literal
       end
     end
   end

--- a/lib/rouge/lexers/fsharp.rb
+++ b/lib/rouge/lexers/fsharp.rb
@@ -46,11 +46,11 @@ module Rouge
       upper_id = /[A-Z][\w']*/
 
       state :root do
-        rule /\s+/m, Text
-        rule /false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
-        rule /#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
+        rule %r/\s+/m, Text
+        rule %r/false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
+        rule %r/#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
         rule upper_id, Name::Class
-        rule /[(][*](?![)])/, Comment, :comment
+        rule %r/[(][*](?![)])/, Comment, :comment
         rule %r(//.*?$), Comment::Single
         rule id do |m|
           match = m[0]
@@ -74,43 +74,43 @@ module Rouge
           end
         end
 
-        rule /-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
-        rule /0x\h[\h_]*/i, Num::Hex
-        rule /0o[0-7][0-7_]*/i, Num::Oct
-        rule /0b[01][01_]*/i, Num::Bin
-        rule /\d[\d_]*/, Num::Integer
+        rule %r/-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
+        rule %r/0x\h[\h_]*/i, Num::Hex
+        rule %r/0o[0-7][0-7_]*/i, Num::Oct
+        rule %r/0b[01][01_]*/i, Num::Bin
+        rule %r/\d[\d_]*/, Num::Integer
 
-        rule /'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
-        rule /'[.]'/, Str::Char
-        rule /'/, Keyword
-        rule /"/, Str::Double, :string
-        rule /[~?]#{id}/, Name::Variable
+        rule %r/'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
+        rule %r/'[.]'/, Str::Char
+        rule %r/'/, Keyword
+        rule %r/"/, Str::Double, :string
+        rule %r/[~?]#{id}/, Name::Variable
       end
 
       state :comment do
-        rule /[^(*)]+/, Comment
+        rule %r/[^(*)]+/, Comment
         rule(/[(][*]/) { token Comment; push }
-        rule /[*][)]/, Comment, :pop!
-        rule /[(*)]/, Comment
+        rule %r/[*][)]/, Comment, :pop!
+        rule %r/[(*)]/, Comment
       end
 
       state :string do
-        rule /[^\\"]+/, Str::Double
+        rule %r/[^\\"]+/, Str::Double
         mixin :escape_sequence
-        rule /\\\n/, Str::Double
-        rule /"/, Str::Double, :pop!
+        rule %r/\\\n/, Str::Double
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :escape_sequence do
-        rule /\\[\\"'ntbr]/, Str::Escape
-        rule /\\\d{3}/, Str::Escape
-        rule /\\x\h{2}/, Str::Escape
+        rule %r/\\[\\"'ntbr]/, Str::Escape
+        rule %r/\\\d{3}/, Str::Escape
+        rule %r/\\x\h{2}/, Str::Escape
       end
 
       state :dotted do
-        rule /\s+/m, Text
-        rule /[.]/, Punctuation
-        rule /#{upper_id}(?=\s*[.])/, Name::Namespace
+        rule %r/\s+/m, Text
+        rule %r/[.]/, Punctuation
+        rule %r/#{upper_id}(?=\s*[.])/, Name::Namespace
         rule upper_id, Name::Class, :pop!
         rule id, Name, :pop!
       end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -41,7 +41,7 @@ module Rouge
 
       state :basic do
         rule %r(#.*$), Comment
-        rule /[ \r\t]+/, Text
+        rule %r/[ \r\t]+/, Text
       end
 
       state :root do
@@ -85,8 +85,8 @@ module Rouge
       end
 
       state :table_header do
-        rule /[^|\s]+/, Name::Variable
-        rule /\n/ do
+        rule %r/[^|\s]+/, Name::Variable
+        rule %r/\n/ do
           token Text
           goto :table
         end
@@ -95,9 +95,9 @@ module Rouge
 
       state :table do
         mixin :basic
-        rule /\n/, Text, :table_bol
-        rule /[|]/, Punctuation
-        rule /[^|\s]+/, Name
+        rule %r/\n/, Text, :table_bol
+        rule %r/[|]/, Punctuation
+        rule %r/[^|\s]+/, Name
       end
 
       state :table_bol do
@@ -108,29 +108,29 @@ module Rouge
       state :description do
         mixin :basic
         mixin :has_examples
-        rule /\n/, Text
+        rule %r/\n/, Text
         rule rest_of_line, Text
       end
 
       state :feature_description do
         mixin :basic
         mixin :has_scenarios
-        rule /\n/, Text
+        rule %r/\n/, Text
         rule rest_of_line, Text
       end
 
       state :example_description do
         mixin :basic
         mixin :has_table
-        rule /\n/, Text
+        rule %r/\n/, Text
         rule rest_of_line, Text
       end
 
       state :step do
         mixin :basic
-        rule /<.*?>/, Name::Variable
-        rule /".*?"/, Str
-        rule /\S+/, Text
+        rule %r/<.*?>/, Name::Variable
+        rule %r/".*?"/, Str
+        rule %r/\S+/, Text
         rule rest_of_line, Text, :pop!
       end
     end

--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -12,24 +12,24 @@ module Rouge
       name = /[_A-Za-z][_0-9A-Za-z]*/
 
       state :root do
-        rule /\b(?:query|mutation|subscription)\b/, Keyword, :query_definition
-        rule /\{/ do
+        rule %r/\b(?:query|mutation|subscription)\b/, Keyword, :query_definition
+        rule %r/\{/ do
           token Punctuation
           push :query_definition
           push :selection_set
         end
 
-        rule /\bfragment\b/, Keyword, :fragment_definition
+        rule %r/\bfragment\b/, Keyword, :fragment_definition
 
-        rule /\b(?:type|interface|enum)\b/, Keyword, :type_definition
-        rule /\b(?:input|schema)\b/, Keyword, :type_definition
+        rule %r/\b(?:type|interface|enum)\b/, Keyword, :type_definition
+        rule %r/\b(?:input|schema)\b/, Keyword, :type_definition
 
-        rule /\bunion\b/, Keyword, :union_definition
+        rule %r/\bunion\b/, Keyword, :union_definition
 
         mixin :basic
 
         # Markdown descriptions
-        rule /(""")(.*?)(""")/m do |m|
+        rule %r/(""")(.*?)(""")/m do |m|
           token Str::Double, m[1]
           delegate Markdown, m[2]
           token Str::Double, m[3]
@@ -37,22 +37,22 @@ module Rouge
       end
 
       state :basic do
-        rule /\s+/m, Text::Whitespace
-        rule /#.*$/, Comment
+        rule %r/\s+/m, Text::Whitespace
+        rule %r/#.*$/, Comment
 
-        rule /[!,]/, Punctuation
+        rule %r/[!,]/, Punctuation
       end
 
       state :has_directives do
-        rule /(@#{name})(\s*)(\()/ do
+        rule %r/(@#{name})(\s*)(\()/ do
           groups Keyword, Text::Whitespace, Punctuation
           push :arguments
         end
-        rule /@#{name}\b/, Keyword
+        rule %r/@#{name}\b/, Keyword
       end
 
       state :fragment_definition do
-        rule /\bon\b/, Keyword
+        rule %r/\bon\b/, Keyword
 
         mixin :query_definition
       end
@@ -60,31 +60,31 @@ module Rouge
       state :query_definition do
         mixin :has_directives
 
-        rule /\b#{name}\b/, Name
-        rule /\(/, Punctuation, :variable_definitions
-        rule /\{/, Punctuation, :selection_set
+        rule %r/\b#{name}\b/, Name
+        rule %r/\(/, Punctuation, :variable_definitions
+        rule %r/\{/, Punctuation, :selection_set
 
         mixin :basic
       end
 
       state :type_definition do
-        rule /\bimplements\b/, Keyword
-        rule /\b#{name}\b/, Name
-        rule /\(/, Punctuation, :variable_definitions
-        rule /\{/, Punctuation, :type_definition_set
+        rule %r/\bimplements\b/, Keyword
+        rule %r/\b#{name}\b/, Name
+        rule %r/\(/, Punctuation, :variable_definitions
+        rule %r/\{/, Punctuation, :type_definition_set
 
         mixin :basic
       end
 
       state :union_definition do
-        rule /\b#{name}\b/, Name
-        rule /\=/, Punctuation, :union_definition_variant
+        rule %r/\b#{name}\b/, Name
+        rule %r/\=/, Punctuation, :union_definition_variant
 
         mixin :basic
       end
 
       state :union_definition_variant do
-        rule /\b#{name}\b/ do
+        rule %r/\b#{name}\b/ do
           token Name
           pop!
           push :union_definition_pipe
@@ -94,13 +94,13 @@ module Rouge
       end
 
       state :union_definition_pipe do
-        rule /\|/ do
+        rule %r/\|/ do
           token Punctuation
           pop!
           push :union_definition_variant
         end
 
-        rule /(?!\||\s+|#[^\n]*)/ do
+        rule %r/(?!\||\s+|#[^\n]*)/ do
           pop! 2
         end
 
@@ -108,62 +108,62 @@ module Rouge
       end
 
       state :type_definition_set do
-        rule /\}/ do
+        rule %r/\}/ do
           token Punctuation
           pop! 2
         end
 
-        rule /\b(#{name})(\s*)(\()/ do
+        rule %r/\b(#{name})(\s*)(\()/ do
           groups Name, Text::Whitespace, Punctuation
           push :variable_definitions
         end
-        rule /\b#{name}\b/, Name
+        rule %r/\b#{name}\b/, Name
 
-        rule /:/, Punctuation, :type_names
+        rule %r/:/, Punctuation, :type_names
 
         mixin :basic
       end
 
       state :arguments do
-        rule /\)/ do
+        rule %r/\)/ do
           token Punctuation
           pop!
         end
 
-        rule /\b#{name}\b/, Name
-        rule /:/, Punctuation, :value
+        rule %r/\b#{name}\b/, Name
+        rule %r/:/, Punctuation, :value
 
         mixin :basic
       end
 
       state :variable_definitions do
-        rule /\)/ do
+        rule %r/\)/ do
           token Punctuation
           pop!
         end
 
-        rule /\$#{name}\b/, Name::Variable
-        rule /\b#{name}\b/, Name
-        rule /:/, Punctuation, :type_names
-        rule /\=/, Punctuation, :value
+        rule %r/\$#{name}\b/, Name::Variable
+        rule %r/\b#{name}\b/, Name
+        rule %r/:/, Punctuation, :type_names
+        rule %r/\=/, Punctuation, :value
 
         mixin :basic
       end
 
       state :type_names do
-        rule /\b(?:Int|Float|String|Boolean|ID)\b/, Name::Builtin, :pop!
-        rule /\b#{name}\b/, Name, :pop!
+        rule %r/\b(?:Int|Float|String|Boolean|ID)\b/, Name::Builtin, :pop!
+        rule %r/\b#{name}\b/, Name, :pop!
 
-        rule /\[/, Punctuation, :type_name_list
+        rule %r/\[/, Punctuation, :type_name_list
 
         mixin :basic
       end
 
       state :type_name_list do
-        rule /\b(?:Int|Float|String|Boolean|ID)\b/, Name::Builtin
-        rule /\b#{name}\b/, Name
+        rule %r/\b(?:Int|Float|String|Boolean|ID)\b/, Name::Builtin
+        rule %r/\b#{name}\b/, Name
 
-        rule /\]/ do
+        rule %r/\]/ do
           token Punctuation
           pop! 2
         end
@@ -174,35 +174,35 @@ module Rouge
       state :selection_set do
         mixin :has_directives
 
-        rule /\}/ do
+        rule %r/\}/ do
           token Punctuation
           pop!
           pop! if state?(:query_definition) || state?(:fragment_definition)
         end
 
-        rule /\b(#{name})(\s*)(\()/ do
+        rule %r/\b(#{name})(\s*)(\()/ do
           groups Name, Text::Whitespace, Punctuation
           push :arguments
         end
 
-        rule /\b(#{name})(\s*)(:)/ do
+        rule %r/\b(#{name})(\s*)(:)/ do
           groups Name, Text::Whitespace, Punctuation
         end
 
-        rule /\b#{name}\b/, Name
+        rule %r/\b#{name}\b/, Name
 
-        rule /(\.\.\.)(\s+)(on)\b/ do
+        rule %r/(\.\.\.)(\s+)(on)\b/ do
           groups Punctuation, Text::Whitespace, Keyword
         end
-        rule /\.\.\./, Punctuation
+        rule %r/\.\.\./, Punctuation
 
-        rule /\{/, Punctuation, :selection_set
+        rule %r/\{/, Punctuation, :selection_set
 
         mixin :basic
       end
 
       state :list do
-        rule /\]/ do
+        rule %r/\]/ do
           token Punctuation
           pop!
           pop! if state?(:value)
@@ -212,13 +212,13 @@ module Rouge
       end
 
       state :object do
-        rule /\}/ do
+        rule %r/\}/ do
           token Punctuation
           pop!
           pop! if state?(:value)
         end
 
-        rule /\b(#{name})(\s*)(:)/ do
+        rule %r/\b(#{name})(\s*)(:)/ do
           groups Name, Text::Whitespace, Punctuation
           push :value
         end
@@ -235,17 +235,17 @@ module Rouge
         }
 
         # Multiline strings
-        rule /""".*?"""/m, Str::Double
+        rule %r/""".*?"""/m, Str::Double
 
-        rule /\$#{name}\b/, &pop_unless_list[Name::Variable]
-        rule /\b(?:true|false|null)\b/, &pop_unless_list[Keyword::Constant]
-        rule /[+-]?[0-9]+\.[0-9]+(?:[eE][+-]?[0-9]+)?/, &pop_unless_list[Num::Float]
-        rule /[+-]?[1-9][0-9]*(?:[eE][+-]?[0-9]+)?/, &pop_unless_list[Num::Integer]
-        rule /"(\\[\\"]|[^"])*"/, &pop_unless_list[Str::Double]
-        rule /\b#{name}\b/, &pop_unless_list[Name]
+        rule %r/\$#{name}\b/, &pop_unless_list[Name::Variable]
+        rule %r/\b(?:true|false|null)\b/, &pop_unless_list[Keyword::Constant]
+        rule %r/[+-]?[0-9]+\.[0-9]+(?:[eE][+-]?[0-9]+)?/, &pop_unless_list[Num::Float]
+        rule %r/[+-]?[1-9][0-9]*(?:[eE][+-]?[0-9]+)?/, &pop_unless_list[Num::Integer]
+        rule %r/"(\\[\\"]|[^"])*"/, &pop_unless_list[Str::Double]
+        rule %r/\b#{name}\b/, &pop_unless_list[Name]
 
-        rule /\{/, Punctuation, :object
-        rule /\[/, Punctuation, :list
+        rule %r/\{/, Punctuation, :object
+        rule %r/\[/, Punctuation, :list
 
         mixin :basic
       end

--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -54,29 +54,29 @@ module Rouge
         end
 
         # whitespace
-        rule /[^\S\n]+/, Text
+        rule %r/[^\S\n]+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
-        rule /@\w[\w\d.]*/, Name::Decorator
-        rule /(class|interface|trait)\b/,  Keyword::Declaration, :class
-        rule /package\b/, Keyword::Namespace, :import
-        rule /import\b/, Keyword::Namespace, :import
+        rule %r/@\w[\w\d.]*/, Name::Decorator
+        rule %r/(class|interface|trait)\b/,  Keyword::Declaration, :class
+        rule %r/package\b/, Keyword::Namespace, :import
+        rule %r/import\b/, Keyword::Namespace, :import
 
         # TODO: highlight backslash escapes
-        rule /""".*?"""/m, Str::Double
-        rule /'''.*?'''/m, Str::Single
+        rule %r/""".*?"""/m, Str::Double
+        rule %r/'''.*?'''/m, Str::Single
 
-        rule /"(\\.|\\\n|.)*?"/, Str::Double
-        rule /'(\\.|\\\n|.)*?'/, Str::Single
+        rule %r/"(\\.|\\\n|.)*?"/, Str::Double
+        rule %r/'(\\.|\\\n|.)*?'/, Str::Single
         rule %r(\$/(\$.|.)*?/\$)m, Str
         rule %r(/(\\.|\\\n|.)*?/), Str
-        rule /'\\.'|'[^\\]'|'\\u[0-9a-f]{4}'/, Str::Char
-        rule /(\.)([a-zA-Z_][a-zA-Z0-9_]*)/ do
+        rule %r/'\\.'|'[^\\]'|'\\u[0-9a-f]{4}'/, Str::Char
+        rule %r/(\.)([a-zA-Z_][a-zA-Z0-9_]*)/ do
           groups Operator, Name::Attribute
         end
 
-        rule /[a-zA-Z_][a-zA-Z0-9_]*:/, Name::Label
-        rule /[a-zA-Z_\$][a-zA-Z0-9_]*/ do |m|
+        rule %r/[a-zA-Z_][a-zA-Z0-9_]*:/, Name::Label
+        rule %r/[a-zA-Z_\$][a-zA-Z0-9_]*/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           elsif self.class.declarations.include? m[0]
@@ -93,20 +93,20 @@ module Rouge
         rule %r([~^*!%&\[\](){}<>\|+=:;,./?-]), Operator
 
         # numbers
-        rule /\d+\.\d+([eE]\d+)?[fd]?/, Num::Float
-        rule /0x[0-9a-f]+/, Num::Hex
-        rule /[0-9]+L?/, Num::Integer
-        rule /\n/, Text
+        rule %r/\d+\.\d+([eE]\d+)?[fd]?/, Num::Float
+        rule %r/0x[0-9a-f]+/, Num::Hex
+        rule %r/[0-9]+L?/, Num::Integer
+        rule %r/\n/, Text
       end
 
       state :class do
-        rule /\s+/, Text
-        rule /\w[\w\d]*/, Name::Class, :pop!
+        rule %r/\s+/, Text
+        rule %r/\w[\w\d]*/, Name::Class, :pop!
       end
 
       state :import do
-        rule /\s+/, Text
-        rule /[\w\d.]+[*]?/, Name::Namespace, :pop!
+        rule %r/\s+/, Text
+        rule %r/[\w\d.]+[*]?/, Name::Namespace, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/hack.rb
+++ b/lib/rouge/lexers/hack.rb
@@ -33,7 +33,7 @@ module Rouge
       end
 
       prepend :template do
-        rule /<\?hh(\s*\/\/\s*(strict|decl|partial))?$/, Comment::Preproc, :php
+        rule %r/<\?hh(\s*\/\/\s*(strict|decl|partial))?$/, Comment::Preproc, :php
       end
 
       prepend :php do

--- a/lib/rouge/lexers/haml.rb
+++ b/lib/rouge/lexers/haml.rb
@@ -71,14 +71,14 @@ module Rouge
       comma_dot = /,\s*\n|#{dot}/
 
       state :root do
-        rule /\s*\n/, Text
+        rule %r/\s*\n/, Text
         rule(/\s*/) { |m| token Text; indentation(m[0]) }
       end
 
       state :content do
         mixin :css
         rule(/%#{identifier}/) { token Name::Tag; goto :tag }
-        rule /!!!#{dot}*\n/, Name::Namespace, :pop!
+        rule %r/!!!#{dot}*\n/, Name::Namespace, :pop!
         rule %r(
           (/) (\[#{dot}*?\]) (#{dot}*\n)
         )x do
@@ -92,20 +92,20 @@ module Rouge
           starts_block :html_comment_block
         end
 
-        rule /-##{dot}*\n/ do
+        rule %r/-##{dot}*\n/ do
           token Comment
           pop!
           starts_block :haml_comment_block
         end
 
-        rule /-/ do
+        rule %r/-/ do
           token Punctuation
           reset_stack
           ruby! :ruby_line
         end
 
         # filters
-        rule /:(#{dot}*)\n/ do |m|
+        rule %r/:(#{dot}*)\n/ do |m|
           token Name::Decorator
           pop!
           starts_block :filter_block
@@ -131,11 +131,11 @@ module Rouge
         rule(/[{]/) { token Punctuation; ruby! :ruby_tag }
         rule(/\[#{dot}*?\]/) { delegate ruby }
 
-        rule /\(/, Punctuation, :html_attributes
-        rule /\s*\n/, Text, :pop!
+        rule %r/\(/, Punctuation, :html_attributes
+        rule %r/\s*\n/, Text, :pop!
 
         # whitespace chompers
-        rule /[<>]{1,2}(?=[ \t=])/, Punctuation
+        rule %r/[<>]{1,2}(?=[ \t=])/, Punctuation
 
         mixin :eval_or_plain
       end
@@ -147,8 +147,8 @@ module Rouge
       end
 
       state :eval_or_plain do
-        rule /[&!]?==/, Punctuation, :plain
-        rule /[&!]?[=!]/ do
+        rule %r/[&!]?==/, Punctuation, :plain
+        rule %r/[&!]?[=!]/ do
           token Punctuation
           reset_stack
           ruby! :ruby_line
@@ -158,9 +158,9 @@ module Rouge
       end
 
       state :ruby_line do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         rule(/,[ \t]*\n/) { delegate ruby }
-        rule /[ ]\|[ \t]*\n/, Str::Escape
+        rule %r/[ ]\|[ \t]*\n/, Str::Escape
         rule(/.*?(?=(,$| \|)?[ \t]*$)/) { delegate ruby }
       end
 
@@ -169,33 +169,33 @@ module Rouge
       end
 
       state :html_attributes do
-        rule /\s+/, Text
-        rule /#{identifier}\s*=/, Name::Attribute, :html_attribute_value
+        rule %r/\s+/, Text
+        rule %r/#{identifier}\s*=/, Name::Attribute, :html_attribute_value
         rule identifier, Name::Attribute
-        rule /\)/, Text, :pop!
+        rule %r/\)/, Text, :pop!
       end
 
       state :html_attribute_value do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule ruby_var, Name::Variable, :pop!
-        rule /@#{ruby_var}/, Name::Variable::Instance, :pop!
-        rule /\$#{ruby_var}/, Name::Variable::Global, :pop!
-        rule /'(\\\\|\\'|[^'\n])*'/, Str, :pop!
-        rule /"(\\\\|\\"|[^"\n])*"/, Str, :pop!
+        rule %r/@#{ruby_var}/, Name::Variable::Instance, :pop!
+        rule %r/\$#{ruby_var}/, Name::Variable::Global, :pop!
+        rule %r/'(\\\\|\\'|[^'\n])*'/, Str, :pop!
+        rule %r/"(\\\\|\\"|[^"\n])*"/, Str, :pop!
       end
 
       state :html_comment_block do
-        rule /#{dot}+/, Comment
+        rule %r/#{dot}+/, Comment
         mixin :indented_block
       end
 
       state :haml_comment_block do
-        rule /#{dot}+/, Comment::Preproc
+        rule %r/#{dot}+/, Comment::Preproc
         mixin :indented_block
       end
 
       state :filter_block do
-        rule /([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
+        rule %r/([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
           if @filter_lexer
             delegate @filter_lexer
           else
@@ -208,11 +208,11 @@ module Rouge
       end
 
       state :interpolation do
-        rule /#[{]/, Str::Interpol, :ruby
+        rule %r/#[{]/, Str::Interpol, :ruby
       end
 
       state :ruby do
-        rule /[}]/, Str::Interpol, :pop!
+        rule %r/[}]/, Str::Interpol, :pop!
         mixin :ruby_inner
       end
 

--- a/lib/rouge/lexers/handlebars.rb
+++ b/lib/rouge/lexers/handlebars.rb
@@ -18,10 +18,10 @@ module Rouge
         rule(/\\{+/) { delegate parent }
 
         # block comments
-        rule /{{!--/, Comment, :comment
-        rule /{{!.*?}}/, Comment
+        rule %r/{{!--/, Comment, :comment
+        rule %r/{{!.*?}}/, Comment
 
-        rule /{{{?/ do
+        rule %r/{{{?/ do
           token Keyword
           push :stache
           push :open_sym
@@ -42,20 +42,20 @@ module Rouge
       end
 
       state :stache do
-        rule /}}}?/, Keyword, :pop!
-        rule /\s+/m, Text
-        rule /[=]/, Operator
-        rule /[\[\]]/, Punctuation
-        rule /[.](?=[}\s])/, Name::Variable
-        rule /[.][.]/, Name::Variable
+        rule %r/}}}?/, Keyword, :pop!
+        rule %r/\s+/m, Text
+        rule %r/[=]/, Operator
+        rule %r/[\[\]]/, Punctuation
+        rule %r/[.](?=[}\s])/, Name::Variable
+        rule %r/[.][.]/, Name::Variable
         rule %r([/.]), Punctuation
-        rule /"(\\.|.)*?"/, Str::Double
-        rule /'(\\.|.)*?'/, Str::Single
-        rule /\d+(?=}\s)/, Num
-        rule /(true|false)(?=[}\s])/, Keyword::Constant
-        rule /else(?=[}\s])/, Keyword
-        rule /this(?=[}\s])/, Name::Builtin::Pseudo
-        rule /@#{id}/, Name::Attribute
+        rule %r/"(\\.|.)*?"/, Str::Double
+        rule %r/'(\\.|.)*?'/, Str::Single
+        rule %r/\d+(?=}\s)/, Num
+        rule %r/(true|false)(?=[}\s])/, Keyword::Constant
+        rule %r/else(?=[}\s])/, Keyword
+        rule %r/this(?=[}\s])/, Name::Builtin::Pseudo
+        rule %r/@#{id}/, Name::Attribute
         rule id, Name::Variable
       end
 
@@ -65,13 +65,13 @@ module Rouge
           goto :block_name
         end
 
-        rule /[>^&]/, Keyword
+        rule %r/[>^&]/, Keyword
 
         rule(//) { pop! }
       end
 
       state :block_name do
-        rule /if(?=[}\s])/, Keyword
+        rule %r/if(?=[}\s])/, Keyword
         rule id, Name::Namespace, :pop!
         rule(//) { pop! }
       end

--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -27,40 +27,40 @@ module Rouge
       )
 
       state :basic do
-        rule /\s+/m, Text
-        rule /{-#/, Comment::Preproc, :comment_preproc
-        rule /{-/, Comment::Multiline, :comment
-        rule /^--\s+\|.*?$/, Comment::Doc
+        rule %r/\s+/m, Text
+        rule %r/{-#/, Comment::Preproc, :comment_preproc
+        rule %r/{-/, Comment::Multiline, :comment
+        rule %r/^--\s+\|.*?$/, Comment::Doc
         # this is complicated in order to support custom symbols
         # like -->
-        rule /--(?![!#\$\%&*+.\/<=>?@\^\|_~]).*?$/, Comment::Single
+        rule %r/--(?![!#\$\%&*+.\/<=>?@\^\|_~]).*?$/, Comment::Single
       end
 
       # nested commenting
       state :comment do
-        rule /-}/, Comment::Multiline, :pop!
-        rule /{-/, Comment::Multiline, :comment
-        rule /[^-{}]+/, Comment::Multiline
-        rule /[-{}]/, Comment::Multiline
+        rule %r/-}/, Comment::Multiline, :pop!
+        rule %r/{-/, Comment::Multiline, :comment
+        rule %r/[^-{}]+/, Comment::Multiline
+        rule %r/[-{}]/, Comment::Multiline
       end
 
       state :comment_preproc do
-        rule /-}/, Comment::Preproc, :pop!
-        rule /{-/, Comment::Preproc, :comment
-        rule /[^-{}]+/, Comment::Preproc
-        rule /[-{}]/, Comment::Preproc
+        rule %r/-}/, Comment::Preproc, :pop!
+        rule %r/{-/, Comment::Preproc, :comment
+        rule %r/[^-{}]+/, Comment::Preproc
+        rule %r/[-{}]/, Comment::Preproc
       end
 
       state :root do
         mixin :basic
 
-        rule /\bimport\b/, Keyword::Reserved, :import
-        rule /\bmodule\b/, Keyword::Reserved, :module
-        rule /\b(?:#{reserved.join('|')})\b/, Keyword::Reserved
+        rule %r/\bimport\b/, Keyword::Reserved, :import
+        rule %r/\bmodule\b/, Keyword::Reserved, :module
+        rule %r/\b(?:#{reserved.join('|')})\b/, Keyword::Reserved
         # not sure why, but ^ doesn't work here
-        # rule /^[_a-z][\w']*/, Name::Function
-        rule /[_a-z][\w']*/, Name
-        rule /[A-Z][\w']*/, Keyword::Type
+        # rule %r/^[_a-z][\w']*/, Name::Function
+        rule %r/[_a-z][\w']*/, Name
+        rule %r/[A-Z][\w']*/, Keyword::Type
 
         # lambda operator
         rule %r(\\(?![:!#\$\%&*+.\\/<=>?@^\|~-]+)), Name::Function
@@ -71,35 +71,35 @@ module Rouge
         # other operators
         rule %r([:!#\$\%&*+.\\/<=>?@^\|~-]+), Operator
 
-        rule /\d+e[+-]?\d+/i, Num::Float
-        rule /\d+\.\d+(e[+-]?\d+)?/i, Num::Float
-        rule /0o[0-7]+/i, Num::Oct
-        rule /0x[\da-f]+/i, Num::Hex
-        rule /\d+/, Num::Integer
+        rule %r/\d+e[+-]?\d+/i, Num::Float
+        rule %r/\d+\.\d+(e[+-]?\d+)?/i, Num::Float
+        rule %r/0o[0-7]+/i, Num::Oct
+        rule %r/0x[\da-f]+/i, Num::Hex
+        rule %r/\d+/, Num::Integer
 
-        rule /'/, Str::Char, :character
-        rule /"/, Str, :string
+        rule %r/'/, Str::Char, :character
+        rule %r/"/, Str, :string
 
-        rule /\[\s*\]/, Keyword::Type
-        rule /\(\s*\)/, Name::Builtin
+        rule %r/\[\s*\]/, Keyword::Type
+        rule %r/\(\s*\)/, Name::Builtin
 
         # Quasiquotations
-        rule /(\[)([_a-z][\w']*)(\|)/ do |m|
+        rule %r/(\[)([_a-z][\w']*)(\|)/ do |m|
           token Operator, m[1]
           token Name, m[2]
           token Operator, m[3]
           push :quasiquotation
         end
 
-        rule /[\[\](),;`{}]/, Punctuation
+        rule %r/[\[\](),;`{}]/, Punctuation
       end
 
       state :import do
-        rule /\s+/, Text
-        rule /"/, Str, :string
-        rule /\bqualified\b/, Keyword
+        rule %r/\s+/, Text
+        rule %r/"/, Str, :string
+        rule %r/\bqualified\b/, Keyword
         # import X as Y
-        rule /([A-Z][\w.]*)(\s+)(as)(\s+)([A-Z][a-zA-Z0-9_.]*)/ do
+        rule %r/([A-Z][\w.]*)(\s+)(as)(\s+)([A-Z][a-zA-Z0-9_.]*)/ do
           groups(
             Name::Namespace, # X
             Text, Keyword, # as
@@ -109,7 +109,7 @@ module Rouge
         end
 
         # import X hiding (functions)
-        rule /([A-Z][\w.]*)(\s+)(hiding)(\s+)(\()/ do
+        rule %r/([A-Z][\w.]*)(\s+)(hiding)(\s+)(\()/ do
           groups(
             Name::Namespace, # X
             Text, Keyword, # hiding
@@ -119,7 +119,7 @@ module Rouge
         end
 
         # import X (functions)
-        rule /([A-Z][\w.]*)(\s+)(\()/ do
+        rule %r/([A-Z][\w.]*)(\s+)(\()/ do
           groups(
             Name::Namespace, # X
             Text,
@@ -128,70 +128,70 @@ module Rouge
           goto :funclist
         end
 
-        rule /[\w.]+/, Name::Namespace, :pop!
+        rule %r/[\w.]+/, Name::Namespace, :pop!
       end
 
       state :module do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         # module Foo (functions)
-        rule /([A-Z][\w.]*)(\s+)(\()/ do
+        rule %r/([A-Z][\w.]*)(\s+)(\()/ do
           groups Name::Namespace, Text, Punctuation
           push :funclist
         end
 
-        rule /\bwhere\b/, Keyword::Reserved, :pop!
+        rule %r/\bwhere\b/, Keyword::Reserved, :pop!
 
-        rule /[A-Z][a-zA-Z0-9_.]*/, Name::Namespace, :pop!
+        rule %r/[A-Z][a-zA-Z0-9_.]*/, Name::Namespace, :pop!
       end
 
       state :funclist do
         mixin :basic
-        rule /[A-Z]\w*/, Keyword::Type
-        rule /(_[\w\']+|[a-z][\w\']*)/, Name::Function
-        rule /,/, Punctuation
-        rule /[:!#\$\%&*+.\\\/<=>?@^\|~-]+/, Operator
-        rule /\(/, Punctuation, :funclist
-        rule /\)/, Punctuation, :pop!
+        rule %r/[A-Z]\w*/, Keyword::Type
+        rule %r/(_[\w\']+|[a-z][\w\']*)/, Name::Function
+        rule %r/,/, Punctuation
+        rule %r/[:!#\$\%&*+.\\\/<=>?@^\|~-]+/, Operator
+        rule %r/\(/, Punctuation, :funclist
+        rule %r/\)/, Punctuation, :pop!
       end
 
       state :character do
-        rule /\\/ do
+        rule %r/\\/ do
           token Str::Escape
           goto :character_end
           push :escape
         end
 
-        rule /./ do
+        rule %r/./ do
           token Str::Char
           goto :character_end
         end
       end
 
       state :character_end do
-        rule /'/, Str::Char, :pop!
-        rule /./, Error, :pop!
+        rule %r/'/, Str::Char, :pop!
+        rule %r/./, Error, :pop!
       end
 
       state :quasiquotation do
-        rule /\|\]/, Operator, :pop!
-        rule /[^\|]+/m, Text
-        rule /\|/, Text
+        rule %r/\|\]/, Operator, :pop!
+        rule %r/[^\|]+/m, Text
+        rule %r/\|/, Text
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\/, Str::Escape, :escape
-        rule /[^\\"]+/, Str
+        rule %r/"/, Str, :pop!
+        rule %r/\\/, Str::Escape, :escape
+        rule %r/[^\\"]+/, Str
       end
 
       state :escape do
-        rule /[abfnrtv"'&\\]/, Str::Escape, :pop!
-        rule /\^[\]\[A-Z@\^_]/, Str::Escape, :pop!
-        rule /#{ascii.join('|')}/, Str::Escape, :pop!
-        rule /o[0-7]+/i, Str::Escape, :pop!
-        rule /x[\da-f]+/i, Str::Escape, :pop!
-        rule /\d+/, Str::Escape, :pop!
-        rule /\s+\\/, Str::Escape, :pop!
+        rule %r/[abfnrtv"'&\\]/, Str::Escape, :pop!
+        rule %r/\^[\]\[A-Z@\^_]/, Str::Escape, :pop!
+        rule %r/#{ascii.join('|')}/, Str::Escape, :pop!
+        rule %r/o[0-7]+/i, Str::Escape, :pop!
+        rule %r/x[\da-f]+/i, Str::Escape, :pop!
+        rule %r/\d+/, Str::Escape, :pop!
+        rule %r/\s+\\/, Str::Escape, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -16,19 +16,19 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(#.*?$), Comment::Single
         rule %r(/[*]), Comment::Multiline, :multiline_comment
       end
 
       state :primitives do
-        rule /[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?([kKmMgG]b?)?/, Num::Float
-        rule /[0-9]+([kKmMgG]b?)?/, Num::Integer
+        rule %r/[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?([kKmMgG]b?)?/, Num::Float
+        rule %r/[0-9]+([kKmMgG]b?)?/, Num::Integer
 
-        rule /"/, Str::Double, :dq
-        rule /'/, Str::Single, :sq
-        rule /(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
+        rule %r/"/, Str::Double, :dq
+        rule %r/'/, Str::Single, :sq
+        rule %r/(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
           groups Operator, Text, Str::Heredoc, Str::Heredoc, Name::Constant, Str::Heredoc
           @heredocstr = Regexp.escape(m[5])
           push :heredoc
@@ -61,11 +61,11 @@ module Rouge
         mixin :comments_and_whitespace
         mixin :primitives
 
-        rule /\{/ do
+        rule %r/\{/ do
           token Punctuation
           push :hash
         end
-        rule /\[/ do
+        rule %r/\[/ do
           token Punctuation
           push :array
         end
@@ -93,13 +93,13 @@ module Rouge
       state :composite do
         mixin :comments_and_whitespace
 
-        rule /[{]/ do
+        rule %r/[{]/ do
           token Punctuation
           pop!
           push :hash
         end
 
-        rule /[\[]/ do
+        rule %r/[\[]/ do
           token Punctuation
           pop!
           push :array
@@ -107,14 +107,14 @@ module Rouge
 
         mixin :root
 
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :hash do
         mixin :comments_and_whitespace
 
-        rule /\=/, Punctuation
-        rule /\}/, Punctuation, :pop!
+        rule %r/\=/, Punctuation
+        rule %r/\}/, Punctuation, :pop!
 
         mixin :root
       end
@@ -122,32 +122,32 @@ module Rouge
       state :array do
         mixin :comments_and_whitespace
 
-        rule /,/, Punctuation
-        rule /\]/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/\]/, Punctuation, :pop!
 
         mixin :root
       end
 
       state :dq do
-        rule /[^\\"]+/, Str::Double
-        rule /\\"/, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/[^\\"]+/, Str::Double
+        rule %r/\\"/, Str::Escape
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :sq do
-        rule /[^\\']+/, Str::Single
-        rule /\\'/, Str::Escape
-        rule /'/, Str::Single, :pop!
+        rule %r/[^\\']+/, Str::Single
+        rule %r/\\'/, Str::Escape
+        rule %r/'/, Str::Single, :pop!
       end
 
       state :heredoc do
-        rule /\n/, Str::Heredoc, :heredoc_nl
-        rule /[^$\n]+/, Str::Heredoc
-        rule /[$]/, Str::Heredoc
+        rule %r/\n/, Str::Heredoc, :heredoc_nl
+        rule %r/[^$\n]+/, Str::Heredoc
+        rule %r/[$]/, Str::Heredoc
       end
 
       state :heredoc_nl do
-        rule /\s*(\w+)\s*\n/ do |m|
+        rule %r/\s*(\w+)\s*\n/ do |m|
           if m[1] == @heredocstr
             token Name::Constant
             pop! 2

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -44,7 +44,7 @@ module Rouge
           push :tag
         end
 
-        rule %r/<\//, Name::Tag, :tag_end
+        rule %r(</), Name::Tag, :tag_end
         rule %r/</, Name::Tag, :tag_start
 
         rule %r(<\s*[a-zA-Z0-9:-]+), Name::Tag, :tag # opening tags

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -22,21 +22,21 @@ module Rouge
       end
 
       state :root do
-        rule /[^<&]+/m, Text
-        rule /&\S*?;/, Name::Entity
-        rule /<!DOCTYPE .*?>/im, Comment::Preproc
-        rule /<!\[CDATA\[.*?\]\]>/m, Comment::Preproc
-        rule /<!--/, Comment, :comment
-        rule /<\?.*?\?>/m, Comment::Preproc # php? really?
+        rule %r/[^<&]+/m, Text
+        rule %r/&\S*?;/, Name::Entity
+        rule %r/<!DOCTYPE .*?>/im, Comment::Preproc
+        rule %r/<!\[CDATA\[.*?\]\]>/m, Comment::Preproc
+        rule %r/<!--/, Comment, :comment
+        rule %r/<\?.*?\?>/m, Comment::Preproc # php? really?
 
-        rule /<\s*script\s*/m do
+        rule %r/<\s*script\s*/m do
           token Name::Tag
           @javascript.reset!
           push :script_content
           push :tag
         end
 
-        rule /<\s*style\s*/m do
+        rule %r/<\s*style\s*/m do
           token Name::Tag
           @css.reset!
           @lang = @css
@@ -44,8 +44,8 @@ module Rouge
           push :tag
         end
 
-        rule /<\//, Name::Tag, :tag_end
-        rule /</, Name::Tag, :tag_start
+        rule %r/<\//, Name::Tag, :tag_end
+        rule %r/</, Name::Tag, :tag_start
 
         rule %r(<\s*[a-zA-Z0-9:-]+), Name::Tag, :tag # opening tags
         rule %r(<\s*/\s*[a-zA-Z0-9:-]+\s*>), Name::Tag # closing tags
@@ -53,21 +53,21 @@ module Rouge
 
       state :tag_end do
         mixin :tag_end_end
-        rule /[a-zA-Z0-9:-]+/ do
+        rule %r/[a-zA-Z0-9:-]+/ do
           token Name::Tag
           goto :tag_end_end
         end
       end
 
       state :tag_end_end do
-        rule /\s+/, Text
-        rule />/, Name::Tag, :pop!
+        rule %r/\s+/, Text
+        rule %r/>/, Name::Tag, :pop!
       end
 
       state :tag_start do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /[a-zA-Z0-9:-]+/ do
+        rule %r/[a-zA-Z0-9:-]+/ do
           token Name::Tag
           goto :tag
         end
@@ -76,41 +76,41 @@ module Rouge
       end
 
       state :comment do
-        rule /[^-]+/, Comment
-        rule /-->/, Comment, :pop!
-        rule /-/, Comment
+        rule %r/[^-]+/, Comment
+        rule %r/-->/, Comment, :pop!
+        rule %r/-/, Comment
       end
 
       state :tag do
-        rule /\s+/m, Text
-        rule /[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
-        rule /[a-zA-Z0-9_:-]+/, Name::Attribute
+        rule %r/\s+/m, Text
+        rule %r/[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
+        rule %r/[a-zA-Z0-9_:-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!
       end
 
       state :attr do
         # TODO: are backslash escapes valid here?
-        rule /"/ do
+        rule %r/"/ do
           token Str
           goto :dq
         end
 
-        rule /'/ do
+        rule %r/'/ do
           token Str
           goto :sq
         end
 
-        rule /[^\s>]+/, Str, :pop!
+        rule %r/[^\s>]+/, Str, :pop!
       end
 
       state :dq do
-        rule /"/, Str, :pop!
-        rule /[^"]+/, Str
+        rule %r/"/, Str, :pop!
+        rule %r/[^"]+/, Str
       end
 
       state :sq do
-        rule /'/, Str, :pop!
-        rule /[^']+/, Str
+        rule %r/'/, Str, :pop!
+        rule %r/[^']+/, Str
       end
 
       state :script_content do
@@ -126,13 +126,13 @@ module Rouge
       end
 
       state :style_content do
-        rule /[^<]+/ do
+        rule %r/[^<]+/ do
           delegate @lang
         end
 
         rule %r(<\s*/\s*style\s*>)m, Name::Tag, :pop!
 
-        rule /</ do
+        rule %r/</ do
           delegate @lang
         end
       end

--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -54,7 +54,7 @@ module Rouge
       end
 
       state :headers do
-        rule /([^\s:]+)( *)(:)( *)([^\r\n]+)(\r?\n|$)/ do |m|
+        rule %r/([^\s:]+)( *)(:)( *)([^\r\n]+)(\r?\n|$)/ do |m|
           key = m[1]
           value = m[5]
           if key.strip.casecmp('content-type').zero?
@@ -64,15 +64,15 @@ module Rouge
           groups Name::Attribute, Text, Punctuation, Text, Str, Text
         end
 
-        rule /([^\r\n]+)(\r?\n|$)/ do
+        rule %r/([^\r\n]+)(\r?\n|$)/ do
           groups Str, Text
         end
 
-        rule /\r?\n/, Text, :content
+        rule %r/\r?\n/, Text, :content
       end
 
       state :content do
-        rule /.+/m do |m|
+        rule %r/.+/m do |m|
           delegate(content_lexer)
         end
       end

--- a/lib/rouge/lexers/hylang.rb
+++ b/lib/rouge/lexers/hylang.rb
@@ -54,22 +54,22 @@ module Rouge
       end
 
       state :root do
-        rule /;.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule %r/;.*?$/, Comment::Single
+        rule %r/\s+/m, Text::Whitespace
 
-        rule /-?\d+\.\d+/, Num::Float
-        rule /-?\d+/, Num::Integer
-        rule /0x-?[0-9a-fA-F]+/, Num::Hex
+        rule %r/-?\d+\.\d+/, Num::Float
+        rule %r/-?\d+/, Num::Integer
+        rule %r/0x-?[0-9a-fA-F]+/, Num::Hex
 
-        rule /"(\\.|[^"])*"/, Str
-        rule /'#{keyword}/, Str::Symbol
-        rule /::?#{keyword}/, Name::Constant
-        rule /\\(.|[a-z]+)/i, Str::Char
+        rule %r/"(\\.|[^"])*"/, Str
+        rule %r/'#{keyword}/, Str::Symbol
+        rule %r/::?#{keyword}/, Name::Constant
+        rule %r/\\(.|[a-z]+)/i, Str::Char
 
 
-        rule /~@|[`\'#^~&@]/, Operator
+        rule %r/~@|[`\'#^~&@]/, Operator
 
-        rule /(\()(\s*)(#{identifier})/m do |m|
+        rule %r/(\()(\s*)(#{identifier})/m do |m|
           token Punctuation, m[1]
           token Text::Whitespace, m[2]
           token(name_token(m[3]) || Name::Function, m[3])
@@ -80,13 +80,13 @@ module Rouge
         end
 
         # vectors
-        rule /[\[\]]/, Punctuation
+        rule %r/[\[\]]/, Punctuation
 
         # maps
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
 
         # parentheses
-        rule /[()]/, Punctuation
+        rule %r/[()]/, Punctuation
       end
     end
   end

--- a/lib/rouge/lexers/idlang.rb
+++ b/lib/rouge/lexers/idlang.rb
@@ -209,17 +209,17 @@ module Rouge
       end
 
       state :root do
-        rule /[\s\n]+/, Text::Whitespace
+        rule %r/[\s\n]+/, Text::Whitespace
         # Normal comments
-        rule /;.*$/, Comment::Single
-        rule /\,\s*\,/, Error
-        rule /\!#{name}/, Name::Variable::Global
+        rule %r/;.*$/, Comment::Single
+        rule %r/\,\s*\,/, Error
+        rule %r/\!#{name}/, Name::Variable::Global
 
-        rule /[(),:\&\$]/, Punctuation
+        rule %r/[(),:\&\$]/, Punctuation
 
         ## Format statements are quite a strange beast.
         ## Better process them in their own state.
-        #rule /\b(FORMAT)(\s*)(\()/mi do |m|
+        #rule %r/\b(FORMAT)(\s*)(\()/mi do |m|
         #  token Keyword, m[1]
         #  token Text::Whitespace, m[2]
         #  token Punctuation, m[3]
@@ -235,25 +235,25 @@ module Rouge
           (_#{kind_param})? # kind parameter
         )xi, Num::Float
 
-        rule /\d+(B|S|U|US|LL|L|ULL|UL)?/i, Num::Integer
-        rule /"[0-7]+(B|O|U|ULL|UL|LL|L)?/i, Num::Oct
-        rule /'[0-9A-F]+'X(B|S|US|ULL|UL|U|LL|L)?/i, Num::Hex
-        rule /(#{kind_param}_)?'/, Str::Single, :string_single
-        rule /(#{kind_param}_)?"/, Str::Double, :string_double
+        rule %r/\d+(B|S|U|US|LL|L|ULL|UL)?/i, Num::Integer
+        rule %r/"[0-7]+(B|O|U|ULL|UL|LL|L)?/i, Num::Oct
+        rule %r/'[0-9A-F]+'X(B|S|US|ULL|UL|U|LL|L)?/i, Num::Hex
+        rule %r/(#{kind_param}_)?'/, Str::Single, :string_single
+        rule %r/(#{kind_param}_)?"/, Str::Double, :string_double
 
         rule %r{\#\#|\#|\&\&|\|\||/=|<=|>=|->|\@|\?|[-+*/<=~^{}]}, Operator
         # Structures and the like
-        rule /(#{name})(\.)([^\s,]*)/i do |m|
+        rule %r/(#{name})(\.)([^\s,]*)/i do |m|
           groups Name, Operator, Name
           #delegate IDLang, m[3]
         end
 
-        rule /(function|pro)((?:\s|\$\s)+)/i do
+        rule %r/(function|pro)((?:\s|\$\s)+)/i do
           groups Keyword, Text::Whitespace
           push :funcname
         end
 
-        rule /#{name}/m do |m|
+        rule %r/#{name}/m do |m|
           match = m[0].upcase
           if self.class.keywords.include? match
             token Keyword
@@ -275,37 +275,37 @@ module Rouge
       end
 
       state :funcname do
-        rule /#{name}/, Name::Function
+        rule %r/#{name}/, Name::Function
 
-        rule /\s+/, Text::Whitespace
-        rule /(:+|\$)/, Operator
-        rule /;.*/, Comment::Single
+        rule %r/\s+/, Text::Whitespace
+        rule %r/(:+|\$)/, Operator
+        rule %r/;.*/, Comment::Single
 
         # Be done with this state if we hit EOL or comma
-        rule /$/, Text::Whitespace, :pop!
-        rule /,/, Operator, :pop!
+        rule %r/$/, Text::Whitespace, :pop!
+        rule %r/,/, Operator, :pop!
       end
 
       state :string_single do
-        rule /[^']+/, Str::Single
-        rule /''/, Str::Escape
-        rule /'/, Str::Single, :pop!
+        rule %r/[^']+/, Str::Single
+        rule %r/''/, Str::Escape
+        rule %r/'/, Str::Single, :pop!
       end
 
       state :string_double do
-        rule /[^"]+/, Str::Double
-        rule /"/, Str::Double, :pop!
+        rule %r/[^"]+/, Str::Double
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :format_spec do
-        rule /'/, Str::Single, :string_single
-        rule /"/, Str::Double, :string_double
-        rule /\(/, Punctuation, :format_spec
-        rule /\)/, Punctuation, :pop!
-        rule /,/, Punctuation
-        rule /[\s\n]+/, Text::Whitespace
+        rule %r/'/, Str::Single, :string_single
+        rule %r/"/, Str::Double, :string_double
+        rule %r/\(/, Punctuation, :format_spec
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/[\s\n]+/, Text::Whitespace
         # Edit descriptors could be seen as a kind of "format literal".
-        rule /[^\s'"(),]+/, Literal
+        rule %r/[^\s'"(),]+/, Literal
       end
     end
   end

--- a/lib/rouge/lexers/igorpro.rb
+++ b/lib/rouge/lexers/igorpro.rb
@@ -521,7 +521,7 @@ module Rouge
       state :root do
         rule %r(//), Comment, :comments
 
-        rule /#{object}/ do |m|
+        rule %r/#{object}/ do |m|
           if m[0].downcase =~ /function/
             token Keyword::Declaration
             push :parse_function
@@ -567,22 +567,22 @@ module Rouge
 
       state :assignment do
         mixin :whitespace
-        rule /\"/, Literal::String::Double, :string1 #punctuation for string
+        rule %r/\"/, Literal::String::Double, :string1 #punctuation for string
         mixin :string2
-        rule /#{number_float}/, Literal::Number::Float, :pop!
-        rule /#{number_int}/, Literal::Number::Integer, :pop!
-        rule /[\(\[\{][^\)\]\}]+[\)\]\}]/, Generic, :pop!
-        rule /[^\s\/\(]+/, Generic, :pop!
+        rule %r/#{number_float}/, Literal::Number::Float, :pop!
+        rule %r/#{number_int}/, Literal::Number::Integer, :pop!
+        rule %r/[\(\[\{][^\)\]\}]+[\)\]\}]/, Generic, :pop!
+        rule %r/[^\s\/\(]+/, Generic, :pop!
         rule(//) { pop! }
       end
 
       state :parse_variables do
         mixin :whitespace
-        rule /[=]/, Punctuation, :assignment
+        rule %r/[=]/, Punctuation, :assignment
         rule object, Name::Variable
-        rule /[\[\]]/, Punctuation # optional variables in functions
-        rule /[,]/, Punctuation, :parse_variables
-        rule /\)/, Punctuation, :pop! # end of function
+        rule %r/[\[\]]/, Punctuation # optional variables in functions
+        rule %r/[,]/, Punctuation, :parse_variables
+        rule %r/\)/, Punctuation, :pop! # end of function
         rule %r([/][a-z]+)i, Keyword::Pseudo, :parse_variables
         rule(//) { pop! }
       end
@@ -591,15 +591,15 @@ module Rouge
         rule %r([/][a-z]+)i, Keyword::Pseudo # only one flag
         mixin :whitespace
         rule object, Name::Function
-        rule /[\(]/, Punctuation, :parse_variables
+        rule %r/[\(]/, Punctuation, :parse_variables
         rule(//) { pop! }
       end
 
       state :operationFlags do
-        rule /#{noLineBreak}/, Text
-        rule /[=]/, Punctuation, :assignment
+        rule %r/#{noLineBreak}/, Text
+        rule %r/[=]/, Punctuation, :assignment
         rule %r([/][a-z]+)i, Keyword::Pseudo, :operationFlags
-        rule /(as)(\s*)(#{object})/i do
+        rule %r/(as)(\s*)(#{object})/i do
           groups Keyword::Type, Text, Name::Label
         end
         rule(//) { pop! }
@@ -621,34 +621,34 @@ module Rouge
       end
 
       state :characters do
-        rule /\s/, Text
-        rule /#{operator}/, Operator
-        rule /#{punctuation}/, Punctuation
-        rule /\"/, Literal::String::Double, :string1 #punctuation for string
+        rule %r/\s/, Text
+        rule %r/#{operator}/, Operator
+        rule %r/#{punctuation}/, Punctuation
+        rule %r/\"/, Literal::String::Double, :string1 #punctuation for string
         mixin :string2
       end
 
       state :numbers do
-        rule /#{number_float}/, Literal::Number::Float
-        rule /#{number_hex}/, Literal::Number::Hex
-        rule /#{number_int}/, Literal::Number::Integer
+        rule %r/#{number_float}/, Literal::Number::Float
+        rule %r/#{number_hex}/, Literal::Number::Hex
+        rule %r/#{number_int}/, Literal::Number::Integer
       end
 
       state :whitespace do
-        rule /#{noLineBreak}/, Text
+        rule %r/#{noLineBreak}/, Text
       end
 
       state :string1 do
-        rule /%\w\b/, Literal::String::Other
-        rule /\\\\/, Literal::String::Escape
-        rule /\\\"/, Literal::String::Escape
-        rule /\\/, Literal::String::Escape
-        rule /[^"]/, Literal::String
-        rule /\"/, Literal::String::Double, :pop! #punctuation for string
+        rule %r/%\w\b/, Literal::String::Other
+        rule %r/\\\\/, Literal::String::Escape
+        rule %r/\\\"/, Literal::String::Escape
+        rule %r/\\/, Literal::String::Escape
+        rule %r/[^"]/, Literal::String
+        rule %r/\"/, Literal::String::Double, :pop! #punctuation for string
       end
 
       state :string2 do
-        rule /\'[^']*\'/, Literal::String::Single
+        rule %r/\'[^']*\'/, Literal::String::Single
       end
 
       state :comments do
@@ -656,7 +656,7 @@ module Rouge
           # doxygen comments
           groups Comment, Comment::Special
         end
-        rule /[^\r\n]/, Comment
+        rule %r/[^\r\n]/, Comment
         rule(//) { pop! }
       end
     end

--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -15,39 +15,39 @@ module Rouge
       identifier = /[\w\-.]+/
 
       state :basic do
-        rule /[;#].*?\n/, Comment
-        rule /\s+/, Text
-        rule /\\\n/, Str::Escape
+        rule %r/[;#].*?\n/, Comment
+        rule %r/\s+/, Text
+        rule %r/\\\n/, Str::Escape
       end
 
       state :root do
         mixin :basic
 
-        rule /(#{identifier})(\s*)(=)/ do
+        rule %r/(#{identifier})(\s*)(=)/ do
           groups Name::Property, Text, Punctuation
           push :value
         end
 
-        rule /\[.*?\]/, Name::Namespace
+        rule %r/\[.*?\]/, Name::Namespace
       end
 
       state :value do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         mixin :basic
-        rule /"/, Str, :dq
-        rule /'.*?'/, Str
+        rule %r/"/, Str, :dq
+        rule %r/'.*?'/, Str
         mixin :esc_str
-        rule /[^\\\n]+/, Str
+        rule %r/[^\\\n]+/, Str
       end
 
       state :dq do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         mixin :esc_str
-        rule /[^\\"]+/m, Str
+        rule %r/[^\\"]+/m, Str
       end
 
       state :esc_str do
-        rule /\\./m, Str::Escape
+        rule %r/\\./m, Str::Escape
       end
     end
   end

--- a/lib/rouge/lexers/io.rb
+++ b/lib/rouge/lexers/io.rb
@@ -26,22 +26,22 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule %r(//.*?\n), Comment::Single
         rule %r(#.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
         rule %r(/[+]), Comment::Multiline, :nested_comment
 
-        rule /"(\\\\|\\"|[^"])*"/, Str
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
 
         rule %r(:?:=), Keyword
-        rule /[()]/, Punctuation
+        rule %r/[()]/, Punctuation
 
         rule %r([-=;,*+><!/|^.%&\[\]{}]), Operator
 
-        rule /[A-Z]\w*/, Name::Class
+        rule %r/[A-Z]\w*/, Name::Class
 
-        rule /[a-z_]\w*/ do |m|
+        rule %r/[a-z_]\w*/ do |m|
           name = m[0]
 
           if self.class.constants.include? name
@@ -54,9 +54,9 @@ module Rouge
         end
 
         rule %r((\d+[.]?\d*|\d*[.]\d+)(e[+-]?[0-9]+)?)i, Num::Float
-        rule /\d+/, Num::Integer
+        rule %r/\d+/, Num::Integer
 
-        rule /@@?/, Keyword
+        rule %r/@@?/, Keyword
       end
 
       state :nested_comment do

--- a/lib/rouge/lexers/irb.rb
+++ b/lib/rouge/lexers/irb.rb
@@ -41,25 +41,25 @@ module Rouge
 
       state :has_irb_output do
         rule %r(=>), Punctuation, :pop!
-        rule /.+?(\n|$)/, Generic::Output
+        rule %r/.+?(\n|$)/, Generic::Output
       end
 
       state :irb_error do
-        rule /.+?(\n|$)/, Generic::Error
+        rule %r/.+?(\n|$)/, Generic::Error
         mixin :has_irb_output
       end
 
       state :stdout do
-        rule /\w+?(Error|Exception):.+?(\n|$)/, Generic::Error, :irb_error
+        rule %r/\w+?(Error|Exception):.+?(\n|$)/, Generic::Error, :irb_error
         mixin :has_irb_output
       end
 
       prepend :root do
-        rule /#</, Keyword::Type, :irb_object
+        rule %r/#</, Keyword::Type, :irb_object
       end
 
       state :irb_object do
-        rule />/, Keyword::Type, :pop!
+        rule %r/>/, Keyword::Type, :pop!
         mixin :root
       end
     end

--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -28,12 +28,12 @@ module Rouge
       class_name = /[A-Z][a-zA-Z0-9]*\b/
 
       state :root do
-        rule /[^\S\n]+/, Text
+        rule %r/[^\S\n]+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
         # keywords: go before method names to avoid lexing "throw new XYZ"
         # as a method signature
-        rule /(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword
 
         rule %r(
           (\s*(?:[a-zA-Z_][a-zA-Z0-9_.\[\]<>]*\s+)+?) # return arguments
@@ -47,45 +47,45 @@ module Rouge
           token Operator, m[4]
         end
 
-        rule /@#{id}/, Name::Decorator
-        rule /(?:#{declarations.join('|')})\b/, Keyword::Declaration
-        rule /(?:#{types.join('|')})\b/, Keyword::Type
-        rule /package\b/, Keyword::Namespace
-        rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /(?:class|interface)\b/, Keyword::Declaration, :class
-        rule /import\b/, Keyword::Namespace, :import
-        rule /"(\\\\|\\"|[^"])*"/, Str
-        rule /'(?:\\.|[^\\]|\\u[0-9a-f]{4})'/, Str::Char
-        rule /(\.)(#{id})/ do
+        rule %r/@#{id}/, Name::Decorator
+        rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
+        rule %r/(?:#{types.join('|')})\b/, Keyword::Type
+        rule %r/package\b/, Keyword::Namespace
+        rule %r/(?:true|false|null)\b/, Keyword::Constant
+        rule %r/(?:class|interface)\b/, Keyword::Declaration, :class
+        rule %r/import\b/, Keyword::Namespace, :import
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
+        rule %r/'(?:\\.|[^\\]|\\u[0-9a-f]{4})'/, Str::Char
+        rule %r/(\.)(#{id})/ do
           groups Operator, Name::Attribute
         end
 
-        rule /#{id}:/, Name::Label
+        rule %r/#{id}:/, Name::Label
         rule const_name, Name::Constant
         rule class_name, Name::Class
-        rule /\$?#{id}/, Name
-        rule /[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
+        rule %r/\$?#{id}/, Name
+        rule %r/[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
 
         digit = /[0-9]_+[0-9]|[0-9]/
         bin_digit = /[01]_+[01]|[01]/
         oct_digit = /[0-7]_+[0-7]|[0-7]/
         hex_digit = /[0-9a-f]_+[0-9a-f]|[0-9a-f]/i
-        rule /#{digit}+\.#{digit}+([eE]#{digit}+)?[fd]?/, Num::Float
-        rule /0b#{bin_digit}+/i, Num::Bin
-        rule /0x#{hex_digit}+/i, Num::Hex
-        rule /0#{oct_digit}+/, Num::Oct
-        rule /#{digit}+L?/, Num::Integer
-        rule /\n/, Text
+        rule %r/#{digit}+\.#{digit}+([eE]#{digit}+)?[fd]?/, Num::Float
+        rule %r/0b#{bin_digit}+/i, Num::Bin
+        rule %r/0x#{hex_digit}+/i, Num::Hex
+        rule %r/0#{oct_digit}+/, Num::Oct
+        rule %r/#{digit}+L?/, Num::Integer
+        rule %r/\n/, Text
       end
 
       state :class do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule id, Name::Class, :pop!
       end
 
       state :import do
-        rule /\s+/m, Text
-        rule /[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
+        rule %r/\s+/m, Text
+        rule %r/[a-z0-9_.]+\*?/i, Name::Namespace, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -80,7 +80,7 @@ module Rouge
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule %r/\//, Str::Escape
+        rule %r(/), Str::Escape
 
         rule %r([^/]\n) do
           token Error

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -32,8 +32,8 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
-        rule /<!--/, Comment # really...?
+        rule %r/\s+/, Text
+        rule %r/<!--/, Comment # really...?
         rule %r(//.*?$), Comment::Single
         rule %r(/[*]), Comment::Multiline, :multiline_comment
       end
@@ -46,12 +46,12 @@ module Rouge
           goto :regex
         end
 
-        rule /[{]/ do
+        rule %r/[{]/ do
           token Punctuation
           goto :object
         end
 
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :regex do
@@ -62,38 +62,38 @@ module Rouge
 
         rule %r([^/]\n), Error, :pop!
 
-        rule /\n/, Error, :pop!
-        rule /\[\^/, Str::Escape, :regex_group
-        rule /\[/, Str::Escape, :regex_group
-        rule /\\./, Str::Escape
+        rule %r/\n/, Error, :pop!
+        rule %r/\[\^/, Str::Escape, :regex_group
+        rule %r/\[/, Str::Escape, :regex_group
+        rule %r/\\./, Str::Escape
         rule %r{[(][?][:=<!]}, Str::Escape
-        rule /[{][\d,]+[}]/, Str::Escape
-        rule /[()?]/, Str::Escape
-        rule /./, Str::Regex
+        rule %r/[{][\d,]+[}]/, Str::Escape
+        rule %r/[()?]/, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :regex_end do
-        rule /[gim]+/, Str::Regex, :pop!
+        rule %r/[gim]+/, Str::Regex, :pop!
         rule(//) { pop! }
       end
 
       state :regex_group do
         # specially highlight / in a group to indicate that it doesn't
         # close the regex
-        rule /\//, Str::Escape
+        rule %r/\//, Str::Escape
 
         rule %r([^/]\n) do
           token Error
           pop! 2
         end
 
-        rule /\]/, Str::Escape, :pop!
-        rule /\\./, Str::Escape
-        rule /./, Str::Regex
+        rule %r/\]/, Str::Escape, :pop!
+        rule %r/\\./, Str::Escape
+        rule %r/./, Str::Regex
       end
 
       state :bad_regex do
-        rule /[^\n]+/, Error, :pop!
+        rule %r/[^\n]+/, Error, :pop!
       end
 
       def self.keywords
@@ -144,34 +144,34 @@ module Rouge
       id = self.id_regex
 
       state :root do
-        rule /\A\s*#!.*?\n/m, Comment::Preproc, :statement
+        rule %r/\A\s*#!.*?\n/m, Comment::Preproc, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===
                | !== )x,
           Operator, :expr_start
         rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start
-        rule /[(\[,]/, Punctuation, :expr_start
-        rule /;/, Punctuation, :statement
-        rule /[)\].]/, Punctuation
+        rule %r/[(\[,]/, Punctuation, :expr_start
+        rule %r/;/, Punctuation, :statement
+        rule %r/[)\].]/, Punctuation
 
-        rule /`/ do
+        rule %r/`/ do
           token Str::Double
           push :template_string
         end
 
-        rule /[?]/ do
+        rule %r/[?]/ do
           token Punctuation
           push :ternary
           push :expr_start
         end
 
-        rule /(\@)(\w+)?/ do
+        rule %r/(\@)(\w+)?/ do
           groups Punctuation, Name::Decorator
           push :expr_start
         end
 
-        rule /[{}]/, Punctuation, :statement
+        rule %r/[{}]/, Punctuation, :statement
 
         rule id do |m|
           if self.class.keywords.include? m[0]
@@ -191,41 +191,41 @@ module Rouge
           end
         end
 
-        rule /[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
-        rule /0x[0-9a-fA-F]+/i, Num::Hex
-        rule /0o[0-7][0-7_]*/i, Num::Oct
-        rule /0b[01][01_]*/i, Num::Bin
-        rule /[0-9]+/, Num::Integer
+        rule %r/[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
+        rule %r/0x[0-9a-fA-F]+/i, Num::Hex
+        rule %r/0o[0-7][0-7_]*/i, Num::Oct
+        rule %r/0b[01][01_]*/i, Num::Bin
+        rule %r/[0-9]+/, Num::Integer
 
-        rule /"/, Str::Delimiter, :dq
-        rule /'/, Str::Delimiter, :sq
-        rule /:/, Punctuation
+        rule %r/"/, Str::Delimiter, :dq
+        rule %r/'/, Str::Delimiter, :sq
+        rule %r/:/, Punctuation
       end
 
       state :dq do
-        rule /\\[\\nrt"]?/, Str::Escape
-        rule /[^\\"]+/, Str::Double
-        rule /"/, Str::Delimiter, :pop!
+        rule %r/\\[\\nrt"]?/, Str::Escape
+        rule %r/[^\\"]+/, Str::Double
+        rule %r/"/, Str::Delimiter, :pop!
       end
 
       state :sq do
-        rule /\\[\\nrt']?/, Str::Escape
-        rule /[^\\']+/, Str::Single
-        rule /'/, Str::Delimiter, :pop!
+        rule %r/\\[\\nrt']?/, Str::Escape
+        rule %r/[^\\']+/, Str::Single
+        rule %r/'/, Str::Delimiter, :pop!
       end
 
       # braced parts that aren't object literals
       state :statement do
-        rule /case\b/ do
+        rule %r/case\b/ do
           token Keyword
           goto :expr_start
         end
 
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/(#{id})(\s*)(:)/ do
           groups Name::Label, Text, Punctuation
         end
 
-        rule /[{}]/, Punctuation
+        rule %r/[{}]/, Punctuation
 
         mixin :expr_start
       end
@@ -234,28 +234,28 @@ module Rouge
       state :object do
         mixin :comments_and_whitespace
 
-        rule /[{]/ do
+        rule %r/[{]/ do
           token Punctuation
           push
         end
 
-        rule /[}]/ do
+        rule %r/[}]/ do
           token Punctuation
           goto :statement
         end
 
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/(#{id})(\s*)(:)/ do
           groups Name::Attribute, Text, Punctuation
           push :expr_start
         end
 
-        rule /:/, Punctuation
+        rule %r/:/, Punctuation
         mixin :root
       end
 
       # ternary expressions, where <id>: is not a label!
       state :ternary do
-        rule /:/ do
+        rule %r/:/ do
           token Punctuation
           goto :expr_start
         end
@@ -265,13 +265,13 @@ module Rouge
 
       # template strings
       state :template_string do
-        rule /\${/, Punctuation, :template_string_expr
-        rule /`/, Str::Double, :pop!
-        rule /(\\\\|\\[\$`]|[^\$`]|\$(?!{))*/, Str::Double
+        rule %r/\${/, Punctuation, :template_string_expr
+        rule %r/`/, Str::Double, :pop!
+        rule %r/(\\\\|\\[\$`]|[^\$`]|\$(?!{))*/, Str::Double
       end
 
       state :template_string_expr do
-        rule /}/, Punctuation, :pop!
+        rule %r/}/, Punctuation, :pop!
         mixin :root
       end
     end

--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -37,16 +37,16 @@ module Rouge
 
       state :root do
         # Comments
-        rule /{#/, Comment, :comment
+        rule %r/{#/, Comment, :comment
 
         # Statements
-        rule /\{\%/ do
+        rule %r/\{\%/ do
           token Comment::Preproc
           push :statement
         end
 
         # Expressions
-        rule /\{\{/ do
+        rule %r/\{\{/ do
           token Comment::Preproc
           push :expression
         end
@@ -57,42 +57,42 @@ module Rouge
 
       state :filter do
         # Filters are called like variable|foo(arg1, ...)
-        rule /(\|)(\w+)/ do
+        rule %r/(\|)(\w+)/ do
           groups Operator, Name::Function
         end
       end
 
       state :function do
-        rule /(\w+)(\()/ do
+        rule %r/(\w+)(\()/ do
           groups Name::Function, Punctuation
         end
       end
 
       state :text do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
       end
 
       state :literal do
         # Strings
-        rule /"(\\.|.)*?"/, Str::Double
-        rule /'(\\.|.)*?'/, Str::Single
+        rule %r/"(\\.|.)*?"/, Str::Double
+        rule %r/'(\\.|.)*?'/, Str::Single
 
         # Numbers
-        rule /\d+(?=}\s)/, Num
+        rule %r/\d+(?=}\s)/, Num
 
         # Arithmetic operators (+, -, *, **, //, /)
         # TODO : implement modulo (%)
-        rule /(\+|\-|\*|\/\/?|\*\*?|=)/, Operator
+        rule %r/(\+|\-|\*|\/\/?|\*\*?|=)/, Operator
 
         # Comparisons operators (<=, <, >=, >, ==, ===, !=)
-        rule /(<=?|>=?|===?|!=)/, Operator
+        rule %r/(<=?|>=?|===?|!=)/, Operator
 
         # Punctuation (the comma, [], ())
-        rule /,/,  Punctuation
-        rule /\[/, Punctuation
-        rule /\]/, Punctuation
-        rule /\(/, Punctuation
-        rule /\)/, Punctuation
+        rule %r/,/,  Punctuation
+        rule %r/\[/, Punctuation
+        rule %r/\]/, Punctuation
+        rule %r/\(/, Punctuation
+        rule %r/\)/, Punctuation
       end
 
       state :comment do
@@ -101,23 +101,23 @@ module Rouge
       end
 
       state :expression do
-        rule /\w+\.?/m, Name::Variable
+        rule %r/\w+\.?/m, Name::Variable
 
         mixin :filter
         mixin :function
         mixin :literal
         mixin :text
 
-        rule /%}|}}/, Comment::Preproc, :pop!
+        rule %r/%}|}}/, Comment::Preproc, :pop!
       end
 
       state :statement do
-        rule /(raw|verbatim)(\s+)(\%\})/ do
+        rule %r/(raw|verbatim)(\s+)(\%\})/ do
           groups Keyword, Text, Comment::Preproc
           goto :raw
         end
 
-        rule /(\w+\.?)/ do |m|
+        rule %r/(\w+\.?)/ do |m|
           if self.class.keywords.include?(m[0])
             groups Keyword
           elsif self.class.pseudo_keywords.include?(m[0])
@@ -136,7 +136,7 @@ module Rouge
         mixin :literal
         mixin :text
 
-        rule /\%\}/, Comment::Preproc, :pop!
+        rule %r/\%\}/, Comment::Preproc, :pop!
       end
 
       state :raw do
@@ -145,7 +145,7 @@ module Rouge
           pop!
         end
 
-        rule /(.+?)/m, Text
+        rule %r/(.+?)/m, Text
       end
     end
   end

--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -12,18 +12,18 @@ module Rouge
                 'application/hal+json'
 
       state :root do
-        rule /\s+/m, Text::Whitespace
-        rule /"/, Str::Double, :string
-        rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /[{},:\[\]]/, Punctuation
-        rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]?\d+)?/i, Num::Float
-        rule /-?(?:0|[1-9]\d*)(?:e[+-]?\d+)?/i, Num::Integer
+        rule %r/\s+/m, Text::Whitespace
+        rule %r/"/, Str::Double, :string
+        rule %r/(?:true|false|null)\b/, Keyword::Constant
+        rule %r/[{},:\[\]]/, Punctuation
+        rule %r/-?(?:0|[1-9]\d*)\.\d+(?:e[+-]?\d+)?/i, Num::Float
+        rule %r/-?(?:0|[1-9]\d*)(?:e[+-]?\d+)?/i, Num::Integer
       end
 
       state :string do
-        rule /[^\\"]+/, Str::Double
-        rule /\\./, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/[^\\"]+/, Str::Double
+        rule %r/\\./, Str::Escape
+        rule %r/"/, Str::Double, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/json_doc.rb
+++ b/lib/rouge/lexers/json_doc.rb
@@ -10,14 +10,14 @@ module Rouge
       tag 'json-doc'
 
       prepend :root do
-        rule /([$\w]+)(\s*)(:)/ do
+        rule %r/([$\w]+)(\s*)(:)/ do
           groups Name::Attribute, Text, Punctuation
         end
 
         rule %r(/[*].*?[*]/), Comment
 
         rule %r(//.*?$), Comment::Single
-        rule /(\.\.\.)/, Comment::Single
+        rule %r/(\.\.\.)/, Comment::Single
       end
     end
   end

--- a/lib/rouge/lexers/jsonnet.rb
+++ b/lib/rouge/lexers/jsonnet.rb
@@ -93,21 +93,21 @@ module Rouge
       identifier = /[a-zA-Z_][a-zA-Z0-9_]*/
 
       state :root do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(#.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
 
-        rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
-        rule /-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
+        rule %r/-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
+        rule %r/-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
 
-        rule /[{}:\.,;+\[\]=%\(\)]/, Punctuation
+        rule %r/[{}:\.,;+\[\]=%\(\)]/, Punctuation
 
-        rule /"/, Str, :string_double
-        rule /'/, Str, :string_single
-        rule /\|\|\|/, Str, :string_block
+        rule %r/"/, Str, :string_double
+        rule %r/'/, Str, :string_single
+        rule %r/\|\|\|/, Str, :string_block
 
-        rule /\$/, Keyword
+        rule %r/\$/, Keyword
 
         rule identifier do |m|
           if self.class.keywords.include? m[0]
@@ -125,27 +125,27 @@ module Rouge
       end
 
       state :string do
-        rule /\\([\\\/bfnrt]|(u[0-9a-fA-F]{4}))/, Str::Escape
+        rule %r/\\([\\\/bfnrt]|(u[0-9a-fA-F]{4}))/, Str::Escape
       end
 
       state :string_double do
         mixin :string
-        rule /\\"/, Str::Escape
-        rule /"/, Str, :pop!
-        rule /[^\\"]+/, Str
+        rule %r/\\"/, Str::Escape
+        rule %r/"/, Str, :pop!
+        rule %r/[^\\"]+/, Str
       end
 
       state :string_single do
         mixin :string
-        rule /\\'/, Str::Escape
-        rule /'/, Str, :pop!
-        rule /[^\\']+/, Str
+        rule %r/\\'/, Str::Escape
+        rule %r/'/, Str, :pop!
+        rule %r/[^\\']+/, Str
       end
 
       state :string_block do
         mixin :string
-        rule /\|\|\|/, Str, :pop!
-        rule /.*/, Str
+        rule %r/\|\|\|/, Str, :pop!
+        rule %r/.*/, Str
       end
     end
   end

--- a/lib/rouge/lexers/jsp.rb
+++ b/lib/rouge/lexers/jsp.rb
@@ -31,7 +31,7 @@ module Rouge
         rule %r/<[a-zA-Z]*:[a-zA-Z]*\s*/, Name::Tag, :jsp_tag
 
         # end of tag, e.g. </c:if>
-        rule %r/<\/[a-zA-Z]*:[a-zA-Z]*>/, Name::Tag
+        rule %r(</[a-zA-Z]*:[a-zA-Z]*>), Name::Tag
 
         rule %r/<%[!=]?/, Name::Tag, :jsp_expression2
 
@@ -52,7 +52,7 @@ module Rouge
       end
 
       state :jsp_directive2 do
-        rule %r/(\/>)/, Name::Tag, :pop!
+        rule %r!(/>)!, Name::Tag, :pop!
         mixin :attributes
         rule(/(.+?)(?=\/>)/m) { delegate parent }
       end

--- a/lib/rouge/lexers/jsp.rb
+++ b/lib/rouge/lexers/jsp.rb
@@ -19,21 +19,21 @@ module Rouge
      
       state :root do
 
-        rule /<%--/, Comment, :jsp_comment
+        rule %r/<%--/, Comment, :jsp_comment
 
-        rule /<%@\s*(#{directives.join('|')})\s*/, Name::Tag, :jsp_directive
+        rule %r/<%@\s*(#{directives.join('|')})\s*/, Name::Tag, :jsp_directive
 
-        rule /<jsp:directive\.(#{directives.join('|')})/, Name::Tag, :jsp_directive2
+        rule %r/<jsp:directive\.(#{directives.join('|')})/, Name::Tag, :jsp_directive2
 
-        rule /<jsp:(#{actions.join('|')})>/, Name::Tag, :jsp_expression
+        rule %r/<jsp:(#{actions.join('|')})>/, Name::Tag, :jsp_expression
 
         # start of tag, e.g. <c:if>
-        rule /<[a-zA-Z]*:[a-zA-Z]*\s*/, Name::Tag, :jsp_tag
+        rule %r/<[a-zA-Z]*:[a-zA-Z]*\s*/, Name::Tag, :jsp_tag
 
         # end of tag, e.g. </c:if>
-        rule /<\/[a-zA-Z]*:[a-zA-Z]*>/, Name::Tag
+        rule %r/<\/[a-zA-Z]*:[a-zA-Z]*>/, Name::Tag
 
-        rule /<%[!=]?/, Name::Tag, :jsp_expression2
+        rule %r/<%[!=]?/, Name::Tag, :jsp_expression2
 
         # fallback to HTML
         rule(/(.+?)(?=(<%|<\/?[a-zA-Z]*:))/m) { delegate parent }
@@ -41,78 +41,78 @@ module Rouge
       end
 
       state :jsp_comment do
-        rule /(--%>)/, Comment, :pop!
-        rule /./m, Comment
+        rule %r/(--%>)/, Comment, :pop!
+        rule %r/./m, Comment
       end
 
       state :jsp_directive do
-        rule /(%>)/, Name::Tag, :pop!
+        rule %r/(%>)/, Name::Tag, :pop!
         mixin :attributes
         rule(/(.+?)(?=%>)/m) { delegate parent }
       end
 
       state :jsp_directive2 do
-        rule /(\/>)/, Name::Tag, :pop!
+        rule %r/(\/>)/, Name::Tag, :pop!
         mixin :attributes
         rule(/(.+?)(?=\/>)/m) { delegate parent }
       end
 
       state :jsp_expression do
-        rule /<\/jsp:(#{actions.join('|')})>/, Name::Tag, :pop!
+        rule %r/<\/jsp:(#{actions.join('|')})>/, Name::Tag, :pop!
         mixin :attributes
         rule(/[^<\/]+/) { delegate @java }
       end
 
       state :jsp_expression2 do
-        rule /%>/, Name::Tag, :pop!
+        rule %r/%>/, Name::Tag, :pop!
         rule(/[^%>]+/) { delegate @java }
       end
 
       state :jsp_tag do
-        rule /\/?>/, Name::Tag, :pop!
+        rule %r/\/?>/, Name::Tag, :pop!
         mixin :attributes
         rule(/(.+?)(?=\/?>)/m) { delegate parent }
       end
 
       state :attributes do
-        rule /\s*[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
+        rule %r/\s*[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
       end
 
       state :attr do
-        rule /"/ do
+        rule %r/"/ do
           token Str
           goto :double_quotes
         end
 
-        rule /'/ do
+        rule %r/'/ do
           token Str
           goto :single_quotes
         end
 
-        rule /[^\s>]+/, Str, :pop!
+        rule %r/[^\s>]+/, Str, :pop!
       end
 
       state :double_quotes do
-        rule /"/, Str, :pop!
-        rule /\$\{/, Str::Interpol, :jsp_interp
-        rule /[^"]+/, Str
+        rule %r/"/, Str, :pop!
+        rule %r/\$\{/, Str::Interpol, :jsp_interp
+        rule %r/[^"]+/, Str
       end
 
       state :single_quotes do
-        rule /'/, Str, :pop!
-        rule /\$\{/, Str::Interpol, :jsp_interp
-        rule /[^']+/, Str
+        rule %r/'/, Str, :pop!
+        rule %r/\$\{/, Str::Interpol, :jsp_interp
+        rule %r/[^']+/, Str
       end
 
       state :jsp_interp do
-        rule /\}/, Str::Interpol, :pop!
-        rule /'/, Literal, :jsp_interp_literal_start 
+        rule %r/\}/, Str::Interpol, :pop!
+        rule %r/'/, Literal, :jsp_interp_literal_start 
         rule(/[^'\}]+/) { delegate @java }
       end
 
       state :jsp_interp_literal_start do
-        rule /'/, Literal, :pop!
-        rule /[^']*/, Literal
+        rule %r/'/, Literal, :pop!
+        rule %r/[^']*/, Literal
       end
 
     end

--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -29,7 +29,7 @@ module Rouge
       start { @html = HTML.new(options) }
 
       state :jsx_tags do
-        rule /</, Punctuation, :jsx_element
+        rule %r/</, Punctuation, :jsx_element
       end
 
       state :jsx_internal do
@@ -38,12 +38,12 @@ module Rouge
           goto :jsx_end_tag
         end
 
-        rule /{/ do
+        rule %r/{/ do
           token Str::Interpol
           start_embed!
         end
 
-        rule /[^<>{]+/ do
+        rule %r/[^<>{]+/ do
           delegate @html
         end
 
@@ -56,29 +56,29 @@ module Rouge
 
       state :jsx_tag do
         mixin :comments_and_whitespace
-        rule /#{id}/ do |m|
+        rule %r/#{id}/ do |m|
           token tag_token(m[0])
         end
 
-        rule /[.]/, Punctuation
+        rule %r/[.]/, Punctuation
       end
 
       state :jsx_end_tag do
         mixin :jsx_tag
-        rule />/, Punctuation, :pop!
+        rule %r/>/, Punctuation, :pop!
       end
 
       state :jsx_element do
-        rule /#{id}=/, Name::Attribute, :jsx_attribute
+        rule %r/#{id}=/, Name::Attribute, :jsx_attribute
         mixin :jsx_tag
-        rule />/ do token Punctuation; goto :jsx_internal end
+        rule %r/>/ do token Punctuation; goto :jsx_internal end
         rule %r(/>), Punctuation, :pop!
       end
 
       state :jsx_attribute do
-        rule /"(\\[\\"]|[^"])*"/, Str::Double, :pop!
-        rule /'(\\[\\']|[^'])*'/, Str::Single, :pop!
-        rule /{/ do
+        rule %r/"(\\[\\"]|[^"])*"/, Str::Double, :pop!
+        rule %r/'(\\[\\']|[^'])*'/, Str::Single, :pop!
+        rule %r/{/ do
           token Str::Interpol
           pop!
           start_embed!
@@ -86,15 +86,15 @@ module Rouge
       end
 
       state :jsx_embed_root do
-        rule /[.][.][.]/, Punctuation
-        rule /}/, Str::Interpol, :pop!
+        rule %r/[.][.][.]/, Punctuation
+        rule %r/}/, Str::Interpol, :pop!
         mixin :jsx_embed
       end
 
       state :jsx_embed do
-        rule /{/ do delegate @embed; push :jsx_embed end
-        rule /}/ do delegate @embed; pop! end
-        rule /[^{}]+/ do
+        rule %r/{/ do delegate @embed; push :jsx_embed end
+        rule %r/}/ do delegate @embed; pop! end
+        rule %r/[^{}]+/ do
           delegate @embed
         end
       end

--- a/lib/rouge/lexers/julia.rb
+++ b/lib/rouge/lexers/julia.rb
@@ -183,30 +183,30 @@ module Rouge
 
 
       state :root do
-        rule /\n/, Text
-        rule /[^\S\n]+/, Text
-        rule /#=/, Comment::Multiline, :blockcomment
-        rule /#.*$/, Comment
+        rule %r/\n/, Text
+        rule %r/[^\S\n]+/, Text
+        rule %r/#=/, Comment::Multiline, :blockcomment
+        rule %r/#.*$/, Comment
         rule OPERATORS, Operator
-        rule /\\\n/, Text
-        rule /\\/, Text
+        rule %r/\\\n/, Text
+        rule %r/\\/, Text
 
 
         # functions and macros
-        rule /(function|macro)((?:\s|\\\s)+)/ do
+        rule %r/(function|macro)((?:\s|\\\s)+)/ do
           groups Keyword, Name::Function
           push :funcname
         end
 
         # types
-        rule /((mutable )?struct|(abstract|primitive) type)((?:\s|\\\s)+)/ do
+        rule %r/((mutable )?struct|(abstract|primitive) type)((?:\s|\\\s)+)/ do
           groups Keyword, Name::Class
           push :typename
         end
         rule TYPES, Keyword::Type
 
         # keywords
-        rule /(local|global|const)\b/, Keyword::Declaration
+        rule %r/(local|global|const)\b/, Keyword::Declaration
         rule KEYWORDS, Keyword
 
         # TODO: end is a builtin when inside of an indexing expression
@@ -215,75 +215,75 @@ module Rouge
         # TODO: symbols
 
         # backticks
-        rule /`.*?`/, Literal::String::Backtick
+        rule %r/`.*?`/, Literal::String::Backtick
 
         # chars
-        rule /'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,3}|\\u[a-fA-F0-9]{1,4}|\\U[a-fA-F0-9]{1,6}|[^\\\'\n])'/, Literal::String::Char
+        rule %r/'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,3}|\\u[a-fA-F0-9]{1,4}|\\U[a-fA-F0-9]{1,6}|[^\\\'\n])'/, Literal::String::Char
 
         # try to match trailing transpose
-        rule /(?<=[.\w)\]])\'+/, Operator
+        rule %r/(?<=[.\w)\]])\'+/, Operator
 
         # strings
         # TODO: triple quoted string literals
         # TODO: Detect string interpolation
-        rule /(?:[IL])"/, Literal::String, :string
-        rule /[E]?"/, Literal::String, :string
+        rule %r/(?:[IL])"/, Literal::String, :string
+        rule %r/[E]?"/, Literal::String, :string
 
         # names
-        rule /@[\w.]+/, Name::Decorator
-        rule /(?:[a-zA-Z_\u00A1-\uffff]|[\u1000-\u10ff])(?:[a-zA-Z_0-9\u00A1-\uffff]|[\u1000-\u10ff])*!*/, Name
+        rule %r/@[\w.]+/, Name::Decorator
+        rule %r/(?:[a-zA-Z_\u00A1-\uffff]|[\u1000-\u10ff])(?:[a-zA-Z_0-9\u00A1-\uffff]|[\u1000-\u10ff])*!*/, Name
 
         rule PUNCTUATION, Other
 
         # numbers
-        rule /(\d+(_\d+)+\.\d*|\d*\.\d+(_\d+)+)([eEf][+-]?[0-9]+)?/, Literal::Number::Float
-        rule /(\d+\.\d*|\d*\.\d+)([eEf][+-]?[0-9]+)?/, Literal::Number::Float
-        rule /\d+(_\d+)+[eEf][+-]?[0-9]+/, Literal::Number::Float
-        rule /\d+[eEf][+-]?[0-9]+/, Literal::Number::Float
-        rule /0b[01]+(_[01]+)+/, Literal::Number::Bin
-        rule /0b[01]+/, Literal::Number::Bin
-        rule /0o[0-7]+(_[0-7]+)+/, Literal::Number::Oct
-        rule /0o[0-7]+/, Literal::Number::Oct
-        rule /0x[a-fA-F0-9]+(_[a-fA-F0-9]+)+/, Literal::Number::Hex
-        rule /0x[a-fA-F0-9]+/, Literal::Number::Hex
-        rule /\d+(_\d+)+/, Literal::Number::Integer
-        rule /\d+/, Literal::Number::Integer
+        rule %r/(\d+(_\d+)+\.\d*|\d*\.\d+(_\d+)+)([eEf][+-]?[0-9]+)?/, Literal::Number::Float
+        rule %r/(\d+\.\d*|\d*\.\d+)([eEf][+-]?[0-9]+)?/, Literal::Number::Float
+        rule %r/\d+(_\d+)+[eEf][+-]?[0-9]+/, Literal::Number::Float
+        rule %r/\d+[eEf][+-]?[0-9]+/, Literal::Number::Float
+        rule %r/0b[01]+(_[01]+)+/, Literal::Number::Bin
+        rule %r/0b[01]+/, Literal::Number::Bin
+        rule %r/0o[0-7]+(_[0-7]+)+/, Literal::Number::Oct
+        rule %r/0o[0-7]+/, Literal::Number::Oct
+        rule %r/0x[a-fA-F0-9]+(_[a-fA-F0-9]+)+/, Literal::Number::Hex
+        rule %r/0x[a-fA-F0-9]+/, Literal::Number::Hex
+        rule %r/\d+(_\d+)+/, Literal::Number::Integer
+        rule %r/\d+/, Literal::Number::Integer
       end
 
 
       state :funcname do
-        rule /[a-zA-Z_]\w*/, Name::Function, :pop!
-        rule /\([^\s\w{]{1,2}\)/, Operator, :pop!
-        rule /[^\s\w{]{1,2}/, Operator, :pop!
+        rule %r/[a-zA-Z_]\w*/, Name::Function, :pop!
+        rule %r/\([^\s\w{]{1,2}\)/, Operator, :pop!
+        rule %r/[^\s\w{]{1,2}/, Operator, :pop!
       end
 
       state :typename do
-        rule /[a-zA-Z_]\w*/, Name::Class, :pop!
+        rule %r/[a-zA-Z_]\w*/, Name::Class, :pop!
       end
 
       state :stringescape do
-        rule /\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})/,
+        rule %r/\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})/,
           Literal::String::Escape
       end
 
       state :blockcomment do
-        rule /[^=#]/, Comment::Multiline
-        rule /#=/, Comment::Multiline, :blockcomment
-        rule /\=#/, Comment::Multiline, :pop!
-        rule /[=#]/, Comment::Multiline
+        rule %r/[^=#]/, Comment::Multiline
+        rule %r/#=/, Comment::Multiline, :blockcomment
+        rule %r/\=#/, Comment::Multiline, :pop!
+        rule %r/[=#]/, Comment::Multiline
       end
 
       state :string do
         mixin :stringescape
 
-        rule /"/, Literal::String, :pop!
-        rule /\\\\|\\"|\\\n/, Literal::String::Escape  # included here for raw strings
-        rule /\$(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/, Literal::String::Interpol
-        rule /[^\\"$]+/, Literal::String
+        rule %r/"/, Literal::String, :pop!
+        rule %r/\\\\|\\"|\\\n/, Literal::String::Escape  # included here for raw strings
+        rule %r/\$(\(\w+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/, Literal::String::Interpol
+        rule %r/[^\\"$]+/, Literal::String
         # quotes, dollar signs, and backslashes must be parsed one at a time
-        rule /["\\]/, Literal::String
+        rule %r/["\\]/, Literal::String
         # unhandled string formatting sign
-        rule /\$/, Literal::String
+        rule %r/\$/, Literal::String
       end
     end
   end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -68,7 +68,7 @@ module Rouge
           push :property
         end
         rule %r/\bfun\b/, Keyword
-        rule /\b(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/\b(?:#{keywords.join('|')})\b/, Keyword
         rule %r'^\s*\[.*?\]', Name::Attribute
         rule %r'[^\S\n]+', Text
         rule %r'\\\n', Text # line continuation
@@ -85,12 +85,12 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
-        rule /@#{id}/, Name::Decorator
+        rule %r/@#{id}/, Name::Decorator
         rule id, Name
       end
 
       state :package do
-        rule /\S+/, Name::Namespace, :pop!
+        rule %r/\S+/, Name::Namespace, :pop!
       end
 
       state :class do

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -48,23 +48,23 @@ module Rouge
       id = /[a-z_][\w.]*/i
 
       state :root do
-        rule /^#![ \S]+lasso9\b/, Comment::Preproc, :lasso
+        rule %r/^#![ \S]+lasso9\b/, Comment::Preproc, :lasso
         rule(/(?=\[|<)/) { push :delimiters }
-        rule /\s+/, Text::Whitespace
+        rule %r/\s+/, Text::Whitespace
         rule(//) { push :delimiters; push :lassofile }
       end
 
       state :delimiters do
-        rule /\[no_square_brackets\]/, Comment::Preproc, :nosquarebrackets
-        rule /\[noprocess\]/, Comment::Preproc, :noprocess
-        rule /\[/, Comment::Preproc, :squarebrackets
-        rule /<\?(lasso(script)?|=)/i, Comment::Preproc, :anglebrackets
+        rule %r/\[no_square_brackets\]/, Comment::Preproc, :nosquarebrackets
+        rule %r/\[noprocess\]/, Comment::Preproc, :noprocess
+        rule %r/\[/, Comment::Preproc, :squarebrackets
+        rule %r/<\?(lasso(script)?|=)/i, Comment::Preproc, :anglebrackets
         rule(/([^\[<]|<!--.*?-->|<(script|style).*?\2>|<(?!\?(lasso(script)?|=)))+/im) { delegate parent }
       end
 
       state :nosquarebrackets do
-        rule /\[noprocess\]/, Comment::Preproc, :noprocess
-        rule /<\?(lasso(script)?|=)/i, Comment::Preproc, :anglebrackets
+        rule %r/\[noprocess\]/, Comment::Preproc, :noprocess
+        rule %r/<\?(lasso(script)?|=)/i, Comment::Preproc, :anglebrackets
         rule(/([^\[<]|<!--.*?-->|<(script|style).*?\2>|<(?!\?(lasso(script)?|=))|\[(?!noprocess))+/im) { delegate parent }
       end
 
@@ -74,22 +74,22 @@ module Rouge
       end
 
       state :squarebrackets do
-        rule /\]/, Comment::Preproc, :pop!
+        rule %r/\]/, Comment::Preproc, :pop!
         mixin :lasso
       end
 
       state :anglebrackets do
-        rule /\?>/, Comment::Preproc, :pop!
+        rule %r/\?>/, Comment::Preproc, :pop!
         mixin :lasso
       end
 
       state :lassofile do
-        rule /\]|\?>/, Comment::Preproc, :pop!
+        rule %r/\]|\?>/, Comment::Preproc, :pop!
         mixin :lasso
       end
 
       state :whitespacecomments do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?\n), Comment::Single
         rule %r(/\*\*!.*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline
@@ -99,43 +99,43 @@ module Rouge
         mixin :whitespacecomments
 
         # literals
-        rule /\d*\.\d+(e[+-]?\d+)?/i, Num::Float
-        rule /0x[\da-f]+/i, Num::Hex
-        rule /\d+/, Num::Integer
-        rule /(infinity|NaN)\b/i, Num
-        rule /'[^'\\]*(\\.[^'\\]*)*'/m, Str::Single
-        rule /"[^"\\]*(\\.[^"\\]*)*"/m, Str::Double
-        rule /`[^`]*`/m, Str::Backtick
+        rule %r/\d*\.\d+(e[+-]?\d+)?/i, Num::Float
+        rule %r/0x[\da-f]+/i, Num::Hex
+        rule %r/\d+/, Num::Integer
+        rule %r/(infinity|NaN)\b/i, Num
+        rule %r/'[^'\\]*(\\.[^'\\]*)*'/m, Str::Single
+        rule %r/"[^"\\]*(\\.[^"\\]*)*"/m, Str::Double
+        rule %r/`[^`]*`/m, Str::Backtick
 
         # names
-        rule /\$#{id}/, Name::Variable
-        rule /#(#{id}|\d+\b)/, Name::Variable::Instance
-        rule /(\.\s*)('#{id}')/ do
+        rule %r/\$#{id}/, Name::Variable
+        rule %r/#(#{id}|\d+\b)/, Name::Variable::Instance
+        rule %r/(\.\s*)('#{id}')/ do
           groups Name::Builtin::Pseudo, Name::Variable::Class
         end
-        rule /(self)(\s*->\s*)('#{id}')/i do
+        rule %r/(self)(\s*->\s*)('#{id}')/i do
           groups Name::Builtin::Pseudo, Operator, Name::Variable::Class
         end
-        rule /(\.\.?\s*)(#{id}(=(?!=))?)/ do
+        rule %r/(\.\.?\s*)(#{id}(=(?!=))?)/ do
           groups Name::Builtin::Pseudo, Name::Other
         end
-        rule /(->\\?\s*|&\s*)(#{id}(=(?!=))?)/ do
+        rule %r/(->\\?\s*|&\s*)(#{id}(=(?!=))?)/ do
           groups Operator, Name::Other
         end
-        rule /(?<!->)(self|inherited|currentcapture|givenblock)\b/i, Name::Builtin::Pseudo
-        rule /-(?!infinity)#{id}/i, Name::Attribute
-        rule /::\s*#{id}/, Name::Label
-        rule /error_((code|msg)_\w+|adderror|columnrestriction|databaseconnectionunavailable|databasetimeout|deleteerror|fieldrestriction|filenotfound|invaliddatabase|invalidpassword|invalidusername|modulenotfound|noerror|nopermission|outofmemory|reqcolumnmissing|reqfieldmissing|requiredcolumnmissing|requiredfieldmissing|updateerror)/i, Name::Exception
+        rule %r/(?<!->)(self|inherited|currentcapture|givenblock)\b/i, Name::Builtin::Pseudo
+        rule %r/-(?!infinity)#{id}/i, Name::Attribute
+        rule %r/::\s*#{id}/, Name::Label
+        rule %r/error_((code|msg)_\w+|adderror|columnrestriction|databaseconnectionunavailable|databasetimeout|deleteerror|fieldrestriction|filenotfound|invaliddatabase|invalidpassword|invalidusername|modulenotfound|noerror|nopermission|outofmemory|reqcolumnmissing|reqfieldmissing|requiredcolumnmissing|requiredfieldmissing|updateerror)/i, Name::Exception
 
         # definitions
-        rule /(define)(\s+)(#{id})(\s*=>\s*)(type|trait|thread)\b/i do
+        rule %r/(define)(\s+)(#{id})(\s*=>\s*)(type|trait|thread)\b/i do
           groups Keyword::Declaration, Text, Name::Class, Operator, Keyword
         end
         rule %r((define)(\s+)(#{id})(\s*->\s*)(#{id}=?|[-+*/%]))i do
           groups Keyword::Declaration, Text, Name::Class, Operator, Name::Function
           push :signature
         end
-        rule /(define)(\s+)(#{id})/i do
+        rule %r/(define)(\s+)(#{id})/i do
           groups Keyword::Declaration, Text, Name::Function
           push :signature
         end
@@ -143,25 +143,25 @@ module Rouge
           groups Keyword, Text, Name::Function
           push :signature
         end
-        rule /(public|protected|private|provide)(\s+)(#{id})/i do
+        rule %r/(public|protected|private|provide)(\s+)(#{id})/i do
           groups Keyword, Text, Name::Function
         end
 
         # keywords
-        rule /(true|false|none|minimal|full|all|void)\b/i, Keyword::Constant
-        rule /(local|var|variable|global|data(?=\s))\b/i, Keyword::Declaration
-        rule /(array|date|decimal|duration|integer|map|pair|string|tag|xml|null|boolean|bytes|keyword|list|locale|queue|set|stack|staticarray)\b/i, Keyword::Type
-        rule /(#{id})(\s+)(in)\b/i do
+        rule %r/(true|false|none|minimal|full|all|void)\b/i, Keyword::Constant
+        rule %r/(local|var|variable|global|data(?=\s))\b/i, Keyword::Declaration
+        rule %r/(array|date|decimal|duration|integer|map|pair|string|tag|xml|null|boolean|bytes|keyword|list|locale|queue|set|stack|staticarray)\b/i, Keyword::Type
+        rule %r/(#{id})(\s+)(in)\b/i do
           groups Name, Text, Keyword
         end
-        rule /(let|into)(\s+)(#{id})/i do
+        rule %r/(let|into)(\s+)(#{id})/i do
           groups Keyword, Text, Name
         end
 
         # other
-        rule /,/, Punctuation, :commamember
-        rule /(and|or|not)\b/i, Operator::Word
-        rule /(#{id})(\s*::\s*#{id})?(\s*=(?!=|>))/ do
+        rule %r/,/, Punctuation, :commamember
+        rule %r/(and|or|not)\b/i, Operator::Word
+        rule %r/(#{id})(\s*::\s*#{id})?(\s*=(?!=|>))/ do
           groups Name, Name::Label, Operator
         end
 
@@ -183,31 +183,31 @@ module Rouge
           end
         end
 
-        rule /(=)(n?bw|n?ew|n?cn|lte?|gte?|n?eq|n?rx|ft)\b/i do
+        rule %r/(=)(n?bw|n?ew|n?cn|lte?|gte?|n?eq|n?rx|ft)\b/i do
           groups Operator, Operator::Word
         end
         rule %r(:=|[-+*/%=<>&|!?\\]+), Operator
-        rule /[{}():;,@^]/, Punctuation
+        rule %r/[{}():;,@^]/, Punctuation
       end
 
       state :signature do
-        rule /\=>/, Operator, :pop!
-        rule /\)/, Punctuation, :pop!
-        rule /[(,]/, Punctuation, :parameter
+        rule %r/\=>/, Operator, :pop!
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/[(,]/, Punctuation, :parameter
         mixin :lasso
       end
 
       state :parameter do
-        rule /\)/, Punctuation, :pop!
-        rule /-?#{id}/, Name::Attribute, :pop!
-        rule /\.\.\./, Name::Builtin::Pseudo
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/-?#{id}/, Name::Attribute, :pop!
+        rule %r/\.\.\./, Name::Builtin::Pseudo
         mixin :lasso
       end
 
       state :commamember do
         rule %r((#{id}=?|[-+*/%])(?=\s*(\(([^()]*\([^()]*\))*[^\)]*\)\s*)?(::[\w.\s]+)?=>)), Name::Function, :signature
         mixin :whitespacecomments
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
     end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -10,67 +10,67 @@ module Rouge
       filenames '*.liquid'
 
       state :root do
-        rule /[^\{]+/, Text
+        rule %r/[^\{]+/, Text
 
-        rule /(\{%)(\s*)/ do
+        rule %r/(\{%)(\s*)/ do
           groups Punctuation, Text::Whitespace
           push :tag_or_block
         end
 
-        rule /(\{\{)(\s*)/ do
+        rule %r/(\{\{)(\s*)/ do
           groups Punctuation, Text::Whitespace
           push :output
         end
 
-        rule /\{/, Text
+        rule %r/\{/, Text
       end
 
       state :tag_or_block do
         # builtin logic blocks
-        rule /(if|unless|elsif|case)(?=\s+)/, Keyword::Reserved, :condition
+        rule %r/(if|unless|elsif|case)(?=\s+)/, Keyword::Reserved, :condition
 
-        rule /(when)(\s+)/ do
+        rule %r/(when)(\s+)/ do
           groups Keyword::Reserved, Text::Whitespace
           push :when
         end
 
-        rule /(else)(\s*)(%\})/ do
+        rule %r/(else)(\s*)(%\})/ do
           groups Keyword::Reserved, Text::Whitespace, Punctuation
           pop!
         end
 
         # other builtin blocks
-        rule /(capture)(\s+)([^\s%]+)(\s*)(%\})/ do
+        rule %r/(capture)(\s+)([^\s%]+)(\s*)(%\})/ do
           groups Name::Tag, Text::Whitespace, Name::Attribute, Text::Whitespace, Punctuation
           pop!
         end
 
-        rule /(comment)(\s*)(%\})/ do
+        rule %r/(comment)(\s*)(%\})/ do
           groups Name::Tag, Text::Whitespace, Punctuation
           push :comment
         end
 
-        rule /(raw)(\s*)(%\})/ do
+        rule %r/(raw)(\s*)(%\})/ do
           groups Name::Tag, Text::Whitespace, Punctuation
           push :raw
         end
 
-        rule /assign/, Name::Tag, :assign
-        rule /include/, Name::Tag, :include
+        rule %r/assign/, Name::Tag, :assign
+        rule %r/include/, Name::Tag, :include
 
         # end of block
-        rule /(end(case|unless|if))(\s*)(%\})/ do
+        rule %r/(end(case|unless|if))(\s*)(%\})/ do
           groups Keyword::Reserved, nil, Text::Whitespace, Punctuation
           pop!
         end
 
-        rule /(end([^\s%]+))(\s*)(%\})/ do
+        rule %r/(end([^\s%]+))(\s*)(%\})/ do
           groups Name::Tag, nil, Text::Whitespace, Punctuation
           pop!
         end
 
         # builtin tags
-        rule /(cycle)(\s+)(([^\s:]*)(:))?(\s*)/ do |m|
+        rule %r/(cycle)(\s+)(([^\s:]*)(:))?(\s*)/ do |m|
           token Name::Tag, m[1]
           token Text::Whitespace, m[2]
 
@@ -89,7 +89,7 @@ module Rouge
         end
 
         # other tags or blocks
-        rule /([^\s%]+)(\s*)/ do
+        rule %r/([^\s%]+)(\s*)/ do
           groups Name::Tag, Text::Whitespace
           push :tag_markup
         end
@@ -99,8 +99,8 @@ module Rouge
         mixin :whitespace
         mixin :generic
 
-        rule /\}\}/, Punctuation, :pop!
-        rule /\|/, Punctuation, :filters
+        rule %r/\}\}/, Punctuation, :pop!
+        rule %r/\|/, Punctuation, :filters
       end
 
       state :filters do
@@ -108,14 +108,14 @@ module Rouge
 
         rule(/\}\}/) { token Punctuation; reset_stack }
 
-        rule /([^\s\|:]+)(:?)(\s*)/ do
+        rule %r/([^\s\|:]+)(:?)(\s*)/ do
           groups Name::Function, Punctuation, Text::Whitespace
           push :filter_markup
         end
       end
 
       state :filter_markup do
-        rule /\|/, Punctuation, :pop!
+        rule %r/\|/, Punctuation, :pop!
 
         mixin :end_of_tag
         mixin :end_of_block
@@ -126,13 +126,13 @@ module Rouge
         mixin :end_of_block
         mixin :whitespace
 
-        rule /([=!><]=?)/, Operator
+        rule %r/([=!><]=?)/, Operator
 
-        rule /\b((!)|(not\b))/ do
+        rule %r/\b((!)|(not\b))/ do
           groups nil, Operator, Operator::Word
         end
 
-        rule /(contains)/, Operator::Word
+        rule %r/(contains)/, Operator::Word
 
         mixin :generic
         mixin :whitespace
@@ -145,12 +145,12 @@ module Rouge
       end
 
       state :operator do
-        rule /(\s*)((=|!|>|<)=?)(\s*)/ do
+        rule %r/(\s*)((=|!|>|<)=?)(\s*)/ do
           groups Text::Whitespace, Operator, nil, Text::Whitespace
           pop!
         end
 
-        rule /(\s*)(\bcontains\b)(\s*)/ do
+        rule %r/(\s*)(\bcontains\b)(\s*)/ do
           groups Text::Whitespace, Operator::Word, Text::Whitespace
           pop!
         end
@@ -169,29 +169,29 @@ module Rouge
         mixin :whitespace
         mixin :string
 
-        rule /([^\s=:]+)(\s*)(=|:)/ do
+        rule %r/([^\s=:]+)(\s*)(=|:)/ do
           groups Name::Attribute, Text::Whitespace, Operator
         end
 
-        rule /(\{\{)(\s*)([^\s\}])(\s*)(\}\})/ do
+        rule %r/(\{\{)(\s*)([^\s\}])(\s*)(\}\})/ do
           groups Punctuation, Text::Whitespace, nil, Text::Whitespace, Punctuation
         end
 
         mixin :number
         mixin :keyword
 
-        rule /,/, Punctuation
+        rule %r/,/, Punctuation
       end
 
       state :default_param_markup do
         mixin :param_markup
-        rule /./, Text
+        rule %r/./, Text
       end
 
       state :variable_param_markup do
         mixin :param_markup
         mixin :variable
-        rule /./, Text
+        rule %r/./, Text
       end
 
       state :tag_markup do
@@ -206,27 +206,27 @@ module Rouge
 
       # states for different values types
       state :keyword do
-        rule /\b(false|true)\b/, Keyword::Constant
+        rule %r/\b(false|true)\b/, Keyword::Constant
       end
 
       state :variable do
-        rule /\.(?=\w)/, Punctuation
-        rule /[a-zA-Z_]\w*\??/, Name::Variable
+        rule %r/\.(?=\w)/, Punctuation
+        rule %r/[a-zA-Z_]\w*\??/, Name::Variable
       end
 
       state :string do
-        rule /'[^']*'/, Str::Single
-        rule /"[^"]*"/, Str::Double
+        rule %r/'[^']*'/, Str::Single
+        rule %r/"[^"]*"/, Str::Double
       end
 
       state :number do
-        rule /\d+\.\d+/, Num::Float
-        rule /\d+/, Num::Integer
+        rule %r/\d+\.\d+/, Num::Float
+        rule %r/\d+/, Num::Integer
       end
 
       state :array_index do
-        rule /\[/, Punctuation
-        rule /\]/, Punctuation
+        rule %r/\[/, Punctuation
+        rule %r/\]/, Punctuation
       end
 
       state :generic do
@@ -238,38 +238,38 @@ module Rouge
       end
 
       state :whitespace do
-        rule /[ \t]+/, Text::Whitespace
+        rule %r/[ \t]+/, Text::Whitespace
       end
 
       state :comment do
-        rule /(\{%)(\s*)(endcomment)(\s*)(%\})/ do
+        rule %r/(\{%)(\s*)(endcomment)(\s*)(%\})/ do
           groups Punctuation, Text::Whitespace, Name::Tag, Text::Whitespace, Punctuation
           reset_stack
         end
 
-        rule /./, Comment
+        rule %r/./, Comment
       end
 
       state :raw do
-        rule /[^\{]+/, Text
+        rule %r/[^\{]+/, Text
 
-        rule /(\{%)(\s*)(endraw)(\s*)(%\})/ do
+        rule %r/(\{%)(\s*)(endraw)(\s*)(%\})/ do
           groups Punctuation, Text::Whitespace, Name::Tag, Text::Whitespace, Punctuation
           reset_stack
         end
 
-        rule /\{/, Text
+        rule %r/\{/, Text
       end
 
       state :assign do
         mixin :whitespace
         mixin :end_of_block
 
-        rule /(\s*)(=)(\s*)/ do
+        rule %r/(\s*)(=)(\s*)/ do
           groups Text::Whitespace, Operator, Text::Whitespace
         end
 
-        rule /\|/, Punctuation, :filters
+        rule %r/\|/, Punctuation, :filters
 
         mixin :generic
       end
@@ -277,7 +277,7 @@ module Rouge
       state :include do
         mixin :whitespace
 
-        rule /([^\.]+)(\.)(html|liquid)/ do
+        rule %r/([^\.]+)(\.)(html|liquid)/ do
           groups Name::Attribute, Punctuation, Name::Attribute
         end
 

--- a/lib/rouge/lexers/literate_coffeescript.rb
+++ b/lib/rouge/lexers/literate_coffeescript.rb
@@ -21,11 +21,11 @@ module Rouge
       start { markdown.reset!; coffee.reset! }
 
       state :root do
-        rule /^(    .*?\n)+/m do
+        rule %r/^(    .*?\n)+/m do
           delegate coffee
         end
 
-        rule /^([ ]{0,3}(\S.*?|)\n)*/m do
+        rule %r/^([ ]{0,3}(\S.*?|)\n)*/m do
           delegate markdown
         end
       end

--- a/lib/rouge/lexers/literate_haskell.rb
+++ b/lib/rouge/lexers/literate_haskell.rb
@@ -19,18 +19,18 @@ module Rouge
 
       # TODO: support TeX versions as well.
       state :root do
-        rule /\s*?\n(?=>)/, Text, :code
-        rule /.*?\n/, Text
-        rule /.+\z/, Text
+        rule %r/\s*?\n(?=>)/, Text, :code
+        rule %r/.*?\n/, Text
+        rule %r/.+\z/, Text
       end
 
       state :code do
-        rule /(>)( .*?(\n|\z))/ do |m|
+        rule %r/(>)( .*?(\n|\z))/ do |m|
           token Name::Label, m[1]
           delegate haskell, m[2]
         end
 
-        rule /\s*\n(?=\s*[^>])/, Text, :pop!
+        rule %r/\s*\n(?=\s*[^>])/, Text, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/llvm.rb
+++ b/lib/rouge/lexers/llvm.rb
@@ -15,21 +15,21 @@ module Rouge
       identifier = /([-a-zA-Z$._][-a-zA-Z$._0-9]*|#{string})/
 
       state :basic do
-        rule /;.*?$/, Comment::Single
-        rule /\s+/, Text
+        rule %r/;.*?$/, Comment::Single
+        rule %r/\s+/, Text
 
-        rule /#{identifier}\s*:/, Name::Label
+        rule %r/#{identifier}\s*:/, Name::Label
 
-        rule /@(#{identifier}|\d+)/, Name::Variable::Global
-        rule /(%|!)#{identifier}/, Name::Variable
-        rule /(%|!)\d+/, Name::Variable
+        rule %r/@(#{identifier}|\d+)/, Name::Variable::Global
+        rule %r/(%|!)#{identifier}/, Name::Variable
+        rule %r/(%|!)\d+/, Name::Variable
 
-        rule /c?#{string}/, Str
+        rule %r/c?#{string}/, Str
 
-        rule /0[xX][a-fA-F0-9]+/, Num
-        rule /-?\d+(?:[.]\d+)?(?:[eE][-+]?\d+(?:[.]\d+)?)?/, Num
+        rule %r/0[xX][a-fA-F0-9]+/, Num
+        rule %r/-?\d+(?:[.]\d+)?(?:[eE][-+]?\d+(?:[.]\d+)?)?/, Num
 
-        rule /[=<>{}\[\]()*.,!]|x/, Punctuation
+        rule %r/[=<>{}\[\]()*.,!]|x/, Punctuation
       end
 
       builtin_types = %w(
@@ -37,8 +37,8 @@ module Rouge
       )
 
       state :types do
-        rule /i[1-9]\d*/, Keyword::Type
-        rule /#{builtin_types.join('|')}/, Keyword::Type
+        rule %r/i[1-9]\d*/, Keyword::Type
+        rule %r/#{builtin_types.join('|')}/, Keyword::Type
       end
 
       builtin_keywords = %w(
@@ -67,8 +67,8 @@ module Rouge
       )
 
       state :keywords do
-        rule /#{builtin_instructions.join('|')}/, Keyword
-        rule /#{builtin_keywords.join('|')}/, Keyword
+        rule %r/#{builtin_instructions.join('|')}/, Keyword
+        rule %r/#{builtin_keywords.join('|')}/, Keyword
       end
 
       state :root do

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -43,7 +43,7 @@ module Rouge
       state :root do
         # lua allows a file to start with a shebang
         rule %r(#!(.*?)$), Comment::Preproc
-        rule //, Text, :base
+        rule %r//, Text, :base
       end
 
       state :base do
@@ -89,7 +89,7 @@ module Rouge
       end
 
       state :function_name do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r((?:([A-Za-z_][A-Za-z0-9_]*)(\.))?([A-Za-z_][A-Za-z0-9_]*)) do
           groups Name::Class, Punctuation, Name::Function
           pop!

--- a/lib/rouge/lexers/m68k.rb
+++ b/lib/rouge/lexers/m68k.rb
@@ -83,11 +83,11 @@ module Rouge
       end
 
       state :inline_whitespace do
-        rule /[\s\t\r]+/, Text
+        rule %r/[\s\t\r]+/, Text
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         rule %r(^\*(\\.|.)*?\n), Comment::Single, :expr_bol
         rule %r(;(\\.|.)*?\n), Comment::Single, :expr_bol
         mixin :inline_whitespace
@@ -99,19 +99,19 @@ module Rouge
 
       state :statements do
         mixin :whitespace
-        rule /"/, Str, :string
-        rule /#/, Name::Decorator
-        rule /^\.?[a-zA-Z0-9_]+:?/, Name::Label
-        rule /\.[bswl]\s/i, Name::Decorator
+        rule %r/"/, Str, :string
+        rule %r/#/, Name::Decorator
+        rule %r/^\.?[a-zA-Z0-9_]+:?/, Name::Label
+        rule %r/\.[bswl]\s/i, Name::Decorator
         rule %r('(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
-        rule /\$[0-9a-f]+/i, Num::Hex
-        rule /@[0-8]+/i, Num::Oct
-        rule /%[01]+/i, Num::Bin
-        rule /\d+/i, Num::Integer
+        rule %r/\$[0-9a-f]+/i, Num::Hex
+        rule %r/@[0-8]+/i, Num::Oct
+        rule %r/%[01]+/i, Num::Bin
+        rule %r/\d+/i, Num::Integer
         rule %r([*~&+=\|?:<>/-]), Operator
-        rule /\\./, Comment::Preproc
-        rule /[(),.]/, Punctuation
-        rule /\[[a-zA-Z0-9]*\]/, Punctuation
+        rule %r/\\./, Comment::Preproc
+        rule %r/[(),.]/, Punctuation
+        rule %r/\[[a-zA-Z0-9]*\]/, Punctuation
 
         rule id do |m|
           name = m[0]
@@ -133,11 +133,11 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\\n/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/"/, Str, :pop!
+        rule %r/\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\\n/, Str
+        rule %r/\\/, Str # stray backslash
       end
     end
   end

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -86,15 +86,15 @@ module Rouge
       end
 
       state :root do
-        rule /##(.*)?/, Comment::Doc
-        rule /#(.*)?/, Comment::Single
+        rule %r/##(.*)?/, Comment::Doc
+        rule %r/#(.*)?/, Comment::Single
 
-        rule /(_method)(\s+)/ do
+        rule %r/(_method)(\s+)/ do
           groups Keyword, Text::Whitespace
           push :method_name
         end
 
-        rule /(?:#{Magik.keywords.join('|')})\b/, Keyword
+        rule %r/(?:#{Magik.keywords.join('|')})\b/, Keyword
 
         rule Magik.string_double, Literal::String
         rule Magik.string_single, Literal::String
@@ -106,17 +106,17 @@ module Rouge
         rule Magik.package_identifier, Name
         rule Magik.identifier, Name
 
-        rule /[\[\]{}()\.,;]/, Punctuation
-        rule /\$/, Punctuation
-        rule /(<<|^<<)/, Operator
-        rule /(>>)/, Operator
-        rule /[-~+\/*%=&^<>]|!=/, Operator
+        rule %r/[\[\]{}()\.,;]/, Punctuation
+        rule %r/\$/, Punctuation
+        rule %r/(<<|^<<)/, Operator
+        rule %r/(>>)/, Operator
+        rule %r/[-~+\/*%=&^<>]|!=/, Operator
 
-        rule /[\s]+/, Text::Whitespace
+        rule %r/[\s]+/, Text::Whitespace
       end
 
       state :method_name do
-        rule /(#{Magik.identifier})(\.)(#{Magik.identifier})/ do
+        rule %r/(#{Magik.identifier})(\.)(#{Magik.identifier})/ do
           groups Name::Class, Punctuation, Name::Function
           pop!
         end

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -29,53 +29,53 @@ module Rouge
       start { @shell.reset! }
 
       state :root do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /#.*?\n/, Comment
+        rule %r/#.*?\n/, Comment
 
-        rule /(export)(\s+)(?=[a-zA-Z0-9_\${}\t -]+\n)/ do
+        rule %r/(export)(\s+)(?=[a-zA-Z0-9_\${}\t -]+\n)/ do
           groups Keyword, Text
           push :export
         end
 
-        rule /export\s+/, Keyword
+        rule %r/export\s+/, Keyword
 
         # assignment
-        rule /([a-zA-Z0-9_${}.-]+)(\s*)([!?:+]?=)/m do |m|
+        rule %r/([a-zA-Z0-9_${}.-]+)(\s*)([!?:+]?=)/m do |m|
           token Name::Variable, m[1]
           token Text, m[2]
           token Operator, m[3]
           push :shell_line
         end
 
-        rule /"(\\\\|\\.|[^"\\])*"/, Str::Double
-        rule /'(\\\\|\\.|[^'\\])*'/, Str::Single
-        rule /([^\n:]+)(:+)([ \t]*)/ do
+        rule %r/"(\\\\|\\.|[^"\\])*"/, Str::Double
+        rule %r/'(\\\\|\\.|[^'\\])*'/, Str::Single
+        rule %r/([^\n:]+)(:+)([ \t]*)/ do
           groups Name::Label, Operator, Text
           push :block_header
         end
       end
 
       state :export do
-        rule /[\w\${}-]/, Name::Variable
-        rule /\n/, Text, :pop!
-        rule /\s+/, Text
+        rule %r/[\w\${}-]/, Name::Variable
+        rule %r/\n/, Text, :pop!
+        rule %r/\s+/, Text
       end
 
       state :block_header do
-        rule /[^,\\\n#]+/, Name::Function
-        rule /,/, Punctuation
-        rule /#.*?/, Comment
-        rule /\\\n/, Text
-        rule /\\./, Text
-        rule /\n/ do
+        rule %r/[^,\\\n#]+/, Name::Function
+        rule %r/,/, Punctuation
+        rule %r/#.*?/, Comment
+        rule %r/\\\n/, Text
+        rule %r/\\./, Text
+        rule %r/\n/ do
           token Text
           goto :block_body
         end
       end
 
       state :block_body do
-        rule /(\t[\t ]*)([@-]?)/ do |m|
+        rule %r/(\t[\t ]*)([@-]?)/ do |m|
           groups Text, Punctuation
           push :shell_line
         end
@@ -85,9 +85,9 @@ module Rouge
 
       state :shell do
         # macro interpolation
-        rule /\$\(\s*[a-z_]\w*\s*\)/i, Name::Variable
+        rule %r/\$\(\s*[a-z_]\w*\s*\)/i, Name::Variable
         # $(shell ...)
-        rule /(\$\()(\s*)(shell)(\s+)/m do
+        rule %r/(\$\()(\s*)(shell)(\s+)/m do
           groups Name::Function, Text, Name::Builtin, Text
           push :shell_expr
         end
@@ -100,12 +100,12 @@ module Rouge
 
       state :shell_expr do
         rule(/\(/) { delegate @shell; push }
-        rule /\)/, Name::Variable, :pop!
+        rule %r/\)/, Name::Variable, :pop!
         mixin :shell
       end
 
       state :shell_line do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         mixin :shell
       end
     end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -24,15 +24,15 @@ module Rouge
         # YAML frontmatter
         rule(/\A(---\s*\n.*?\n?)^(---\s*$\n?)/m) { delegate YAML }
 
-        rule /\\./, Str::Escape
+        rule %r/\\./, Str::Escape
 
-        rule /^[\S ]+\n(?:---*)\n/, Generic::Heading
-        rule /^[\S ]+\n(?:===*)\n/, Generic::Subheading
+        rule %r/^[\S ]+\n(?:---*)\n/, Generic::Heading
+        rule %r/^[\S ]+\n(?:===*)\n/, Generic::Subheading
 
-        rule /^#(?=[^#]).*?$/, Generic::Heading
-        rule /^##*.*?$/, Generic::Subheading
+        rule %r/^#(?=[^#]).*?$/, Generic::Heading
+        rule %r/^##*.*?$/, Generic::Subheading
 
-        rule /^([ \t]*)(```|~~~)([^\n]*\n)((.*?)(\2))?/m do |m|
+        rule %r/^([ \t]*)(```|~~~)([^\n]*\n)((.*?)(\2))?/m do |m|
           name = m[3].strip
           sublexer = Lexer.find_fancy(name.empty? ? "guess" : name, m[5], @options)
           sublexer ||= PlainText.new(@options.merge(:token => Str::Backtick))
@@ -49,36 +49,36 @@ module Rouge
             token Punctuation, m[6]
           else
             push do
-              rule /^([ \t]*)(#{m[2]})/ do |mb|
+              rule %r/^([ \t]*)(#{m[2]})/ do |mb|
                 pop!
                 token Text, mb[1]
                 token Punctuation, mb[2]
               end
-              rule /^.*\n/ do |mb|
+              rule %r/^.*\n/ do |mb|
                 delegate sublexer, mb[1]
               end
             end
           end
         end
 
-        rule /\n\n((    |\t).*?\n|\n)+/, Str::Backtick
+        rule %r/\n\n((    |\t).*?\n|\n)+/, Str::Backtick
 
-        rule /(`+)(?:#{edot}|\n)+?\1/, Str::Backtick
+        rule %r/(`+)(?:#{edot}|\n)+?\1/, Str::Backtick
 
         # various uses of * are in order of precedence
 
         # line breaks
-        rule /^(\s*[*]){3,}\s*$/, Punctuation
-        rule /^(\s*[-]){3,}\s*$/, Punctuation
+        rule %r/^(\s*[*]){3,}\s*$/, Punctuation
+        rule %r/^(\s*[-]){3,}\s*$/, Punctuation
 
         # bulleted lists
-        rule /^\s*[*+-](?=\s)/, Punctuation
+        rule %r/^\s*[*+-](?=\s)/, Punctuation
 
         # numbered lists
-        rule /^\s*\d+\./, Punctuation
+        rule %r/^\s*\d+\./, Punctuation
 
         # blockquotes
-        rule /^\s*>.*?$/, Generic::Traceback
+        rule %r/^\s*>.*?$/, Generic::Traceback
 
         # link references
         # [foo]: bar "baz"
@@ -94,77 +94,77 @@ module Rouge
         end
 
         # links and images
-        rule /(!?\[)(#{edot}*?)(\])/ do
+        rule %r/(!?\[)(#{edot}*?)(\])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end
 
-        rule /[*][*]#{edot}*?[*][*]/, Generic::Strong
-        rule /__#{edot}*?__/, Generic::Strong
+        rule %r/[*][*]#{edot}*?[*][*]/, Generic::Strong
+        rule %r/__#{edot}*?__/, Generic::Strong
 
-        rule /[*]#{edot}*?[*]/, Generic::Emph
-        rule /_#{edot}*?_/, Generic::Emph
+        rule %r/[*]#{edot}*?[*]/, Generic::Emph
+        rule %r/_#{edot}*?_/, Generic::Emph
 
         # Automatic links
-        rule /<.*?@.+[.].+>/, Name::Variable
+        rule %r/<.*?@.+[.].+>/, Name::Variable
         rule %r[<(https?|mailto|ftp)://#{edot}*?>], Name::Variable
 
 
-        rule /[^\\`\[*\n&<]+/, Text
+        rule %r/[^\\`\[*\n&<]+/, Text
 
         # inline html
         rule(/&\S*;/) { delegate html }
         rule(/<#{edot}*?>/) { delegate html }
-        rule /[&<]/, Text
+        rule %r/[&<]/, Text
 
-        rule /\n/, Text
+        rule %r/\n/, Text
       end
 
       state :link do
-        rule /(\[)(#{edot}*?)(\])/ do
+        rule %r/(\[)(#{edot}*?)(\])/ do
           groups Punctuation, Str::Symbol, Punctuation
           pop!
         end
 
-        rule /[(]/ do
+        rule %r/[(]/ do
           token Punctuation
           push :inline_title
           push :inline_url
         end
 
-        rule /[ \t]+/, Text
+        rule %r/[ \t]+/, Text
 
         rule(//) { pop! }
       end
 
       state :url do
-        rule /[ \t]+/, Text
+        rule %r/[ \t]+/, Text
 
         # the url
-        rule /(<)(#{edot}*?)(>)/ do
+        rule %r/(<)(#{edot}*?)(>)/ do
           groups Name::Tag, Str::Other, Name::Tag
           pop!
         end
 
-        rule /\S+/, Str::Other, :pop!
+        rule %r/\S+/, Str::Other, :pop!
       end
 
       state :title do
-        rule /"#{edot}*?"/, Name::Namespace
-        rule /'#{edot}*?'/, Name::Namespace
-        rule /[(]#{edot}*?[)]/, Name::Namespace
-        rule /\s*(?=["'()])/, Text
+        rule %r/"#{edot}*?"/, Name::Namespace
+        rule %r/'#{edot}*?'/, Name::Namespace
+        rule %r/[(]#{edot}*?[)]/, Name::Namespace
+        rule %r/\s*(?=["'()])/, Text
         rule(//) { pop! }
       end
 
       state :inline_title do
-        rule /[)]/, Punctuation, :pop!
+        rule %r/[)]/, Punctuation, :pop!
         mixin :title
       end
 
       state :inline_url do
-        rule /[^<\s)]+/, Str::Other, :pop!
-        rule /\s+/m, Text
+        rule %r/[^<\s)]+/, Str::Other, :pop!
+        rule %r/\s+/m, Text
         mixin :url
       end
     end

--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -61,13 +61,13 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/, Text::Whitespace
-        rule /\(\*/, Comment, :comment
-        rule /#{base}\^\^#{number_base}#{precision}?(\*\^[+-]?\d+)?/, Num # a number with a base
-        rule /(?:#{number}#{precision}?(?:\*\^[+-]?\d+)?)/, Num # all other numbers
+        rule %r/\s+/, Text::Whitespace
+        rule %r/\(\*/, Comment, :comment
+        rule %r/#{base}\^\^#{number_base}#{precision}?(\*\^[+-]?\d+)?/, Num # a number with a base
+        rule %r/(?:#{number}#{precision}?(?:\*\^[+-]?\d+)?)/, Num # all other numbers
         rule message, Name::Tag
         rule in_out, Generic::Prompt
-        rule /#{context_symbol}/m do |m|
+        rule %r/#{context_symbol}/m do |m|
           match = m[0]
           if self.class.keywords.include? match
             token Name::Builtin::Pseudo
@@ -85,11 +85,11 @@ module Rouge
 
       # Allow for nested comments and special treatment of ::Section:: or :Author: markup
       state :comment do
-        rule /\(\*/, Comment, :comment
-        rule /\*\)/, Comment, :pop!
-        rule /::#{identifier}::/, Comment::Preproc
-        rule /[ ]:(#{identifier}|[^\S])+:[ ]/, Comment::Preproc
-        rule /./, Comment
+        rule %r/\(\*/, Comment, :comment
+        rule %r/\*\)/, Comment, :pop!
+        rule %r/::#{identifier}::/, Comment::Preproc
+        rule %r/[ ]:(#{identifier}|[^\S])+:[ ]/, Comment::Preproc
+        rule %r/./, Comment
       end
     end
   end

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -24,20 +24,20 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text # Whitespace
+        rule %r/\s+/m, Text # Whitespace
         rule %r([{]%.*?%[}])m, Comment::Multiline
-        rule /%.*$/, Comment::Single
-        rule /([.][.][.])(.*?)$/ do
+        rule %r/%.*$/, Comment::Single
+        rule %r/([.][.][.])(.*?)$/ do
           groups(Keyword, Comment)
         end
 
-        rule /^(!)(.*?)(?=%|$)/ do |m|
+        rule %r/^(!)(.*?)(?=%|$)/ do |m|
           token Keyword, m[1]
           delegate Shell, m[2]
         end
 
 
-        rule /[a-zA-Z][_a-zA-Z0-9]*/m do |m|
+        rule %r/[a-zA-Z][_a-zA-Z0-9]*/m do |m|
           match = m[0]
           if self.class.keywords.include? match
             token Keyword
@@ -50,29 +50,29 @@ module Rouge
 
         rule %r{[(){};:,\/\\\]\[]}, Punctuation
 
-        rule /~=|==|<<|>>|[-~+\/*%=<>&^|.@]/, Operator
+        rule %r/~=|==|<<|>>|[-~+\/*%=<>&^|.@]/, Operator
 
 
-        rule /(\d+\.\d*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
-        rule /\d+e[+-]?[0-9]+/i, Num::Float
-        rule /\d+L/, Num::Integer::Long
-        rule /\d+/, Num::Integer
+        rule %r/(\d+\.\d*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
+        rule %r/\d+e[+-]?[0-9]+/i, Num::Float
+        rule %r/\d+L/, Num::Integer::Long
+        rule %r/\d+/, Num::Integer
 
-        rule /'(?=(.*'))/, Str::Single, :chararray
-        rule /"(?=(.*"))/, Str::Double, :string
-        rule /'/, Operator
+        rule %r/'(?=(.*'))/, Str::Single, :chararray
+        rule %r/"(?=(.*"))/, Str::Double, :string
+        rule %r/'/, Operator
       end
 
       state :chararray do
-        rule /[^']+/, Str::Single
-        rule /''/, Str::Escape
-        rule /'/, Str::Single, :pop!
+        rule %r/[^']+/, Str::Single
+        rule %r/''/, Str::Escape
+        rule %r/'/, Str::Single, :pop!
       end
 
       state :string do
-        rule /[^"]+/, Str::Double
-        rule /""/, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/[^"]+/, Str::Double
+        rule %r/""/, Str::Escape
+        rule %r/"/, Str::Double, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/moonscript.rb
+++ b/lib/rouge/lexers/moonscript.rb
@@ -40,7 +40,7 @@ module Rouge
 
       state :root do
         rule %r(#!(.*?)$), Comment::Preproc # shebang
-        rule //, Text, :main
+        rule %r//, Text, :main
       end
 
       state :base do

--- a/lib/rouge/lexers/mosel.rb
+++ b/lib/rouge/lexers/mosel.rb
@@ -166,7 +166,7 @@ module Rouge
 
       state :whitespace do
         # Spaces
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         # ! Comments
         rule %r((!).*$\n?), Comment::Single
         # (! Comments !)
@@ -182,14 +182,14 @@ module Rouge
       # The escape sequences are not interpreted if they are contained in strings that are enclosed in single quotes.
 
       state :single_quotes do
-        rule /'/, Str::Single, :pop!
-        rule /[^']+/, Str::Single
+        rule %r/'/, Str::Single, :pop!
+        rule %r/[^']+/, Str::Single
       end
 
       state :double_quotes do
-        rule /"/, Str::Double, :pop!
-        rule /(\\"|\\[0-7]{1,3}\D|\\[abfnrtv]|\\\\)/, Str::Escape
-        rule /[^"]/, Str::Double
+        rule %r/"/, Str::Double, :pop!
+        rule %r/(\\"|\\[0-7]{1,3}\D|\\[abfnrtv]|\\\\)/, Str::Escape
+        rule %r/[^"]/, Str::Double
       end
 
       state :base do
@@ -200,25 +200,25 @@ module Rouge
         rule %r{((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?}, Num
         rule %r{[~!@#\$%\^&\*\(\)\+`\-={}\[\]:;<>\?,\.\/\|\\]}, Punctuation
 #        rule %r{'([^']|'')*'}, Str
-#        rule /"(\\\\|\\"|[^"])*"/, Str
+#        rule %r/"(\\\\|\\"|[^"])*"/, Str
         
 
 
-        rule /(true|false)\b/i, Name::Builtin
-        rule /\b(#{core_keywords.join('|')})\b/i, Keyword
-        rule /\b(#{core_functions.join('|')})\b/, Name::Builtin
+        rule %r/(true|false)\b/i, Name::Builtin
+        rule %r/\b(#{core_keywords.join('|')})\b/i, Keyword
+        rule %r/\b(#{core_functions.join('|')})\b/, Name::Builtin
         
         
 
-        rule /\b(#{mmxprs_functions.join('|')})\b/, Name::Function
-        rule /\b(#{mmxpres_constants.join('|')})\b/, Name::Constant
-        rule /\b(#{mmxprs_parameters.join('|')})\b/i, Name::Property
+        rule %r/\b(#{mmxprs_functions.join('|')})\b/, Name::Function
+        rule %r/\b(#{mmxpres_constants.join('|')})\b/, Name::Constant
+        rule %r/\b(#{mmxprs_parameters.join('|')})\b/i, Name::Property
                   
-        rule /\b(#{mmsystem_functions.join('|')})\b/i, Name::Function
-        rule /\b(#{mmsystem_parameters.join('|')})\b/, Name::Property
+        rule %r/\b(#{mmsystem_functions.join('|')})\b/i, Name::Function
+        rule %r/\b(#{mmsystem_parameters.join('|')})\b/, Name::Property
           
-        rule /\b(#{mmjobs_functions.join('|')})\b/i, Name::Function
-        rule /\b(#{mmjobs_parameters.join('|')})\b/, Name::Property
+        rule %r/\b(#{mmjobs_functions.join('|')})\b/i, Name::Function
+        rule %r/\b(#{mmjobs_parameters.join('|')})\b/, Name::Property
 
         rule id, Name
       end

--- a/lib/rouge/lexers/mxml.rb
+++ b/lib/rouge/lexers/mxml.rb
@@ -11,56 +11,56 @@ module Rouge
       mimetypes 'application/xv+xml'
 
       state :root do
-        rule /[^<&]+/, Text
-        rule /&\S*?;/, Name::Entity
+        rule %r/[^<&]+/, Text
+        rule %r/&\S*?;/, Name::Entity
 
-        rule /<!\[CDATA\[/m do
+        rule %r/<!\[CDATA\[/m do
           token Comment::Preproc
           push :actionscript_content
         end
 
-        rule /<!--/, Comment, :comment
-        rule /<\?.*?\?>/, Comment::Preproc
-        rule /<![^>]*>/, Comment::Preproc
+        rule %r/<!--/, Comment, :comment
+        rule %r/<\?.*?\?>/, Comment::Preproc
+        rule %r/<![^>]*>/, Comment::Preproc
 
         rule %r(<\s*[\w:.-]+)m, Name::Tag, :tag # opening tags
         rule %r(<\s*/\s*[\w:.-]+\s*>)m, Name::Tag # closing tags
       end
 
       state :comment do
-        rule /[^-]+/m, Comment
-        rule /-->/, Comment, :pop!
-        rule /-/, Comment
+        rule %r/[^-]+/m, Comment
+        rule %r/-->/, Comment, :pop!
+        rule %r/-/, Comment
       end
 
       state :tag do
-        rule /\s+/m, Text
-        rule /[\w.:-]+\s*=/m, Name::Attribute, :attribute
+        rule %r/\s+/m, Text
+        rule %r/[\w.:-]+\s*=/m, Name::Attribute, :attribute
         rule %r(/?\s*>), Name::Tag, :root
       end
 
       state :attribute do
-        rule /\s+/m, Text
-        rule /(")({|@{)/m do
+        rule %r/\s+/m, Text
+        rule %r/(")({|@{)/m do
           groups Str, Punctuation
           push :actionscript_attribute
         end
-        rule /".*?"|'.*?'|[^\s>]+/, Str, :tag
+        rule %r/".*?"|'.*?'|[^\s>]+/, Str, :tag
       end
 
       state :actionscript_content do
-        rule /\]\]\>/m, Comment::Preproc, :pop!
-        rule /.*?(?=\]\]\>)/m do
+        rule %r/\]\]\>/m, Comment::Preproc, :pop!
+        rule %r/.*?(?=\]\]\>)/m do
           delegate Actionscript
         end
       end
 
       state :actionscript_attribute do
-        rule /(})(")/m do
+        rule %r/(})(")/m do
           groups Punctuation, Str
           push :tag
         end
-        rule /.*?(?=}")/m do
+        rule %r/.*?(?=}")/m do
           delegate Actionscript
         end
       end

--- a/lib/rouge/lexers/nasm.rb
+++ b/lib/rouge/lexers/nasm.rb
@@ -119,57 +119,57 @@ module Rouge
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
+        rule %r/[ \t\r]+/, Text
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         rule %r(//(\\.|.)*?\n), Comment::Single, :expr_bol
         mixin :inline_whitespace
       end
 
       state :expr_whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         mixin :whitespace
       end
 
       state :root do
         mixin :expr_whitespace
         rule(//) { push :statement }
-        rule /^%[a-zA-Z0-9]+/, Comment::Preproc, :statement
+        rule %r/^%[a-zA-Z0-9]+/, Comment::Preproc, :statement
 
         rule(
           %r(&=|[*]=|/=|\\=|\^=|\+=|-=|<<=|>>=|<<|>>|:=|<=|>=|<>|[-&*/\\^+=<>.]),
           Operator
         )
-        rule /;.*/, Comment, :statement
-        rule /^[a-zA-Z]+[a-zA-Z0-9]*:/, Name::Function
-        rule /;.*/, Comment
+        rule %r/;.*/, Comment, :statement
+        rule %r/^[a-zA-Z]+[a-zA-Z0-9]*:/, Name::Function
+        rule %r/;.*/, Comment
       end
 
       state :statement do
         mixin :expr_whitespace
         mixin :statements
-        rule /;.*/, Comment
-        rule /^%[a-zA-Z0-9]+/, Comment::Preproc
-        rule /[a-zA-Z]+%[0-9]+:/, Name::Function
+        rule %r/;.*/, Comment
+        rule %r/^%[a-zA-Z0-9]+/, Comment::Preproc
+        rule %r/[a-zA-Z]+%[0-9]+:/, Name::Function
       end
 
       state :statements do
         mixin :whitespace
-        rule /L?"/, Str, :string
-        rule /[a-zA-Z]+%[0-9]+:/, Name::Function  #labels/subroutines/functions
+        rule %r/L?"/, Str, :string
+        rule %r/[a-zA-Z]+%[0-9]+:/, Name::Function  #labels/subroutines/functions
         rule %r(L?'(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
-        rule /0x[0-9a-f]+[lu]*/i, Num::Hex
-        rule /\d+[lu]*/i, Num::Integer
+        rule %r/0x[0-9a-f]+[lu]*/i, Num::Hex
+        rule %r/\d+[lu]*/i, Num::Integer
         rule %r(\*/), Error
         rule %r([~&*+=\|?:<>/-]), Operator
-        rule /[(),.]/, Punctuation
-        rule /\[[a-zA-Z0-9]*\]/, Punctuation
-        rule /%[0-9]+/, Keyword::Reserved
-        rule /[a-zA-Z]+%[0-9]+/, Name::Function  #labels/subroutines/functions
+        rule %r/[(),.]/, Punctuation
+        rule %r/\[[a-zA-Z0-9]*\]/, Punctuation
+        rule %r/%[0-9]+/, Keyword::Reserved
+        rule %r/[a-zA-Z]+%[0-9]+/, Name::Function  #labels/subroutines/functions
 
-        #rule /(?<!\.)#{id}/ do |m|
+        #rule %r/(?<!\.)#{id}/ do |m|
         rule id do |m|
           name = m[0]
 
@@ -188,11 +188,11 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\\n/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/"/, Str, :pop!
+        rule %r/\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\\n/, Str
+        rule %r/\\/, Str # stray backslash
       end
     end
   end

--- a/lib/rouge/lexers/nginx.rb
+++ b/lib/rouge/lexers/nginx.rb
@@ -13,7 +13,7 @@ module Rouge
       id = /[^\s$;{}()#]+/
 
       state :root do
-        rule /(include)(\s+)([^\s;]+)/ do
+        rule %r/(include)(\s+)([^\s;]+)/ do
           groups Keyword, Text, Name
         end
 
@@ -23,49 +23,49 @@ module Rouge
       end
 
       state :block do
-        rule /}/, Punctuation, :pop!
+        rule %r/}/, Punctuation, :pop!
         rule id, Keyword::Namespace, :statement
         mixin :base
       end
 
       state :statement do
-        rule /{/ do
+        rule %r/{/ do
           token Punctuation; pop!; push :block
         end
 
-        rule /;/, Punctuation, :pop!
+        rule %r/;/, Punctuation, :pop!
 
         mixin :base
       end
 
       state :base do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /#.*?\n/, Comment::Single
-        rule /(?:on|off)\b/, Name::Constant
-        rule /[$][\w-]+/, Name::Variable
+        rule %r/#.*?\n/, Comment::Single
+        rule %r/(?:on|off)\b/, Name::Constant
+        rule %r/[$][\w-]+/, Name::Variable
 
         # host/port
-        rule /([a-z0-9.-]+)(:)([0-9]+)/i do
+        rule %r/([a-z0-9.-]+)(:)([0-9]+)/i do
           groups Name::Function, Punctuation, Num::Integer
         end
 
         # mimetype
         rule %r([a-z-]+/[a-z-]+)i, Name::Class
 
-        rule /[0-9]+[kmg]?\b/i, Num::Integer
-        rule /(~)(\s*)([^\s{]+)/ do
+        rule %r/[0-9]+[kmg]?\b/i, Num::Integer
+        rule %r/(~)(\s*)([^\s{]+)/ do
           groups Punctuation, Text, Str::Regex
         end
 
-        rule /[:=~]/, Punctuation
+        rule %r/[:=~]/, Punctuation
 
         # pathname
         rule %r(/#{id}?), Name
 
-        rule /[^#\s;{}$\\]+/, Str # catchall
+        rule %r/[^#\s;{}$\\]+/, Str # catchall
 
-        rule /[$;]/, Text
+        rule %r/[$;]/, Text
       end
     end
   end

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -17,11 +17,11 @@ module Rouge
 
       state :comment do
         rule %r/#.*$/, Comment
-        rule %r/\/\*/, Comment, :multiline_comment
+        rule %r(/\*), Comment, :multiline_comment
       end
 
       state :multiline_comment do
-        rule %r/\*\//, Comment, :pop!
+        rule %r(\*/), Comment, :pop!
         rule %r/./, Comment
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -11,34 +11,34 @@ module Rouge
       filenames '*.nix'
 
       state :whitespaces do
-        rule /^\s*\n\s*$/m, Text
-        rule /\s+/, Text
+        rule %r/^\s*\n\s*$/m, Text
+        rule %r/\s+/, Text
       end
 
       state :comment do
-        rule /#.*$/, Comment
-        rule /\/\*/, Comment, :multiline_comment
+        rule %r/#.*$/, Comment
+        rule %r/\/\*/, Comment, :multiline_comment
       end
 
       state :multiline_comment do
-        rule /\*\//, Comment, :pop!
-        rule /./, Comment
+        rule %r/\*\//, Comment, :pop!
+        rule %r/./, Comment
       end
 
       state :number do
-        rule /[0-9]/, Num::Integer
+        rule %r/[0-9]/, Num::Integer
       end
 
       state :null do
-        rule /(null)/, Keyword::Constant
+        rule %r/(null)/, Keyword::Constant
       end
 
       state :boolean do
-        rule /(true|false)/, Keyword::Constant
+        rule %r/(true|false)/, Keyword::Constant
       end
 
       state :binding do
-        rule /[a-zA-Z_][a-zA-Z0-9-]*/, Name::Variable
+        rule %r/[a-zA-Z_][a-zA-Z0-9-]*/, Name::Variable
       end
 
       state :path do
@@ -49,86 +49,86 @@ module Rouge
         tilde = /~#{section}+/.source
         basic = /#{word}(\/#{word})+/.source
         url = /#{prefix}(\/?#{basic})/.source
-        rule /(#{root}|#{tilde}|#{basic}|#{url})/, Str::Other
+        rule %r/(#{root}|#{tilde}|#{basic}|#{url})/, Str::Other
       end
 
       state :string do
-        rule /"/, Str::Double, :double_quoted_string
-        rule /''/, Str::Double, :indented_string
+        rule %r/"/, Str::Double, :double_quoted_string
+        rule %r/''/, Str::Double, :indented_string
       end
 
       state :string_content do
-        rule /\\./, Str::Escape
-        rule /\$\$/, Str::Escape
-        rule /\${/, Str::Interpol, :string_interpolated_arg
+        rule %r/\\./, Str::Escape
+        rule %r/\$\$/, Str::Escape
+        rule %r/\${/, Str::Interpol, :string_interpolated_arg
       end
 
       state :indented_string_content do
-        rule /'''/, Str::Escape
-        rule /''\$/, Str::Escape
-        rule /\$\$/, Str::Escape
-        rule /''\\./, Str::Escape
-        rule /\${/, Str::Interpol, :string_interpolated_arg
+        rule %r/'''/, Str::Escape
+        rule %r/''\$/, Str::Escape
+        rule %r/\$\$/, Str::Escape
+        rule %r/''\\./, Str::Escape
+        rule %r/\${/, Str::Interpol, :string_interpolated_arg
       end
 
       state :string_interpolated_arg do
         mixin :expression
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
       end
 
       state :indented_string do
         mixin :indented_string_content
-        rule /''/, Str::Double, :pop!
-        rule /./, Str::Double
+        rule %r/''/, Str::Double, :pop!
+        rule %r/./, Str::Double
       end
 
       state :double_quoted_string do
         mixin :string_content
-        rule /"/, Str::Double, :pop!
-        rule /./, Str::Double
+        rule %r/"/, Str::Double, :pop!
+        rule %r/./, Str::Double
       end
 
       state :operator do
-        rule /(\.|\?|\+\+|\+|!=|!|\/\/|\=\=|&&|\|\||->|\/|\*|-|<|>|<=|=>)/, Operator
+        rule %r/(\.|\?|\+\+|\+|!=|!|\/\/|\=\=|&&|\|\||->|\/|\*|-|<|>|<=|=>)/, Operator
       end
 
       state :assignment do
-        rule /(=)/, Operator
-        rule /(@)/, Operator
+        rule %r/(=)/, Operator
+        rule %r/(@)/, Operator
       end
 
       state :accessor do
-        rule /(\$)/, Punctuation
+        rule %r/(\$)/, Punctuation
       end
 
       state :delimiter do
-        rule /(;|,|:)/, Punctuation
+        rule %r/(;|,|:)/, Punctuation
       end
 
       state :atom_content do
         mixin :expression
-        rule /\)/, Punctuation, :pop!
+        rule %r/\)/, Punctuation, :pop!
       end
 
       state :atom do
-        rule /\(/, Punctuation, :atom_content
+        rule %r/\(/, Punctuation, :atom_content
       end
 
       state :list do
-        rule /\[/, Punctuation, :list_content
+        rule %r/\[/, Punctuation, :list_content
       end
 
       state :list_content do
-        rule /\]/, Punctuation, :pop!
+        rule %r/\]/, Punctuation, :pop!
         mixin :expression
       end
 
       state :set do
-        rule /{/, Punctuation, :set_content
+        rule %r/{/, Punctuation, :set_content
       end
 
       state :set_content do
-        rule /}/, Punctuation, :pop!
+        rule %r/}/, Punctuation, :pop!
         mixin :expression
       end
       
@@ -161,22 +161,22 @@ module Rouge
 
       state :keywords_namespace do
         keywords = %w(with in inherit)
-        rule /(?:#{keywords.join('|')})\b/, Keyword::Namespace
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Namespace
       end
 
       state :keywords_declaration do
         keywords = %w(let)
-        rule /(?:#{keywords.join('|')})\b/, Keyword::Declaration
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Declaration
       end
 
       state :keywords_conditional do
         keywords = %w(if then else)
-        rule /(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword
       end
 
       state :keywords_reserved do
         keywords = %w(rec assert map)
-        rule /(?:#{keywords.join('|')})\b/, Keyword::Reserved
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Reserved
       end
 
       state :keywords_builtin do
@@ -192,7 +192,7 @@ module Rouge
           throw
           toString
         )
-        rule /(?:#{keywords.join('|')})\b/, Keyword::Reserved
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Reserved
       end
 
       state :ignore do

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -33,21 +33,21 @@ module Rouge
       id = /[a-z$_][a-z0-9$_]*/i
 
       prepend :statements do
-        rule /@"/, Str, :string
-        rule /@'(\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|\\.|[^\\'\n]')/,
+        rule %r/@"/, Str, :string
+        rule %r/@'(\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|\\.|[^\\'\n]')/,
           Str::Char
-        rule /@(\d+[.]\d*|[.]\d+|\d+)e[+-]?\d+l?/i,
+        rule %r/@(\d+[.]\d*|[.]\d+|\d+)e[+-]?\d+l?/i,
           Num::Float
-        rule /@(\d+[.]\d*|[.]\d+|\d+f)f?/i, Num::Float
-        rule /@0x\h+[lL]?/, Num::Hex
-        rule /@0[0-7]+l?/i, Num::Oct
-        rule /@\d+l?/, Num::Integer
-        rule /\bin\b/, Keyword
+        rule %r/@(\d+[.]\d*|[.]\d+|\d+f)f?/i, Num::Float
+        rule %r/@0x\h+[lL]?/, Num::Hex
+        rule %r/@0[0-7]+l?/i, Num::Oct
+        rule %r/@\d+l?/, Num::Integer
+        rule %r/\bin\b/, Keyword
 
-        rule /@(?:interface|implementation)\b/, Keyword, :classname
-        rule /@(?:class|protocol)\b/, Keyword, :forward_classname
+        rule %r/@(?:interface|implementation)\b/, Keyword, :classname
+        rule %r/@(?:class|protocol)\b/, Keyword, :forward_classname
 
-        rule /@([[:alnum:]]+)/ do |m|
+        rule %r/@([[:alnum:]]+)/ do |m|
           if self.class.at_keywords.include? m[1]
             token Keyword
           elsif self.class.at_builtins.include? m[1]
@@ -57,32 +57,32 @@ module Rouge
           end
         end
 
-        rule /[?]/, Punctuation, :ternary
-        rule /\[/,  Punctuation, :message
-        rule /@\[/, Punctuation, :array_literal
-        rule /@\{/, Punctuation, :dictionary_literal
+        rule %r/[?]/, Punctuation, :ternary
+        rule %r/\[/,  Punctuation, :message
+        rule %r/@\[/, Punctuation, :array_literal
+        rule %r/@\{/, Punctuation, :dictionary_literal
       end
 
       state :ternary do
-        rule /:/, Punctuation, :pop!
+        rule %r/:/, Punctuation, :pop!
         mixin :statements
       end
 
       state :message_shared do
-        rule /\]/, Punctuation, :pop!
-        rule /\{/, Punctuation, :pop!
-        rule /;/, Error
+        rule %r/\]/, Punctuation, :pop!
+        rule %r/\{/, Punctuation, :pop!
+        rule %r/;/, Error
 
         mixin :statements
       end
 
       state :message do
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/(#{id})(\s*)(:)/ do
           groups(Name::Function, Text, Punctuation)
           goto :message_with_args
         end
 
-        rule /(#{id})(\s*)(\])/ do
+        rule %r/(#{id})(\s*)(\])/ do
           groups(Name::Function, Text, Punctuation)
           pop!
         end
@@ -91,8 +91,8 @@ module Rouge
       end
 
       state :message_with_args do
-        rule /\{/, Punctuation, :function
-        rule /(#{id})(\s*)(:)/ do
+        rule %r/\{/, Punctuation, :function
+        rule %r/(#{id})(\s*)(:)/ do
           groups(Name::Function, Text, Punctuation)
           pop!
         end
@@ -101,28 +101,28 @@ module Rouge
       end
 
       state :array_literal do
-        rule /]/, Punctuation, :pop!
-        rule /,/, Punctuation
+        rule %r/]/, Punctuation, :pop!
+        rule %r/,/, Punctuation
         mixin :statements
       end
 
       state :dictionary_literal do
-        rule /}/, Punctuation, :pop!
-        rule /,/, Punctuation
+        rule %r/}/, Punctuation, :pop!
+        rule %r/,/, Punctuation
         mixin :statements
       end
 
       state :classname do
         mixin :whitespace
 
-        rule /(#{id})(\s*)(:)(\s*)(#{id})/ do
+        rule %r/(#{id})(\s*)(:)(\s*)(#{id})/ do
           groups(Name::Class, Text,
                  Punctuation, Text,
                  Name::Class)
           pop!
         end
 
-        rule /(#{id})(\s*)([(])(\s*)(#{id})(\s*)([)])/ do
+        rule %r/(#{id})(\s*)([(])(\s*)(#{id})(\s*)([)])/ do
           groups(Name::Class, Text,
                  Punctuation, Text,
                  Name::Label, Text,
@@ -136,12 +136,12 @@ module Rouge
       state :forward_classname do
         mixin :whitespace
 
-        rule /(#{id})(\s*)(,)(\s*)/ do
+        rule %r/(#{id})(\s*)(,)(\s*)/ do
           groups(Name::Class, Text, Punctuation, Text)
           push
         end
 
-        rule /(#{id})(\s*)(;?)/ do
+        rule %r/(#{id})(\s*)(;?)/ do
           groups(Name::Class, Text, Punctuation)
           pop!
         end
@@ -162,26 +162,26 @@ module Rouge
       end
 
       state :method_definition do
-        rule /,/, Punctuation
-        rule /[.][.][.]/, Punctuation
-        rule /([(].*?[)])(#{id})/ do |m|
+        rule %r/,/, Punctuation
+        rule %r/[.][.][.]/, Punctuation
+        rule %r/([(].*?[)])(#{id})/ do |m|
           recurse m[1]; token Name::Variable, m[2]
         end
 
-        rule /(#{id})(\s*)(:)/m do
+        rule %r/(#{id})(\s*)(:)/m do
           groups(Name::Function, Text, Punctuation)
         end
 
-        rule /;/, Punctuation, :pop!
+        rule %r/;/, Punctuation, :pop!
 
-        rule /{/ do
+        rule %r/{/ do
           token Punctuation
           goto :function
         end
 
         mixin :inline_whitespace
         rule %r(//.*?\n), Comment::Single
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
 
         rule(//) { pop! }
       end

--- a/lib/rouge/lexers/ocaml.rb
+++ b/lib/rouge/lexers/ocaml.rb
@@ -33,12 +33,12 @@ module Rouge
       upper_id = /[A-Z][\w']*/
 
       state :root do
-        rule /\s+/m, Text
-        rule /false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
-        rule /#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
-        rule /`#{id}/, Name::Tag
+        rule %r/\s+/m, Text
+        rule %r/false|true|[(][)]|\[\]/, Name::Builtin::Pseudo
+        rule %r/#{upper_id}(?=\s*[.])/, Name::Namespace, :dotted
+        rule %r/`#{id}/, Name::Tag
         rule upper_id, Name::Class
-        rule /[(][*](?![)])/, Comment, :comment
+        rule %r/[(][*](?![)])/, Comment, :comment
         rule id do |m|
           match = m[0]
           if self.class.keywords.include? match
@@ -52,49 +52,49 @@ module Rouge
           end
         end
 
-        rule /[(){}\[\];]+/, Punctuation
+        rule %r/[(){}\[\];]+/, Punctuation
         rule operator, Operator
 
-        rule /-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
-        rule /0x\h[\h_]*/i, Num::Hex
-        rule /0o[0-7][0-7_]*/i, Num::Oct
-        rule /0b[01][01_]*/i, Num::Bin
-        rule /\d[\d_]*/, Num::Integer
+        rule %r/-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
+        rule %r/0x\h[\h_]*/i, Num::Hex
+        rule %r/0o[0-7][0-7_]*/i, Num::Oct
+        rule %r/0b[01][01_]*/i, Num::Bin
+        rule %r/\d[\d_]*/, Num::Integer
 
-        rule /'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
-        rule /'[.]'/, Str::Char
-        rule /'/, Keyword
-        rule /"/, Str::Double, :string
-        rule /[~?]#{id}/, Name::Variable
+        rule %r/'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
+        rule %r/'[.]'/, Str::Char
+        rule %r/'/, Keyword
+        rule %r/"/, Str::Double, :string
+        rule %r/[~?]#{id}/, Name::Variable
       end
 
       state :comment do
-        rule /[^(*)]+/, Comment
+        rule %r/[^(*)]+/, Comment
         rule(/[(][*]/) { token Comment; push }
-        rule /[*][)]/, Comment, :pop!
-        rule /[(*)]/, Comment
+        rule %r/[*][)]/, Comment, :pop!
+        rule %r/[(*)]/, Comment
       end
 
       state :string do
-        rule /[^\\"]+/, Str::Double
+        rule %r/[^\\"]+/, Str::Double
         mixin :escape_sequence
-        rule /\\\n/, Str::Double
-        rule /"/, Str::Double, :pop!
+        rule %r/\\\n/, Str::Double
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :escape_sequence do
-        rule /\\[\\"'ntbr]/, Str::Escape
-        rule /\\\d{3}/, Str::Escape
-        rule /\\x\h{2}/, Str::Escape
+        rule %r/\\[\\"'ntbr]/, Str::Escape
+        rule %r/\\\d{3}/, Str::Escape
+        rule %r/\\x\h{2}/, Str::Escape
       end
 
       state :dotted do
-        rule /\s+/m, Text
-        rule /[.]/, Punctuation
-        rule /#{upper_id}(?=\s*[.])/, Name::Namespace
+        rule %r/\s+/m, Text
+        rule %r/[.]/, Punctuation
+        rule %r/#{upper_id}(?=\s*[.])/, Name::Namespace
         rule upper_id, Name::Class, :pop!
         rule id, Name, :pop!
-        rule /[({\[]/, Punctuation, :pop!
+        rule %r/[({\[]/, Punctuation, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/pascal.rb
+++ b/lib/rouge/lexers/pascal.rb
@@ -40,7 +40,7 @@ module Rouge
 
       state :whitespace do
         # Spaces
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         # // Comments
         rule %r((//).*$\n?), Comment::Single
         # -- Comments
@@ -57,9 +57,9 @@ module Rouge
         rule %r{((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?}, Num
         rule %r{[~!@#\$%\^&\*\(\)\+`\-={}\[\]:;<>\?,\.\/\|\\]}, Punctuation
         rule %r{'([^']|'')*'}, Str
-        rule /(true|false|nil)\b/i, Name::Builtin
-        rule /\b(#{keywords.join('|')})\b/i, Keyword
-        rule /\b(#{keywords_type.join('|')})\b/i, Keyword::Type
+        rule %r/(true|false|nil)\b/i, Name::Builtin
+        rule %r/\b(#{keywords.join('|')})\b/i, Keyword
+        rule %r/\b(#{keywords_type.join('|')})\b/i, Keyword::Type
         rule id, Name
       end
     end

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -65,17 +65,17 @@ module Rouge
       end
 
       state :root do
-        rule /#.*?$/, Comment::Single
-        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/m, Comment::Multiline
-        rule /(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/#.*?$/, Comment::Single
+        rule %r/^=[a-zA-Z0-9]+\s+.*?\n=cut/m, Comment::Multiline
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword
 
-        rule /(format)(\s+)([a-zA-Z0-9_]+)(\s*)(=)(\s*\n)/ do
+        rule %r/(format)(\s+)([a-zA-Z0-9_]+)(\s*)(=)(\s*\n)/ do
           groups Keyword, Text, Name, Text, Punctuation, Text
 
           push :format
         end
 
-        rule /(?:eq|lt|gt|le|ge|ne|not|and|or|cmp)\b/, Operator::Word
+        rule %r/(?:eq|lt|gt|le|ge|ne|not|and|or|cmp)\b/, Operator::Word
 
         # common delimiters
         rule %r(s/(\\\\|\\/|[^/])*/(\\\\|\\/|[^/])*/[msixpodualngc]*), re_tok
@@ -100,103 +100,103 @@ module Rouge
         rule %r(((?<==~)|(?<=\())\s*/(\\\\|\\/|[^/])*/[msixpodualngc]*),
           re_tok, :balanced_regex
 
-        rule /\s+/, Text
-        rule /(?:#{builtins.join('|')})\b/, Name::Builtin
-        rule /((__(DATA|DIE|WARN)__)|(STD(IN|OUT|ERR)))\b/,
+        rule %r/\s+/, Text
+        rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
+        rule %r/((__(DATA|DIE|WARN)__)|(STD(IN|OUT|ERR)))\b/,
           Name::Builtin::Pseudo
 
-        rule /<<([\'"]?)([a-zA-Z_][a-zA-Z0-9_]*)\1;?\n.*?\n\2\n/m, Str
+        rule %r/<<([\'"]?)([a-zA-Z_][a-zA-Z0-9_]*)\1;?\n.*?\n\2\n/m, Str
 
-        rule /__END__\b/, Comment::Preproc, :end_part
-        rule /\$\^[ADEFHILMOPSTWX]/, Name::Variable::Global
-        rule /\$[\\"'\[\]&`+*.,;=%~?@$!<>(^\|\/-](?!\w)/, Name::Variable::Global
-        rule /[-+\/*%=<>&^\|!\\~]=?/, Operator
-        rule /[$@%#]+/, Name::Variable, :varname
+        rule %r/__END__\b/, Comment::Preproc, :end_part
+        rule %r/\$\^[ADEFHILMOPSTWX]/, Name::Variable::Global
+        rule %r/\$[\\"'\[\]&`+*.,;=%~?@$!<>(^\|\/-](?!\w)/, Name::Variable::Global
+        rule %r/[-+\/*%=<>&^\|!\\~]=?/, Operator
+        rule %r/[$@%#]+/, Name::Variable, :varname
 
-        rule /0_?[0-7]+(_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(_[0-9A-Fa-f]+)*/, Num::Hex
-        rule /0b[01]+(_[01]+)*/, Num::Bin
-        rule /(\d*(_\d*)*\.\d+(_\d*)*|\d+(_\d*)*\.\d+(_\d*)*)(e[+-]?\d+)?/i,
+        rule %r/0_?[0-7]+(_[0-7]+)*/, Num::Oct
+        rule %r/0x[0-9A-Fa-f]+(_[0-9A-Fa-f]+)*/, Num::Hex
+        rule %r/0b[01]+(_[01]+)*/, Num::Bin
+        rule %r/(\d*(_\d*)*\.\d+(_\d*)*|\d+(_\d*)*\.\d+(_\d*)*)(e[+-]?\d+)?/i,
           Num::Float
-        rule /\d+(_\d*)*e[+-]?\d+(_\d*)*/i, Num::Float
-        rule /\d+(_\d+)*/, Num::Integer
+        rule %r/\d+(_\d*)*e[+-]?\d+(_\d*)*/i, Num::Float
+        rule %r/\d+(_\d+)*/, Num::Integer
 
-        rule /'/, Punctuation, :sq
-        rule /"/, Punctuation, :dq
-        rule /`/, Punctuation, :bq
-        rule /<([^\s>]+)>/, re_tok
-        rule /(q|qq|qw|qr|qx)\{/, Str::Other, :cb_string
-        rule /(q|qq|qw|qr|qx)\(/, Str::Other, :rb_string
-        rule /(q|qq|qw|qr|qx)\[/, Str::Other, :sb_string
-        rule /(q|qq|qw|qr|qx)</, Str::Other, :lt_string
-        rule /(q|qq|qw|qr|qx)([^a-zA-Z0-9])(.|\n)*?\2/, Str::Other
+        rule %r/'/, Punctuation, :sq
+        rule %r/"/, Punctuation, :dq
+        rule %r/`/, Punctuation, :bq
+        rule %r/<([^\s>]+)>/, re_tok
+        rule %r/(q|qq|qw|qr|qx)\{/, Str::Other, :cb_string
+        rule %r/(q|qq|qw|qr|qx)\(/, Str::Other, :rb_string
+        rule %r/(q|qq|qw|qr|qx)\[/, Str::Other, :sb_string
+        rule %r/(q|qq|qw|qr|qx)</, Str::Other, :lt_string
+        rule %r/(q|qq|qw|qr|qx)([^a-zA-Z0-9])(.|\n)*?\2/, Str::Other
 
-        rule /package\s+/, Keyword, :modulename
-        rule /sub\s+/, Keyword, :funcname
-        rule /\[\]|\*\*|::|<<|>>|>=|<=|<=>|={3}|!=|=~|!~|&&?|\|\||\.{1,3}/,
+        rule %r/package\s+/, Keyword, :modulename
+        rule %r/sub\s+/, Keyword, :funcname
+        rule %r/\[\]|\*\*|::|<<|>>|>=|<=|<=>|={3}|!=|=~|!~|&&?|\|\||\.{1,3}/,
           Operator
-        rule /[()\[\]:;,<>\/?{}]/, Punctuation
+        rule %r/[()\[\]:;,<>\/?{}]/, Punctuation
         rule(/(?=\w)/) { push :name }
       end
 
       state :format do
-        rule /\.\n/, Str::Interpol, :pop!
-        rule /.*?\n/, Str::Interpol
+        rule %r/\.\n/, Str::Interpol, :pop!
+        rule %r/.*?\n/, Str::Interpol
       end
 
       state :name_common do
-        rule /\w+::/, Name::Namespace
-        rule /[\w:]+/, Name::Variable, :pop!
+        rule %r/\w+::/, Name::Namespace
+        rule %r/[\w:]+/, Name::Variable, :pop!
       end
 
       state :varname do
-        rule /\s+/, Text
-        rule /\{/, Punctuation, :pop! # hash syntax
-        rule /\)|,/, Punctuation, :pop! # arg specifier
+        rule %r/\s+/, Text
+        rule %r/\{/, Punctuation, :pop! # hash syntax
+        rule %r/\)|,/, Punctuation, :pop! # arg specifier
         mixin :name_common
       end
 
       state :name do
         mixin :name_common
-        rule /[A-Z_]+(?=[^a-zA-Z0-9_])/, Name::Constant, :pop!
+        rule %r/[A-Z_]+(?=[^a-zA-Z0-9_])/, Name::Constant, :pop!
         rule(/(?=\W)/) { pop! }
       end
 
       state :modulename do
-        rule /[a-z_]\w*/i, Name::Namespace, :pop!
+        rule %r/[a-z_]\w*/i, Name::Namespace, :pop!
       end
 
       state :funcname do
-        rule /[a-zA-Z_]\w*[!?]?/, Name::Function
-        rule /\s+/, Text
+        rule %r/[a-zA-Z_]\w*[!?]?/, Name::Function
+        rule %r/\s+/, Text
 
         # argument declaration
-        rule /(\([$@%]*\))(\s*)/ do
+        rule %r/(\([$@%]*\))(\s*)/ do
           groups Punctuation, Text
         end
 
-        rule /.*?{/, Punctuation, :pop!
-        rule /;/, Punctuation, :pop!
+        rule %r/.*?{/, Punctuation, :pop!
+        rule %r/;/, Punctuation, :pop!
       end
 
       state :sq do
-        rule /\\[']/, Str::Escape
-        rule /[^\\']+/, Str::Single
-        rule /'/, Punctuation, :pop!
+        rule %r/\\[']/, Str::Escape
+        rule %r/[^\\']+/, Str::Single
+        rule %r/'/, Punctuation, :pop!
       end
 
       state :dq do
         mixin :string_intp
-        rule /\\[\\tnr"]/, Str::Escape
-        rule /[^\\"]+?/, Str::Double
-        rule /"/, Punctuation, :pop!
+        rule %r/\\[\\tnr"]/, Str::Escape
+        rule %r/[^\\"]+?/, Str::Double
+        rule %r/"/, Punctuation, :pop!
       end
 
       state :bq do
         mixin :string_intp
-        rule /\\[\\tnr`]/, Str::Escape
-        rule /[^\\`]+?/, Str::Backtick
-        rule /`/, Punctuation, :pop!
+        rule %r/\\[\\tnr`]/, Str::Escape
+        rule %r/[^\\`]+?/, Str::Backtick
+        rule %r/`/, Punctuation, :pop!
       end
 
       [[:cb, '\{', '\}'],
@@ -205,28 +205,28 @@ module Rouge
        [:lt, '<',  '>']].each do |name, open, close|
         tok = Str::Other
         state :"#{name}_string" do
-          rule /\\[#{open}#{close}\\]/, tok
-          rule /\\/, tok
+          rule %r/\\[#{open}#{close}\\]/, tok
+          rule %r/\\/, tok
           rule(/#{open}/) { token tok; push }
-          rule /#{close}/, tok, :pop!
-          rule /[^#{open}#{close}\\]+/, tok
+          rule %r/#{close}/, tok, :pop!
+          rule %r/[^#{open}#{close}\\]+/, tok
         end
       end
 
       state :in_interp do
-        rule /}/, Str::Interpol, :pop!
-        rule /\s+/, Text
-        rule /[a-z_]\w*/i, Str::Interpol
+        rule %r/}/, Str::Interpol, :pop!
+        rule %r/\s+/, Text
+        rule %r/[a-z_]\w*/i, Str::Interpol
       end
 
       state :string_intp do
-        rule /[$@][{]/, Str::Interpol, :in_interp
-        rule /[$@][a-z_]\w*/i, Str::Interpol
+        rule %r/[$@][{]/, Str::Interpol, :in_interp
+        rule %r/[$@][a-z_]\w*/i, Str::Interpol
       end
 
       state :end_part do
         # eat the rest of the stream
-        rule /.+/m, Comment::Preproc, :pop!
+        rule %r/.+/m, Comment::Preproc, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -91,49 +91,49 @@ module Rouge
       end
 
       state :template do
-        rule /<\?(php|=)?/, Comment::Preproc, :php
+        rule %r/<\?(php|=)?/, Comment::Preproc, :php
         rule(/.*?(?=<\?)|.*/m) { delegate parent }
       end
 
       state :php do
-        rule /\?>/, Comment::Preproc, :pop!
+        rule %r/\?>/, Comment::Preproc, :pop!
         # heredocs
-        rule /<<<('?)(#{id})\1\n.*?\n\2;?\n/im, Str::Heredoc
-        rule /\s+/, Text
-        rule /#.*?$/, Comment::Single
+        rule %r/<<<('?)(#{id})\1\n.*?\n\2;?\n/im, Str::Heredoc
+        rule %r/\s+/, Text
+        rule %r/#.*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single
         # empty comment, otherwise seen as the start of a docstring
         rule %r(/\*\*/), Comment::Multiline
         rule %r(/\*\*.*?\*/)m, Str::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline
-        rule /(->|::)(\s*)(#{id})/ do
+        rule %r/(->|::)(\s*)(#{id})/ do
           groups Operator, Text, Name::Attribute
         end
 
-        rule /[~!%^&*+=\|:.<>\/?@-]+/, Operator
-        rule /[\[\]{}();,]/, Punctuation
-        rule /class\b/, Keyword, :classname
+        rule %r/[~!%^&*+=\|:.<>\/?@-]+/, Operator
+        rule %r/[\[\]{}();,]/, Punctuation
+        rule %r/class\b/, Keyword, :classname
         # anonymous functions
-        rule /(function)(\s*)(?=\()/ do
+        rule %r/(function)(\s*)(?=\()/ do
           groups Keyword, Text
         end
 
         # named functions
-        rule /(function)(\s+)(&?)(\s*)/ do
+        rule %r/(function)(\s+)(&?)(\s*)/ do
           groups Keyword, Text, Operator, Text
           push :funcname
         end
 
-        rule /(const)(\s+)(#{id})/i do
+        rule %r/(const)(\s+)(#{id})/i do
           groups Keyword, Text, Name::Constant
         end
 
-        rule /(true|false|null)\b/, Keyword::Constant
-        rule /\$\{\$+#{id}\}/i, Name::Variable
-        rule /\$+#{id}/i, Name::Variable
+        rule %r/(true|false|null)\b/, Keyword::Constant
+        rule %r/\$\{\$+#{id}\}/i, Name::Variable
+        rule %r/\$+#{id}/i, Name::Variable
 
         # may be intercepted for builtin highlighting
-        rule /\\?#{nsid}/i do |m|
+        rule %r/\\?#{nsid}/i do |m|
           name = m[0]
 
           if self.class.keywords.include? name
@@ -145,48 +145,48 @@ module Rouge
           end
         end
 
-        rule /(\d+\.\d*|\d*\.\d+)(e[+-]?\d+)?/i, Num::Float
-        rule /\d+e[+-]?\d+/i, Num::Float
-        rule /0[0-7]+/, Num::Oct
-        rule /0x[a-f0-9]+/i, Num::Hex
-        rule /\d+/, Num::Integer
-        rule /'([^'\\]*(?:\\.[^'\\]*)*)'/, Str::Single
-        rule /`([^`\\]*(?:\\.[^`\\]*)*)`/, Str::Backtick
-        rule /"/, Str::Double, :string
+        rule %r/(\d+\.\d*|\d*\.\d+)(e[+-]?\d+)?/i, Num::Float
+        rule %r/\d+e[+-]?\d+/i, Num::Float
+        rule %r/0[0-7]+/, Num::Oct
+        rule %r/0x[a-f0-9]+/i, Num::Hex
+        rule %r/\d+/, Num::Integer
+        rule %r/'([^'\\]*(?:\\.[^'\\]*)*)'/, Str::Single
+        rule %r/`([^`\\]*(?:\\.[^`\\]*)*)`/, Str::Backtick
+        rule %r/"/, Str::Double, :string
       end
 
       state :classname do
-        rule /\s+/, Text
-        rule /#{nsid}/, Name::Class, :pop!
+        rule %r/\s+/, Text
+        rule %r/#{nsid}/, Name::Class, :pop!
       end
 
       state :funcname do
-        rule /#{id}/, Name::Function, :pop!
+        rule %r/#{id}/, Name::Function, :pop!
       end
 
       state :string do
-        rule /"/, Str::Double, :pop!
-        rule /[^\\{$"]+/, Str::Double
-        rule /\\([nrt\"$\\]|[0-7]{1,3}|x[0-9A-Fa-f]{1,2})/,
+        rule %r/"/, Str::Double, :pop!
+        rule %r/[^\\{$"]+/, Str::Double
+        rule %r/\\([nrt\"$\\]|[0-7]{1,3}|x[0-9A-Fa-f]{1,2})/,
           Str::Escape
-        rule /\$#{id}(\[\S+\]|->#{id})?/, Name::Variable
+        rule %r/\$#{id}(\[\S+\]|->#{id})?/, Name::Variable
 
-        rule /\{\$\{/, Str::Interpol, :interp_double
-        rule /\{(?=\$)/, Str::Interpol, :interp_single
-        rule /(\{)(\S+)(\})/ do
+        rule %r/\{\$\{/, Str::Interpol, :interp_double
+        rule %r/\{(?=\$)/, Str::Interpol, :interp_single
+        rule %r/(\{)(\S+)(\})/ do
           groups Str::Interpol, Name::Variable, Str::Interpol
         end
 
-        rule /[${\\]+/, Str::Double
+        rule %r/[${\\]+/, Str::Double
       end
 
       state :interp_double do
-        rule /\}\}/, Str::Interpol, :pop!
+        rule %r/\}\}/, Str::Interpol, :pop!
         mixin :php
       end
 
       state :interp_single do
-        rule /\}/, Str::Interpol, :pop!
+        rule %r/\}/, Str::Interpol, :pop!
         mixin :php
       end
     end

--- a/lib/rouge/lexers/plist.rb
+++ b/lib/rouge/lexers/plist.rb
@@ -6,41 +6,41 @@ module Rouge
       desc 'plist'
       tag 'plist'
       aliases 'plist'
-      filenames *%w(*.plist *.pbxproj)
+      filenames '*.plist', '*.pbxproj'
 
       mimetypes 'text/x-plist', 'application/x-plist'
 
       state :whitespace do
-        rule /\s+/, Text::Whitespace
+        rule %r/\s+/, Text::Whitespace
       end
 
       state :root do
         rule %r{//.*$}, Comment
         rule %r{/\*.+?\*/}m, Comment
         mixin :whitespace
-        rule /{/, Punctuation, :dictionary
-        rule /\(/, Punctuation, :array
-        rule /"([^"\\]|\\.)*"/, Literal::String::Double
-        rule /'([^'\\]|\\.)*'/, Literal::String::Single
-        rule /</, Punctuation, :data
+        rule %r/{/, Punctuation, :dictionary
+        rule %r/\(/, Punctuation, :array
+        rule %r/"([^"\\]|\\.)*"/, Literal::String::Double
+        rule %r/'([^'\\]|\\.)*'/, Literal::String::Single
+        rule %r/</, Punctuation, :data
         rule %r{[\w_$/:.-]+}, Literal
       end
 
       state :dictionary do
         mixin :root
-        rule /[=;]/, Punctuation
-        rule /}/, Punctuation, :pop!
+        rule %r/[=;]/, Punctuation
+        rule %r/}/, Punctuation, :pop!
       end
 
       state :array do
         mixin :root
-        rule /[,]/, Punctuation
-        rule /\)/, Punctuation, :pop!
+        rule %r/[,]/, Punctuation
+        rule %r/\)/, Punctuation, :pop!
       end
 
       state :data do
-        rule /[\h\s]+/, Literal::Number::Hex
-        rule />/, Punctuation, :pop!
+        rule %r/[\h\s]+/, Literal::Number::Hex
+        rule %r/>/, Punctuation, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/pony.rb
+++ b/lib/rouge/lexers/pony.rb
@@ -40,28 +40,28 @@ module Rouge
       )
 
       state :whitespace do
-        rule /[\s\t\r\n]+/m, Text
+        rule %r/[\s\t\r\n]+/m, Text
       end
 
       state :root do
         mixin :whitespace
-        rule /"""/, Str::Doc, :docstring
+        rule %r/"""/, Str::Doc, :docstring
         rule %r{//(.*?)\n}, Comment::Single
         rule %r{/(\\\n)?[*](.|\n)*?[*](\\\n)?/}, Comment::Multiline
-        rule /"/, Str, :string
+        rule %r/"/, Str, :string
         rule %r([~!%^&*+=\|?:<>/-]), Operator
-        rule /(true|false|NULL)\b/, Name::Constant
+        rule %r/(true|false|NULL)\b/, Name::Constant
         rule %r{(?:[A-Z_][a-zA-Z0-9_]*)}, Name::Class
-        rule /[()\[\],.';]/, Punctuation
+        rule %r/[()\[\],.';]/, Punctuation
 
         # Numbers
-        rule /0[xX]([0-9a-fA-F_]*\.[0-9a-fA-F_]+|[0-9a-fA-F_]+)[pP][+\-]?[0-9_]+[fFL]?[i]?/, Num::Float
-        rule /[0-9_]+(\.[0-9_]+[eE][+\-]?[0-9_]+|\.[0-9_]*|[eE][+\-]?[0-9_]+)[fFL]?[i]?/, Num::Float
-        rule /\.(0|[1-9][0-9_]*)([eE][+\-]?[0-9_]+)?[fFL]?[i]?/, Num::Float
-        rule /0[xX][0-9a-fA-F_]+/, Num::Hex
-        rule /(0|[1-9][0-9_]*)([LUu]|Lu|LU|uL|UL)?/, Num::Integer
+        rule %r/0[xX]([0-9a-fA-F_]*\.[0-9a-fA-F_]+|[0-9a-fA-F_]+)[pP][+\-]?[0-9_]+[fFL]?[i]?/, Num::Float
+        rule %r/[0-9_]+(\.[0-9_]+[eE][+\-]?[0-9_]+|\.[0-9_]*|[eE][+\-]?[0-9_]+)[fFL]?[i]?/, Num::Float
+        rule %r/\.(0|[1-9][0-9_]*)([eE][+\-]?[0-9_]+)?[fFL]?[i]?/, Num::Float
+        rule %r/0[xX][0-9a-fA-F_]+/, Num::Hex
+        rule %r/(0|[1-9][0-9_]*)([LUu]|Lu|LU|uL|UL)?/, Num::Integer
 
-        rule /[a-z_][a-z0-9_]*/io do |m|
+        rule %r/[a-z_][a-z0-9_]*/io do |m|
           match = m[0]
 
           if capabilities.include?(match)
@@ -77,17 +77,17 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\\n/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/"/, Str, :pop!
+        rule %r/\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\\n/, Str
+        rule %r/\\/, Str # stray backslash
       end
 
       state :docstring do
-        rule /"""/, Str::Doc, :pop!
-        rule /\n/, Str::Doc
-        rule /./, Str::Doc
+        rule %r/"""/, Str::Doc, :pop!
+        rule %r/\n/, Str::Doc
+        rule %r/./, Str::Doc
       end
     end
   end

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -630,49 +630,49 @@ module Rouge
 
       # Override from Shell
       state :interp do
-        rule /`$/, Str::Escape # line continuation
-        rule /`./, Str::Escape
-        rule /\$\(\(/, Keyword, :math
-        rule /\$\(/, Keyword, :paren
-        rule /\${#?/, Keyword, :curly
-        rule /\$#?(\w+|.)/, Name::Variable
+        rule %r/`$/, Str::Escape # line continuation
+        rule %r/`./, Str::Escape
+        rule %r/\$\(\(/, Keyword, :math
+        rule %r/\$\(/, Keyword, :paren
+        rule %r/\${#?/, Keyword, :curly
+        rule %r/\$#?(\w+|.)/, Name::Variable
       end
 
       # Override from Shell
       state :double_quotes do
         # NB: "abc$" is literally the string abc$.
         # Here we prevent :interp from interpreting $" as a variable.
-        rule /(?:\$#?)?"/, Str::Double, :pop!
+        rule %r/(?:\$#?)?"/, Str::Double, :pop!
         mixin :interp
-        rule /[^"`$]+/, Str::Double
+        rule %r/[^"`$]+/, Str::Double
       end
 
       # Override from Shell
       state :data do
-        rule /\s+/, Text
-        rule /\$?"/, Str::Double, :double_quotes
-        rule /\$'/, Str::Single, :ansi_string
+        rule %r/\s+/, Text
+        rule %r/\$?"/, Str::Double, :double_quotes
+        rule %r/\$'/, Str::Single, :ansi_string
 
-        rule /'/, Str::Single, :single_quotes
+        rule %r/'/, Str::Single, :single_quotes
 
-        rule /\*/, Keyword
+        rule %r/\*/, Keyword
 
-        rule /;/, Text
-        rule /[^=\*\s{}()$"'`<]+/, Text
-        rule /\d+(?= |\Z)/, Num
-        rule /</, Text
+        rule %r/;/, Text
+        rule %r/[^=\*\s{}()$"'`<]+/, Text
+        rule %r/\d+(?= |\Z)/, Num
+        rule %r/</, Text
         mixin :interp
       end
 
       prepend :basic do
         rule %r(<#[\s,\S]*?#>)m, Comment::Multiline
-        rule /#.*$/, Comment::Single
-        rule /\b(#{OPERATORS})\s*\b/i, Operator
-        rule /\b(#{ATTRIBUTES})\s*\b/i, Name::Attribute
-        rule /\b(#{KEYWORDS})\s*\b/i, Keyword
-        rule /\b(#{KEYWORDS_TYPE})\s*\b/i, Keyword::Type
-        rule /\bcase\b/, Keyword, :case
-        rule /\b(#{BUILTINS})\s*\b(?!\.)/i, Name::Builtin
+        rule %r/#.*$/, Comment::Single
+        rule %r/\b(#{OPERATORS})\s*\b/i, Operator
+        rule %r/\b(#{ATTRIBUTES})\s*\b/i, Name::Attribute
+        rule %r/\b(#{KEYWORDS})\s*\b/i, Keyword
+        rule %r/\b(#{KEYWORDS_TYPE})\s*\b/i, Keyword::Type
+        rule %r/\bcase\b/, Keyword, :case
+        rule %r/\b(#{BUILTINS})\s*\b(?!\.)/i, Name::Builtin
       end
     end
   end

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -101,84 +101,84 @@ module Rouge
       )
 
       state :root do
-        rule /(\s+)(#.*?$)/ do
+        rule %r/(\s+)(#.*?$)/ do
           groups Text, Comment::Single
         end
 
-        rule /^#.*?$/,         Comment::Single
-        rule /;[^\n]*/,        Comment::Single
-        rule /\s+/,            Text
+        rule %r/^#.*?$/,         Comment::Single
+        rule %r/;[^\n]*/,        Comment::Single
+        rule %r/\s+/,            Text
 
-        rule /(\bprocedure)(\s+)/ do
+        rule %r/(\bprocedure)(\s+)/ do
           groups Keyword, Text
           push :procedure_definition
         end
 
-        rule /(\bcall)(\s+)/ do
+        rule %r/(\bcall)(\s+)/ do
           groups Keyword, Text
           push :procedure_call
         end
 
-        rule /@/,              Name::Function, :procedure_call
+        rule %r/@/,              Name::Function, :procedure_call
 
         mixin :function_call
 
-        rule /\b(?:select all)\b/, Keyword
-        rule /\b(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/\b(?:select all)\b/, Keyword
+        rule %r/\b(?:#{keywords.join('|')})\b/, Keyword
 
-        rule /(\bform\b)(\s+)([^\n]+)/ do
+        rule %r/(\bform\b)(\s+)([^\n]+)/ do
           groups Keyword, Text, Literal::String
           push :old_form
         end
 
-        rule /(print(?:line|tab)?|echo|exit|asserterror|pause|send(?:praat|socket)|include|execute|system(?:_nocheck)?)(\s+)/ do
+        rule %r/(print(?:line|tab)?|echo|exit|asserterror|pause|send(?:praat|socket)|include|execute|system(?:_nocheck)?)(\s+)/ do
           groups Keyword, Text
           push :string_unquoted
         end
 
-        rule /(goto|label)(\s+)(\w+)/ do
+        rule %r/(goto|label)(\s+)(\w+)/ do
           groups Keyword, Text, Name::Label
         end
 
         mixin :variable_name
         mixin :number
 
-        rule /"/, Literal::String, :string
+        rule %r/"/, Literal::String, :string
 
-        rule /\b(?:#{objects.join('|')})(?=\s+\S+\n)/, Name::Class, :string_unquoted
+        rule %r/\b(?:#{objects.join('|')})(?=\s+\S+\n)/, Name::Class, :string_unquoted
 
-        rule /\b(?=[A-Z])/, Text, :command
-        rule /(\.{3}|[)(,\$])/, Punctuation
+        rule %r/\b(?=[A-Z])/, Text, :command
+        rule %r/(\.{3}|[)(,\$])/, Punctuation
       end
 
       state :command do
-        rule /( ?([^\s:\.'])+ ?)/, Keyword
+        rule %r/( ?([^\s:\.'])+ ?)/, Keyword
         mixin :string_interpolated
 
-        rule /\.{3}/ do
+        rule %r/\.{3}/ do
           token Keyword
           pop!
           push :old_arguments
         end
 
-        rule /:/ do
+        rule %r/:/ do
           token Keyword
           pop!
           push :comma_list
         end
 
-        rule /[\s]/,    Text, :pop!
+        rule %r/[\s]/,    Text, :pop!
       end
 
       state :procedure_call do
         mixin :string_interpolated
 
-        rule /(:|\s*\()/, Punctuation, :pop!
+        rule %r/(:|\s*\()/, Punctuation, :pop!
 
-        rule /'/,            Name::Function
-        rule /[^:\('\s]+/, Name::Function
+        rule %r/'/,            Name::Function
+        rule %r/[^:\('\s]+/, Name::Function
 
-        rule /(?=\s+)/ do
+        rule %r/(?=\s+)/ do
           token Text
           pop!
           push :old_arguments
@@ -186,23 +186,23 @@ module Rouge
       end
 
       state :procedure_definition do
-        rule /(:|\s*\()/, Punctuation, :pop!
+        rule %r/(:|\s*\()/, Punctuation, :pop!
 
-        rule /[^:\(\s]+/, Name::Function
+        rule %r/[^:\(\s]+/, Name::Function
 
-        rule /(\s+)/, Text, :pop!
+        rule %r/(\s+)/, Text, :pop!
       end
 
       state :function_call do
-        rule /\b(#{functions_string.join('|')})\$(?=\s*[:(])/, Name::Function, :function
-        rule /\b(#{functions_array.join('|')})#(?=\s*[:(])/,   Name::Function, :function
-        rule /\b(#{functions_numeric.join('|')})(?=\s*[:(])/,  Name::Function, :function
+        rule %r/\b(#{functions_string.join('|')})\$(?=\s*[:(])/, Name::Function, :function
+        rule %r/\b(#{functions_array.join('|')})#(?=\s*[:(])/,   Name::Function, :function
+        rule %r/\b(#{functions_numeric.join('|')})(?=\s*[:(])/,  Name::Function, :function
       end
 
       state :function do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /(?::|\s*\()/ do
+        rule %r/(?::|\s*\()/ do
           token Text
           pop!
           push :comma_list
@@ -210,140 +210,140 @@ module Rouge
       end
 
       state :comma_list do
-        rule /(\s*\n\s*)(\.{3})/ do
+        rule %r/(\s*\n\s*)(\.{3})/ do
           groups Text, Punctuation
         end
 
-        rule /\s*[\])\n]/, Text, :pop!
+        rule %r/\s*[\])\n]/, Text, :pop!
 
-        rule /\s+/, Text
-        rule /"/,   Literal::String, :string
-        rule /\b(if|then|else|fi|endif)\b/, Keyword
+        rule %r/\s+/, Text
+        rule %r/"/,   Literal::String, :string
+        rule %r/\b(if|then|else|fi|endif)\b/, Keyword
 
         mixin :function_call
         mixin :variable_name
         mixin :operator
         mixin :number
 
-        rule /[()]/, Text
-        rule /,/, Punctuation
+        rule %r/[()]/, Text
+        rule %r/,/, Punctuation
       end
 
       state :old_arguments do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
 
         mixin :variable_name
         mixin :operator
         mixin :number
 
-        rule /"/, Literal::String, :string
-        rule /[^\n]/, Text
+        rule %r/"/, Literal::String, :string
+        rule %r/[^\n]/, Text
       end
 
       state :number do
-        rule /\n/, Text, :pop!
-        rule /\b\d+(\.\d*)?([eE][-+]?\d+)?%?/, Literal::Number
+        rule %r/\n/, Text, :pop!
+        rule %r/\b\d+(\.\d*)?([eE][-+]?\d+)?%?/, Literal::Number
       end
 
       state :variable_name do
         mixin :operator
         mixin :number
 
-        rule /\b(?:#{variables_string.join('|')})\$/,  Name::Builtin
-        rule /\b(?:#{variables_numeric.join('|')})(?!\$)\b/, Name::Builtin
+        rule %r/\b(?:#{variables_string.join('|')})\$/,  Name::Builtin
+        rule %r/\b(?:#{variables_numeric.join('|')})(?!\$)\b/, Name::Builtin
 
-        rule /\b(Object|#{objects.join('|')})_/ do
+        rule %r/\b(Object|#{objects.join('|')})_/ do
           token Name::Builtin
           push :object_reference
         end
 
-        rule /\.?[a-z][a-zA-Z0-9_.]*(\$|#)?/, Text
-        rule /[\[\]]/, Text, :comma_list
+        rule %r/\.?[a-z][a-zA-Z0-9_.]*(\$|#)?/, Text
+        rule %r/[\[\]]/, Text, :comma_list
         mixin :string_interpolated
       end
 
       state :object_reference do
         mixin :string_interpolated
-        rule /([a-z][a-zA-Z0-9_]*|\d+)/, Name::Builtin
+        rule %r/([a-z][a-zA-Z0-9_]*|\d+)/, Name::Builtin
 
-        rule /\.(#{object_attributes.join('|')})\b/, Name::Builtin, :pop!
+        rule %r/\.(#{object_attributes.join('|')})\b/, Name::Builtin, :pop!
 
-        rule /\$/, Name::Builtin
-        rule /\[/, Text, :pop!
+        rule %r/\$/, Name::Builtin
+        rule %r/\[/, Text, :pop!
       end
 
       state :operator do
         # This rule incorrectly matches === or +++++, which are not operators
-        rule /([+\/*<>=!-]=?|[&*|][&*|]?|\^|<>)/,       Operator
-        rule /(?<![\w.])(and|or|not|div|mod)(?![\w.])/, Operator::Word
+        rule %r/([+\/*<>=!-]=?|[&*|][&*|]?|\^|<>)/,       Operator
+        rule %r/(?<![\w.])(and|or|not|div|mod)(?![\w.])/, Operator::Word
       end
 
       state :string_interpolated do
-        rule /'[\._a-z][^\[\]'":]*(\[([\d,]+|"[\w\d,]+")\])?(:[0-9]+)?'/, Literal::String::Interpol
+        rule %r/'[\._a-z][^\[\]'":]*(\[([\d,]+|"[\w\d,]+")\])?(:[0-9]+)?'/, Literal::String::Interpol
       end
 
       state :string_unquoted do
-        rule /\n\s*\.{3}/, Punctuation
-        rule /\n/,         Text, :pop!
-        rule /\s/,         Text
+        rule %r/\n\s*\.{3}/, Punctuation
+        rule %r/\n/,         Text, :pop!
+        rule %r/\s/,         Text
 
         mixin :string_interpolated
 
-        rule /'/,          Literal::String
-        rule /[^'\n]+/,    Literal::String
+        rule %r/'/,          Literal::String
+        rule %r/[^'\n]+/,    Literal::String
       end
 
       state :string do
-        rule /\n\s*\.{3}/, Punctuation
-        rule /"/,          Literal::String,           :pop!
+        rule %r/\n\s*\.{3}/, Punctuation
+        rule %r/"/,          Literal::String,           :pop!
 
         mixin :string_interpolated
 
-        rule /'/,          Literal::String
-        rule /[^'"\n]+/,   Literal::String
+        rule %r/'/,          Literal::String
+        rule %r/[^'"\n]+/,   Literal::String
       end
 
       state :old_form do
-        rule /(\s+)(#.*?$)/ do
+        rule %r/(\s+)(#.*?$)/ do
           groups Text, Comment::Single
         end
 
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
-        rule /(optionmenu|choice)([ \t]+\S+:[ \t]+)/ do
+        rule %r/(optionmenu|choice)([ \t]+\S+:[ \t]+)/ do
           groups Keyword, Text
           push :number
         end
 
-        rule /(option|button)([ \t]+)/ do
+        rule %r/(option|button)([ \t]+)/ do
           groups Keyword, Text
           push :string_unquoted
         end
 
-        rule /(sentence|text)([ \t]+\S+)/ do
+        rule %r/(sentence|text)([ \t]+\S+)/ do
           groups Keyword, Text
           push :string_unquoted
         end
 
-        rule /(word)([ \t]+\S+[ \t]*)(\S+)?([ \t]+.*)?/ do
+        rule %r/(word)([ \t]+\S+[ \t]*)(\S+)?([ \t]+.*)?/ do
           groups Keyword, Text, Literal::String, Text
         end
 
-        rule /(boolean)(\s+\S+\s*)(0|1|"?(?:yes|no)"?)/ do
+        rule %r/(boolean)(\s+\S+\s*)(0|1|"?(?:yes|no)"?)/ do
           groups Keyword, Text, Name::Variable
         end
 
-        rule /(real|natural|positive|integer)([ \t]+\S+[ \t]*)([+-]?)/ do
+        rule %r/(real|natural|positive|integer)([ \t]+\S+[ \t]*)([+-]?)/ do
           groups Keyword, Text, Operator
           push :number
         end
 
-        rule /(comment)(\s+)/ do
+        rule %r/(comment)(\s+)/ do
           groups Keyword, Text
           push :string_unquoted
         end
 
-        rule /\bendform\b/, Keyword, :pop!
+        rule %r/\bendform\b/, Keyword, :pop!
       end
 
     end

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -15,7 +15,7 @@ module Rouge
         rule %r/\s+/, Text
         rule %r/^#.*/, Comment::Single
         rule %r/%.*/, Comment::Single
-        rule %r/\/\*/, Comment::Multiline, :nested_comment
+        rule %r(/\*), Comment::Multiline, :nested_comment
 
         rule %r/[\[\](){}|.,;!]/, Punctuation
         rule %r/:-|-->/, Punctuation
@@ -52,9 +52,9 @@ module Rouge
       end
 
       state :nested_comment do
-        rule %r/\/\*/, Comment::Multiline, :push
+        rule %r(/\*), Comment::Multiline, :push
         rule %r/\s*\*[^*\/]+/, Comment::Multiline
-        rule %r/\*\//, Comment::Multiline, :pop!
+        rule %r(\*/), Comment::Multiline, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -12,36 +12,36 @@ module Rouge
       mimetypes 'text/x-prolog'
 
       state :basic do
-        rule /\s+/, Text
-        rule /^#.*/, Comment::Single
-        rule /%.*/, Comment::Single
-        rule /\/\*/, Comment::Multiline, :nested_comment
+        rule %r/\s+/, Text
+        rule %r/^#.*/, Comment::Single
+        rule %r/%.*/, Comment::Single
+        rule %r/\/\*/, Comment::Multiline, :nested_comment
 
-        rule /[\[\](){}|.,;!]/, Punctuation
-        rule /:-|-->/, Punctuation
+        rule %r/[\[\](){}|.,;!]/, Punctuation
+        rule %r/:-|-->/, Punctuation
 
-        rule /"[^"]*"/, Str::Double
+        rule %r/"[^"]*"/, Str::Double
 
-        rule /\d+\.\d+/, Num::Float
-        rule /\d+/, Num
+        rule %r/\d+\.\d+/, Num::Float
+        rule %r/\d+/, Num
       end
 
       state :atoms do
-        rule /[[:lower:]]([_[:word:][:digit:]])*/, Str::Symbol
-        rule /'[^']*'/, Str::Symbol
+        rule %r/[[:lower:]]([_[:word:][:digit:]])*/, Str::Symbol
+        rule %r/'[^']*'/, Str::Symbol
       end
 
       state :operators do
-        rule /(<|>|=<|>=|==|=:=|=|\/|\/\/|\*|\+|-)(?=\s|[a-zA-Z0-9\[])/,
+        rule %r/(<|>|=<|>=|==|=:=|=|\/|\/\/|\*|\+|-)(?=\s|[a-zA-Z0-9\[])/,
           Operator
-        rule /is/, Operator
-        rule /(mod|div|not)/, Operator
-        rule /[#&*+-.\/:<=>?@^~]+/, Operator
+        rule %r/is/, Operator
+        rule %r/(mod|div|not)/, Operator
+        rule %r/[#&*+-.\/:<=>?@^~]+/, Operator
       end
 
       state :variables do
-        rule /[A-Z]+\w*/, Name::Variable
-        rule /_[[:word:]]*/, Name::Variable
+        rule %r/[A-Z]+\w*/, Name::Variable
+        rule %r/_[[:word:]]*/, Name::Variable
       end
 
       state :root do
@@ -52,9 +52,9 @@ module Rouge
       end
 
       state :nested_comment do
-        rule /\/\*/, Comment::Multiline, :push
-        rule /\s*\*[^*\/]+/, Comment::Multiline
-        rule /\*\//, Comment::Multiline, :pop!
+        rule %r/\/\*/, Comment::Multiline, :push
+        rule %r/\s*\*[^*\/]+/, Comment::Multiline
+        rule %r/\*\//, Comment::Multiline, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/prometheus.rb
+++ b/lib/rouge/lexers/prometheus.rb
@@ -26,21 +26,21 @@ module Rouge
         mixin :strings
         mixin :whitespace
 
-        rule /-?\d+\.\d+/, Num::Float
-        rule /-?\d+[smhdwy]?/, Num::Integer
+        rule %r/-?\d+\.\d+/, Num::Float
+        rule %r/-?\d+[smhdwy]?/, Num::Integer
 
         mixin :operators
 
-        rule /(ignoring|on)(\()/ do
+        rule %r/(ignoring|on)(\()/ do
           groups Keyword::Pseudo, Punctuation
           push :label_list
         end
-        rule /(group_left|group_right)(\()/ do
+        rule %r/(group_left|group_right)(\()/ do
           groups Keyword::Type, Punctuation
         end
-        rule /(bool|offset)\b/, Keyword
-        rule /(without|by)\b/, Keyword, :label_list
-        rule /[\w:]+/ do |m|
+        rule %r/(bool|offset)\b/, Keyword
+        rule %r/(without|by)\b/, Keyword, :label_list
+        rule %r/[\w:]+/ do |m|
           if self.class.functions.include?(m[0])
             token Name::Builtin
           else
@@ -52,17 +52,17 @@ module Rouge
       end
 
       state :metrics do
-        rule /[a-zA-Z0-9_-]+/, Name
+        rule %r/[a-zA-Z0-9_-]+/, Name
 
-        rule /[\(\)\]:.,]/, Punctuation
-        rule /\{/, Punctuation, :filters
-        rule /\[/, Punctuation
+        rule %r/[\(\)\]:.,]/, Punctuation
+        rule %r/\{/, Punctuation, :filters
+        rule %r/\[/, Punctuation
       end
 
       state :strings do
-        rule /"/, Str::Double, :double_string_escaped
-        rule /'/, Str::Single, :single_string_escaped
-        rule /`.*`/, Str::Backtick
+        rule %r/"/, Str::Double, :double_string_escaped
+        rule %r/'/, Str::Single, :single_string_escaped
+        rule %r/`.*`/, Str::Backtick
       end
 
       [
@@ -70,52 +70,52 @@ module Rouge
         [:single, Str::Single, "'"]
       ].each do |name, tok, fin|
         state :"#{name}_string_escaped" do
-          rule /\\[\\abfnrtv#{fin}]/, Str::Escape
-          rule /[^\\#{fin}]+/m, tok
-          rule /#{fin}/, tok, :pop!
+          rule %r/\\[\\abfnrtv#{fin}]/, Str::Escape
+          rule %r/[^\\#{fin}]+/m, tok
+          rule %r/#{fin}/, tok, :pop!
         end
       end
 
       state :filters do
         mixin :inline_whitespace
-        rule /,/, Punctuation
+        rule %r/,/, Punctuation
         mixin :labels
         mixin :filter_matching_operators
         mixin :strings
-        rule /}/, Punctuation, :pop!
+        rule %r/}/, Punctuation, :pop!
       end
 
       state :label_list do
-        rule /\(/, Punctuation
-        rule /[a-zA-Z0-9_:-]+/, Name::Attribute
-        rule /,/, Punctuation
+        rule %r/\(/, Punctuation
+        rule %r/[a-zA-Z0-9_:-]+/, Name::Attribute
+        rule %r/,/, Punctuation
         mixin :whitespace
-        rule /\)/, Punctuation, :pop!
+        rule %r/\)/, Punctuation, :pop!
       end
 
       state :labels do
-        rule /[a-zA-Z0-9_:-]+/, Name::Attribute
+        rule %r/[a-zA-Z0-9_:-]+/, Name::Attribute
       end
 
       state :operators do
         rule %r([+\-\*/%\^]), Operator  # Arithmetic
         rule %r(=|==|!=|<|>|<=|>=), Operator # Comparison
-        rule /and|or|unless/, Operator # Logical/Set
-        rule /(sum|min|max|avg|stddev|stdvar|count|count_values|bottomk|topk)\b/, Name::Function
+        rule %r/and|or|unless/, Operator # Logical/Set
+        rule %r/(sum|min|max|avg|stddev|stdvar|count|count_values|bottomk|topk)\b/, Name::Function
       end
 
       state :filter_matching_operators do
-        rule /!(=|~)|=~?/, Operator
+        rule %r/!(=|~)|=~?/, Operator
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
+        rule %r/[ \t\r]+/, Text
       end
 
       state :whitespace do
         mixin :inline_whitespace
-        rule /\n\s*/m, Text
-        rule /#.*?$/, Comment
+        rule %r/\n\s*/m, Text
+        rule %r/#.*?$/, Comment
       end
     end
   end

--- a/lib/rouge/lexers/properties.rb
+++ b/lib/rouge/lexers/properties.rb
@@ -14,38 +14,38 @@ module Rouge
       identifier = /[\w.-]+/
 
       state :basic do
-        rule /[!#].*?\n/, Comment
-        rule /\s+/, Text
-        rule /\\\n/, Str::Escape
+        rule %r/[!#].*?\n/, Comment
+        rule %r/\s+/, Text
+        rule %r/\\\n/, Str::Escape
       end
 
       state :root do
         mixin :basic
 
-        rule /(#{identifier})(\s*)([=:])/ do
+        rule %r/(#{identifier})(\s*)([=:])/ do
           groups Name::Property, Text, Punctuation
           push :value
         end
       end
 
       state :value do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         mixin :basic
-        rule /"/, Str, :dq
-        rule /'.*?'/, Str
+        rule %r/"/, Str, :dq
+        rule %r/'.*?'/, Str
         mixin :esc_str
-        rule /[^\\\n]+/, Str
+        rule %r/[^\\\n]+/, Str
       end
 
       state :dq do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         mixin :esc_str
-        rule /[^\\"]+/m, Str
+        rule %r/[^\\"]+/m, Str
       end
 
       state :esc_str do
-        rule /\\u[0-9]{4}/, Str::Escape
-        rule /\\./m, Str::Escape
+        rule %r/\\u[0-9]{4}/, Str::Escape
+        rule %r/\\./m, Str::Escape
       end
     end
   end

--- a/lib/rouge/lexers/protobuf.rb
+++ b/lib/rouge/lexers/protobuf.rb
@@ -15,55 +15,55 @@ module Rouge
       datatype = /\b(bool|bytes|double|fixed32|fixed64|float|int32|int64|sfixed32|sfixed64|sint32|sint64|string|uint32|uint64)\b/
 
       state :root do
-        rule /[\s]+/, Text
-        rule /[,;{}\[\]()]/, Punctuation
-        rule /\/(\\\n)?\/(\n|(.|\n)*?[^\\]\n)/, Comment::Single
-        rule /\/(\\\n)?\*(.|\n)*?\*(\\\n)?\//, Comment::Multiline
+        rule %r/[\s]+/, Text
+        rule %r/[,;{}\[\]()]/, Punctuation
+        rule %r/\/(\\\n)?\/(\n|(.|\n)*?[^\\]\n)/, Comment::Single
+        rule %r/\/(\\\n)?\*(.|\n)*?\*(\\\n)?\//, Comment::Multiline
         rule kw, Keyword
         rule datatype, Keyword::Type
-        rule /true|false/, Keyword::Constant
-        rule /(package)(\s+)/ do
+        rule %r/true|false/, Keyword::Constant
+        rule %r/(package)(\s+)/ do
           groups Keyword::Namespace, Text
           push :package
         end
 
-        rule /(message|extend)(\s+)/ do
+        rule %r/(message|extend)(\s+)/ do
           groups Keyword::Declaration, Text
           push :message
         end
 
-        rule /(enum|group|service)(\s+)/ do
+        rule %r/(enum|group|service)(\s+)/ do
           groups Keyword::Declaration, Text
           push :type
         end
 
-        rule /".*?"/, Str
-        rule /'.*?'/, Str
-        rule /(\d+\.\d*|\.\d+|\d+)[eE][+-]?\d+[LlUu]*/, Num::Float
-        rule /(\d+\.\d*|\.\d+|\d+[fF])[fF]?/, Num::Float
-        rule /(\-?(inf|nan))\b/, Num::Float
-        rule /0x[0-9a-fA-F]+[LlUu]*/, Num::Hex
-        rule /0[0-7]+[LlUu]*/, Num::Oct
-        rule /\d+[LlUu]*/, Num::Integer
-        rule /[+-=]/, Operator
-        rule /([a-zA-Z_][\w.]*)([ \t]*)(=)/ do
+        rule %r/".*?"/, Str
+        rule %r/'.*?'/, Str
+        rule %r/(\d+\.\d*|\.\d+|\d+)[eE][+-]?\d+[LlUu]*/, Num::Float
+        rule %r/(\d+\.\d*|\.\d+|\d+[fF])[fF]?/, Num::Float
+        rule %r/(\-?(inf|nan))\b/, Num::Float
+        rule %r/0x[0-9a-fA-F]+[LlUu]*/, Num::Hex
+        rule %r/0[0-7]+[LlUu]*/, Num::Oct
+        rule %r/\d+[LlUu]*/, Num::Integer
+        rule %r/[+-=]/, Operator
+        rule %r/([a-zA-Z_][\w.]*)([ \t]*)(=)/ do
           groups Name::Attribute, Text, Operator
         end
-        rule /[a-zA-Z_][\w.]*/, Name
+        rule %r/[a-zA-Z_][\w.]*/, Name
       end
 
       state :package do
-        rule /[a-zA-Z_]\w*/, Name::Namespace, :pop!
+        rule %r/[a-zA-Z_]\w*/, Name::Namespace, :pop!
         rule(//) { pop! }
       end
 
       state :message do
-        rule /[a-zA-Z_]\w*/, Name::Class, :pop!
+        rule %r/[a-zA-Z_]\w*/, Name::Class, :pop!
         rule(//) { pop! }
       end
 
       state :type do
-        rule /[a-zA-Z_]\w*/, Name, :pop!
+        rule %r/[a-zA-Z_]\w*/, Name, :pop!
         rule(//) { pop! }
       end
     end

--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -39,15 +39,15 @@ module Rouge
       qualname = /(::)?(#{id}::)*\w+/
 
       state :whitespace do
-        rule /\s+/m, Text
-        rule /#.*?\n/, Comment
+        rule %r/\s+/m, Text
+        rule %r/#.*?\n/, Comment
       end
 
       state :root do
         mixin :whitespace
 
-        rule /[$]#{qualname}/, Name::Variable
-        rule /(#{id})(?=\s*[=+]>)/m do |m|
+        rule %r/[$]#{qualname}/, Name::Variable
+        rule %r/(#{id})(?=\s*[=+]>)/m do |m|
           if self.class.metaparameters.include? m[0]
             token Keyword::Pseudo
           else
@@ -55,31 +55,31 @@ module Rouge
           end
         end
 
-        rule /(#{qualname})(?=\s*[(])/m, Name::Function
+        rule %r/(#{qualname})(?=\s*[(])/m, Name::Function
         rule cap_id, Name::Class
 
-        rule /[+=|~-]>|<[|~-]/, Punctuation
-        rule /[:}();\[\]]/, Punctuation
+        rule %r/[+=|~-]>|<[|~-]/, Punctuation
+        rule %r/[:}();\[\]]/, Punctuation
 
         # HACK for case statements and selectors
-        rule /{/, Punctuation, :regex_allowed
-        rule /,/, Punctuation, :regex_allowed
+        rule %r/{/, Punctuation, :regex_allowed
+        rule %r/,/, Punctuation, :regex_allowed
 
-        rule /(in|and|or)\b/, Operator::Word
-        rule /[=!<>]=/, Operator
-        rule /[=!]~/, Operator, :regex_allowed
+        rule %r/(in|and|or)\b/, Operator::Word
+        rule %r/[=!<>]=/, Operator
+        rule %r/[=!]~/, Operator, :regex_allowed
         rule %r([=<>!+*/-]), Operator
 
-        rule /(class|include)(\s*)(#{qualname})/ do
+        rule %r/(class|include)(\s*)(#{qualname})/ do
           groups Keyword, Text, Name::Class
         end
 
-        rule /node\b/, Keyword, :regex_allowed
+        rule %r/node\b/, Keyword, :regex_allowed
 
-        rule /'(\\[\\']|[^'])*'/m, Str::Single
-        rule /"/, Str::Double, :dquotes
+        rule %r/'(\\[\\']|[^'])*'/m, Str::Single
+        rule %r/"/, Str::Double, :dquotes
 
-        rule /\d+([.]\d+)?(e[+-]\d+)?/, Num
+        rule %r/\d+([.]\d+)?(e[+-]\d+)?/, Num
 
         # a valid regex.  TODO: regexes are only allowed
         # in certain places in puppet.
@@ -103,26 +103,26 @@ module Rouge
 
       state :regex do
         rule %r(/), Str::Regex, :pop!
-        rule /\\./, Str::Escape
-        rule /[(){}]/, Str::Interpol
-        rule /\[/, Str::Interpol, :regex_class
-        rule /./, Str::Regex
+        rule %r/\\./, Str::Escape
+        rule %r/[(){}]/, Str::Interpol
+        rule %r/\[/, Str::Interpol, :regex_class
+        rule %r/./, Str::Regex
       end
 
       state :regex_class do
-        rule /\]/, Str::Interpol, :pop!
-        rule /(?<!\[)-(?=\])/, Str::Regex
-        rule /-/, Str::Interpol
-        rule /\\./, Str::Escape
-        rule /[^\\\]-]+/, Str::Regex
+        rule %r/\]/, Str::Interpol, :pop!
+        rule %r/(?<!\[)-(?=\])/, Str::Regex
+        rule %r/-/, Str::Interpol
+        rule %r/\\./, Str::Escape
+        rule %r/[^\\\]-]+/, Str::Regex
       end
 
       state :dquotes do
-        rule /"/, Str::Double, :pop!
-        rule /[^$\\"]+/m, Str::Double
-        rule /\\./m, Str::Escape
-        rule /[$]#{qualname}/, Name::Variable
-        rule /[$][{]#{qualname}[}]/, Name::Variable
+        rule %r/"/, Str::Double, :pop!
+        rule %r/[^$\\"]+/m, Str::Double
+        rule %r/\\./m, Str::Escape
+        rule %r/[$]#{qualname}/, Name::Variable
+        rule %r/[$][{]#{qualname}[}]/, Name::Variable
       end
     end
   end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -69,23 +69,23 @@ module Rouge
       identifier =        /[a-z_][a-z0-9_]*/i
       dotted_identifier = /[a-z_.][a-z0-9_.]*/i
       state :root do
-        rule /\n+/m, Text
-        rule /^(:)(\s*)([ru]{,2}""".*?""")/mi do
+        rule %r/\n+/m, Text
+        rule %r/^(:)(\s*)([ru]{,2}""".*?""")/mi do
           groups Punctuation, Text, Str::Doc
         end
 
-        rule /[^\S\n]+/, Text
+        rule %r/[^\S\n]+/, Text
         rule %r(#(.*)?\n?), Comment::Single
-        rule /[\[\]{}:(),;]/, Punctuation
-        rule /\\\n/, Text
-        rule /\\/, Text
+        rule %r/[\[\]{}:(),;]/, Punctuation
+        rule %r/\\\n/, Text
+        rule %r/\\/, Text
 
-        rule /(in|is|and|or|not)\b/, Operator::Word
-        rule /(<<|>>|\/\/|\*\*)=?/, Operator
-        rule /[-~+\/*%=<>&^|@]=?|!=/, Operator
-        rule /\.(?![0-9])/, Operator  # so it doesn't match float literals
+        rule %r/(in|is|and|or|not)\b/, Operator::Word
+        rule %r/(<<|>>|\/\/|\*\*)=?/, Operator
+        rule %r/[-~+\/*%=<>&^|@]=?|!=/, Operator
+        rule %r/\.(?![0-9])/, Operator  # so it doesn't match float literals
 
-        rule /(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(import)/ do
+        rule %r/(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(import)/ do
           groups Keyword::Namespace,
                  Text,
                  Name::Namespace,
@@ -93,35 +93,35 @@ module Rouge
                  Keyword::Namespace
         end
 
-        rule /(import)(\s+)(#{dotted_identifier})/ do
+        rule %r/(import)(\s+)(#{dotted_identifier})/ do
           groups Keyword::Namespace, Text, Name::Namespace
         end
 
-        rule /(def)((?:\s|\\\s)+)/ do
+        rule %r/(def)((?:\s|\\\s)+)/ do
           groups Keyword, Text
           push :funcname
         end
 
-        rule /(class)((?:\s|\\\s)+)/ do
+        rule %r/(class)((?:\s|\\\s)+)/ do
           groups Keyword, Text
           push :classname
         end
 
         # TODO: not in python 3
-        rule /`.*?`/, Str::Backtick
-        rule /(?:r|ur|ru)"""/i, Str, :raw_tdqs
-        rule /(?:r|ur|ru)'''/i, Str, :raw_tsqs
-        rule /(?:r|ur|ru)"/i,   Str, :raw_dqs
-        rule /(?:r|ur|ru)'/i,   Str, :raw_sqs
-        rule /u?"""/i,          Str, :tdqs
-        rule /u?'''/i,          Str, :tsqs
-        rule /u?"/i,            Str, :dqs
-        rule /u?'/i,            Str, :sqs
+        rule %r/`.*?`/, Str::Backtick
+        rule %r/(?:r|ur|ru)"""/i, Str, :raw_tdqs
+        rule %r/(?:r|ur|ru)'''/i, Str, :raw_tsqs
+        rule %r/(?:r|ur|ru)"/i,   Str, :raw_dqs
+        rule %r/(?:r|ur|ru)'/i,   Str, :raw_sqs
+        rule %r/u?"""/i,          Str, :tdqs
+        rule %r/u?'''/i,          Str, :tsqs
+        rule %r/u?"/i,            Str, :dqs
+        rule %r/u?'/i,            Str, :sqs
 
-        rule /@#{dotted_identifier}/i, Name::Decorator
+        rule %r/@#{dotted_identifier}/i, Name::Decorator
 
         # using negative lookbehind so we don't match property names
-        rule /(?<!\.)#{identifier}/ do |m|
+        rule %r/(?<!\.)#{identifier}/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           elsif self.class.exceptions.include? m[0]
@@ -140,15 +140,15 @@ module Rouge
         digits = /[0-9](_?[0-9])*/
         decimal = /((#{digits})?\.#{digits}|#{digits}\.)/
         exponent = /e[+-]?#{digits}/i
-        rule /#{decimal}(#{exponent})?j?/i, Num::Float
-        rule /#{digits}#{exponent}j?/i, Num::Float
-        rule /#{digits}j/i, Num::Float
+        rule %r/#{decimal}(#{exponent})?j?/i, Num::Float
+        rule %r/#{digits}#{exponent}j?/i, Num::Float
+        rule %r/#{digits}j/i, Num::Float
 
-        rule /0b(_?[0-1])+/i, Num::Bin
-        rule /0o(_?[0-7])+/i, Num::Oct
-        rule /0x(_?[a-f0-9])+/i, Num::Hex
-        rule /\d+L/, Num::Integer::Long
-        rule /([1-9](_?[0-9])*|0(_?0)*)/, Num::Integer
+        rule %r/0b(_?[0-1])+/i, Num::Bin
+        rule %r/0o(_?[0-7])+/i, Num::Oct
+        rule %r/0x(_?[a-f0-9])+/i, Num::Hex
+        rule %r/\d+L/, Num::Integer::Long
+        rule %r/([1-9](_?[0-9])*|0(_?0)*)/, Num::Integer
       end
 
       state :funcname do
@@ -160,11 +160,11 @@ module Rouge
       end
 
       state :raise do
-        rule /from\b/, Keyword
-        rule /raise\b/, Keyword
-        rule /yield\b/, Keyword
-        rule /\n/, Text, :pop!
-        rule /;/, Punctuation, :pop!
+        rule %r/from\b/, Keyword
+        rule %r/raise\b/, Keyword
+        rule %r/yield\b/, Keyword
+        rule %r/\n/, Text, :pop!
+        rule %r/;/, Punctuation, :pop!
         mixin :root
       end
 
@@ -173,21 +173,21 @@ module Rouge
       end
 
       state :strings do
-        rule /%(\([a-z0-9_]+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/i, Str::Interpol
+        rule %r/%(\([a-z0-9_]+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/i, Str::Interpol
       end
 
       state :strings_double do
-        rule /[^\\"%\n]+/, Str
+        rule %r/[^\\"%\n]+/, Str
         mixin :strings
       end
 
       state :strings_single do
-        rule /[^\\'%\n]+/, Str
+        rule %r/[^\\'%\n]+/, Str
         mixin :strings
       end
 
       state :nl do
-        rule /\n/, Str
+        rule %r/\n/, Str
       end
 
       state :escape do
@@ -204,32 +204,32 @@ module Rouge
       end
 
       state :raw_escape do
-        rule /\\./, Str
+        rule %r/\\./, Str
       end
 
       state :dqs do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         mixin :escape
         mixin :strings_double
       end
 
       state :sqs do
-        rule /'/, Str, :pop!
+        rule %r/'/, Str, :pop!
         mixin :escape
         mixin :strings_single
       end
 
       state :tdqs do
-        rule /"""/, Str, :pop!
-        rule /"/, Str
+        rule %r/"""/, Str, :pop!
+        rule %r/"/, Str
         mixin :escape
         mixin :strings_double
         mixin :nl
       end
 
       state :tsqs do
-        rule /'''/, Str, :pop!
-        rule /'/, Str
+        rule %r/'''/, Str, :pop!
+        rule %r/'/, Str
         mixin :escape
         mixin :strings_single
         mixin :nl

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)
-        return true if text.shebang?(/pythonw?(3|2(\.\d)?)?/)
+        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?/)
       end
 
       def self.keywords

--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -36,23 +36,23 @@ module Rouge
 
       state :root do
         # q allows a file to start with a shebang
-        rule /#!(.*?)$/, Comment::Preproc, :top
-        rule //, Text, :top
+        rule %r/#!(.*?)$/, Comment::Preproc, :top
+        rule %r//, Text, :top
       end
 
       state :top do
         # indented lines at the top of the file are ignored by q
-        rule /^[ \t\r]+.*$/, Comment::Special
-        rule /\n+/, Text
-        rule //, Text, :base
+        rule %r/^[ \t\r]+.*$/, Comment::Special
+        rule %r/\n+/, Text
+        rule %r//, Text, :base
       end
 
       state :base do
-        rule /\n+/m, Text
+        rule %r/\n+/m, Text
         rule(/^.\)/, Keyword::Declaration)
 
         # Identifiers, word operators, etc.
-        rule /#{identifier}/ do |m|
+        rule %r/#{identifier}/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           elsif self.class.word_operators.include? m[0]
@@ -102,7 +102,7 @@ module Rouge
         rule(%r{(`:[:a-z0-9._\/]*|`(?:[a-z0-9.][:a-z0-9._]*)?)}i, Str::Symbol)
         rule(/(?:<=|>=|<>|::)|[?:$%&|@._#*^\-+~,!><=]:?/, Operator)
 
-        rule /[{}\[\]();]/, Punctuation
+        rule %r/[{}\[\]();]/, Punctuation
 
         # commands
         rule(/\\.*\n/, Text)
@@ -111,13 +111,13 @@ module Rouge
 
       state :string do
         rule(/"/, Str, :pop!)
-        rule /\\([\\nr]|[01][0-7]{2})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/\\([\\nr]|[01][0-7]{2})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\/, Str # stray backslash
       end
 
       state :bottom do
-        rule /.*\z/m, Comment::Multiline
+        rule %r/.*\z/m, Comment::Multiline
       end
     end
   end

--- a/lib/rouge/lexers/qml.rb
+++ b/lib/rouge/lexers/qml.rb
@@ -17,57 +17,57 @@ module Rouge
       id_with_dots = /[$a-zA-Z_][a-zA-Z0-9_.]*/
 
       prepend :root do
-        rule /(#{id_with_dots})(\s*)({)/ do
+        rule %r/(#{id_with_dots})(\s*)({)/ do
           groups Keyword::Type, Text, Punctuation
           push :type_block
         end
-        rule /(#{id_with_dots})(\s+)(on)(\s+)(#{id_with_dots})(\s*)({)/ do
+        rule %r/(#{id_with_dots})(\s+)(on)(\s+)(#{id_with_dots})(\s*)({)/ do
           groups Keyword::Type, Text, Keyword, Text, Name::Label, Text, Punctuation
           push :type_block
         end
 
-        rule /[{]/, Punctuation, :push
+        rule %r/[{]/, Punctuation, :push
       end
 
       state :type_block do
-        rule /(id)(\s*)(:)(\s*)(#{id_with_dots})/ do
+        rule %r/(id)(\s*)(:)(\s*)(#{id_with_dots})/ do
           groups Name::Label, Text, Punctuation, Text, Keyword::Declaration
         end
 
-        rule /(#{id_with_dots})(\s*)(:)/ do
+        rule %r/(#{id_with_dots})(\s*)(:)/ do
           groups Name::Label, Text, Punctuation
           push :expr_start
         end
 
-        rule /(signal)(\s+)(#{id_with_dots})/ do
+        rule %r/(signal)(\s+)(#{id_with_dots})/ do
           groups Keyword::Declaration, Text, Name::Label
           push :signal
         end
 
-        rule /(property)(\s+)(#{id_with_dots})(\s+)(#{id_with_dots})(\s*)(:?)/ do
+        rule %r/(property)(\s+)(#{id_with_dots})(\s+)(#{id_with_dots})(\s*)(:?)/ do
           groups Keyword::Declaration, Text, Keyword::Type, Text, Name::Label, Text, Punctuation
           push :expr_start
         end
 
-        rule /[}]/, Punctuation, :pop!
+        rule %r/[}]/, Punctuation, :pop!
         mixin :root
       end
 
       state :signal do
         mixin :comments_and_whitespace
-        rule /\(/ do
+        rule %r/\(/ do
           token Punctuation
           goto :signal_args
         end
-        rule //, Text, :pop!
+        rule %r//, Text, :pop!
       end
 
       state :signal_args do
         mixin :comments_and_whitespace
-        rule /(#{id_with_dots})(\s+)(#{id_with_dots})(\s*)(,?)/ do
+        rule %r/(#{id_with_dots})(\s+)(#{id_with_dots})(\s*)(,?)/ do
           groups Keyword::Type, Text, Name, Text, Punctuation
         end
-        rule /\)/ , Punctuation, :pop!
+        rule %r/\)/ , Punctuation, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -49,27 +49,27 @@ module Rouge
       end
 
       state :root do
-        rule /#'.*?$/, Comment::Doc
-        rule /#.*?$/, Comment::Single
-        rule /\s+/m, Text::Whitespace
+        rule %r/#'.*?$/, Comment::Doc
+        rule %r/#.*?$/, Comment::Single
+        rule %r/\s+/m, Text::Whitespace
 
-        rule /`[^`]+?`/, Name
-        rule /'(\\.|.)*?'/m, Str::Single
-        rule /"(\\.|.)*?"/m, Str::Double
+        rule %r/`[^`]+?`/, Name
+        rule %r/'(\\.|.)*?'/m, Str::Single
+        rule %r/"(\\.|.)*?"/m, Str::Double
 
-        rule /%[^%]*?%/, Operator
+        rule %r/%[^%]*?%/, Operator
 
-        rule /0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
-        rule /[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
+        rule %r/0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
+        rule %r/[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
           Num
 
         # Only recognize built-in functions when they are actually used as a
         # function call, i.e. followed by an opening parenthesis.
         # `Name::Builtin` would be more logical, but is usually not
         # highlighted specifically; thus use `Name::Function`.
-        rule /\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
+        rule %r/\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
 
-        rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
+        rule %r/[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
           elsif KEYWORD_CONSTANTS.include? m[0]
@@ -81,7 +81,7 @@ module Rouge
           end
         end
 
-        rule /[\[\]{}();,]/, Punctuation
+        rule %r/[\[\]{}();,]/, Punctuation
 
         rule %r([-<>?*+^/!=~$@:%&|]), Operator
       end

--- a/lib/rouge/lexers/racket.rb
+++ b/lib/rouge/lexers/racket.rb
@@ -487,39 +487,39 @@ module Rouge
 
       state :root do
         # comments
-        rule /;.*$/, Comment::Single
-        rule /\s+/m, Text
+        rule %r/;.*$/, Comment::Single
+        rule %r/\s+/m, Text
 
-        rule /[+-]inf[.][f0]/, Num::Float
-        rule /[+-]nan[.]0/, Num::Float
-        rule /[-]min[.]0/, Num::Float
-        rule /[+]max[.]0/, Num::Float
+        rule %r/[+-]inf[.][f0]/, Num::Float
+        rule %r/[+-]nan[.]0/, Num::Float
+        rule %r/[-]min[.]0/, Num::Float
+        rule %r/[+]max[.]0/, Num::Float
 
-        rule /-?\d+\.\d+/, Num::Float
-        rule /-?\d+/, Num::Integer
+        rule %r/-?\d+\.\d+/, Num::Float
+        rule %r/-?\d+/, Num::Integer
 
-        rule /#:#{id}+/, Name::Tag  # keyword
+        rule %r/#:#{id}+/, Name::Tag  # keyword
 
-        rule /#b[01]+/, Num::Bin
-        rule /#o[0-7]+/, Num::Oct
-        rule /#d[0-9]+/, Num::Integer
-        rule /#x[0-9a-f]+/i, Num::Hex
-        rule /#[ei][\d.]+/, Num::Other
+        rule %r/#b[01]+/, Num::Bin
+        rule %r/#o[0-7]+/, Num::Oct
+        rule %r/#d[0-9]+/, Num::Integer
+        rule %r/#x[0-9a-f]+/i, Num::Hex
+        rule %r/#[ei][\d.]+/, Num::Other
 
-        rule /"(\\\\|\\"|[^"])*"/, Str
-        rule /['`]#{id}/i, Str::Symbol
-        rule /#\\([()\/'"._!\$%& ?=+-]{1}|[a-z0-9]+)/i,
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
+        rule %r/['`]#{id}/i, Str::Symbol
+        rule %r/#\\([()\/'"._!\$%& ?=+-]{1}|[a-z0-9]+)/i,
           Str::Char
-        rule /#t|#f/, Name::Constant
-        rule /(?:'|#|`|,@|,|\.)/, Operator
+        rule %r/#t|#f/, Name::Constant
+        rule %r/(?:'|#|`|,@|,|\.)/, Operator
 
-        rule /(['#])(\s*)(\()/m do
+        rule %r/(['#])(\s*)(\()/m do
           groups Str::Symbol, Text, Punctuation
         end
 
         # () [] {} are all permitted as like pairs
-        rule /\(|\[|\{/, Punctuation, :command
-        rule /\)|\]|\}/, Punctuation
+        rule %r/\(|\[|\{/, Punctuation, :command
+        rule %r/\)|\]|\}/, Punctuation
 
         rule id, Name::Variable
       end

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -31,15 +31,15 @@ module Rouge
         rule %r(:(?:\*\*|[-+]@|[/\%&\|^`~]|\[\]=?|<<|>>|<=?>|<=?|===?)),
           Str::Symbol
 
-        rule /:'(\\\\|\\'|[^'])*'/, Str::Symbol
-        rule /:"/, Str::Symbol, :simple_sym
+        rule %r/:'(\\\\|\\'|[^'])*'/, Str::Symbol
+        rule %r/:"/, Str::Symbol, :simple_sym
       end
 
       state :sigil_strings do
         # %-sigiled strings
         # %(abc), %[abc], %<abc>, %.abc., %r.abc., etc
         delimiter_map = { '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
-        rule /%([rqswQWxiI])?([^\w\s])/ do |m|
+        rule %r/%([rqswQWxiI])?([^\w\s])/ do |m|
           open = Regexp.escape(m[2])
           close = Regexp.escape(delimiter_map[m[2]] || m[2])
           interp = /[rQWxI]/ === m[1]
@@ -57,38 +57,38 @@ module Rouge
           token toktype
 
           push do
-            rule /\\[##{open}#{close}\\]/, Str::Escape
+            rule %r/\\[##{open}#{close}\\]/, Str::Escape
             # nesting rules only with asymmetric delimiters
             if open != close
-              rule /#{open}/ do
+              rule %r/#{open}/ do
                 token toktype
                 push
               end
             end
-            rule /#{close}/, toktype, :pop!
+            rule %r/#{close}/, toktype, :pop!
 
             if interp
               mixin :string_intp_escaped
-              rule /#/, toktype
+              rule %r/#/, toktype
             else
-              rule /[\\#]/, toktype
+              rule %r/[\\#]/, toktype
             end
 
-            rule /[^##{open}#{close}\\]+/m, toktype
+            rule %r/[^##{open}#{close}\\]+/m, toktype
           end
         end
       end
 
       state :strings do
         mixin :symbols
-        rule /\b[a-z_]\w*?[?!]?:\s+/, Str::Symbol, :expr_start
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
-        rule /"/, Str::Double, :simple_string
-        rule /(?<!\.)`/, Str::Backtick, :simple_backtick
+        rule %r/\b[a-z_]\w*?[?!]?:\s+/, Str::Symbol, :expr_start
+        rule %r/'(\\\\|\\'|[^'])*'/, Str::Single
+        rule %r/"/, Str::Double, :simple_string
+        rule %r/(?<!\.)`/, Str::Backtick, :simple_backtick
       end
 
       state :regex_flags do
-        rule /[mixounse]*/, Str::Regex, :pop!
+        rule %r/[mixounse]*/, Str::Regex, :pop!
       end
 
       # double-quoted string and symbol
@@ -97,9 +97,9 @@ module Rouge
        [:backtick, Str::Backtick, '`']].each do |name, tok, fin|
         state :"simple_#{name}" do
           mixin :string_intp_escaped
-          rule /[^\\#{fin}#]+/m, tok
-          rule /[\\#]/, tok
-          rule /#{fin}/, tok, :pop!
+          rule %r/[^\\#{fin}#]+/m, tok
+          rule %r/[\\#]/, tok
+          rule %r/#{fin}/, tok, :pop!
         end
       end
 
@@ -151,38 +151,38 @@ module Rouge
 
       state :whitespace do
         mixin :inline_whitespace
-        rule /\n\s*/m, Text, :expr_start
-        rule /#.*$/, Comment::Single
+        rule %r/\n\s*/m, Text, :expr_start
+        rule %r/#.*$/, Comment::Single
 
         rule %r(=begin\b.*?\n=end\b)m, Comment::Multiline
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
+        rule %r/[ \t\r]+/, Text
       end
 
       state :root do
         mixin :whitespace
-        rule /__END__/, Comment::Preproc, :end_part
+        rule %r/__END__/, Comment::Preproc, :end_part
 
-        rule /0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
-        rule /0b[01]+(?:_[01]+)*/, Num::Bin
-        rule /\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
-        rule /[\d]+(?:_\d+)*/, Num::Integer
+        rule %r/0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
+        rule %r/0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
+        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
+        rule %r/\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
+        rule %r/[\d]+(?:_\d+)*/, Num::Integer
 
         # names
-        rule /@@[a-z_]\w*/i, Name::Variable::Class
-        rule /@[a-z_]\w*/i, Name::Variable::Instance
-        rule /\$\w+/, Name::Variable::Global
+        rule %r/@@[a-z_]\w*/i, Name::Variable::Class
+        rule %r/@[a-z_]\w*/i, Name::Variable::Instance
+        rule %r/\$\w+/, Name::Variable::Global
         rule %r(\$[!@&`'+~=/\\,;.<>_*\$?:"]), Name::Variable::Global
-        rule /\$-[0adFiIlpvw]/, Name::Variable::Global
-        rule /::/, Operator
+        rule %r/\$-[0adFiIlpvw]/, Name::Variable::Global
+        rule %r/::/, Operator
 
         mixin :strings
 
-        rule /(?:#{keywords.join('|')})\b/, Keyword, :expr_start
-        rule /(?:#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo, :expr_start
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword, :expr_start
+        rule %r/(?:#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo, :expr_start
 
         rule %r(
           (module)
@@ -192,52 +192,52 @@ module Rouge
           groups Keyword, Text, Name::Namespace
         end
 
-        rule /(def\b)(\s*)/ do
+        rule %r/(def\b)(\s*)/ do
           groups Keyword, Text
           push :funcname
         end
 
-        rule /(class\b)(\s*)/ do
+        rule %r/(class\b)(\s*)/ do
           groups Keyword, Text
           push :classname
         end
 
-        rule /(?:#{builtins_q.join('|')})[?]/, Name::Builtin, :expr_start
-        rule /(?:#{builtins_b.join('|')})!/,  Name::Builtin, :expr_start
-        rule /(?<!\.)(?:#{builtins_g.join('|')})\b/,
+        rule %r/(?:#{builtins_q.join('|')})[?]/, Name::Builtin, :expr_start
+        rule %r/(?:#{builtins_b.join('|')})!/,  Name::Builtin, :expr_start
+        rule %r/(?<!\.)(?:#{builtins_g.join('|')})\b/,
           Name::Builtin, :method_call
 
         mixin :has_heredocs
 
         # `..` and `...` for ranges must have higher priority than `.`
         # Otherwise, they will be parsed as :method_call
-        rule /\.{2,3}/, Operator, :expr_start
+        rule %r/\.{2,3}/, Operator, :expr_start
 
-        rule /[A-Z][a-zA-Z0-9_]*/, Name::Constant, :method_call
-        rule /(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
+        rule %r/[A-Z][a-zA-Z0-9_]*/, Name::Constant, :method_call
+        rule %r/(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
           groups Punctuation, Text, Name::Function
           push :method_call
         end
 
-        rule /[a-zA-Z_]\w*[?!]/, Name, :expr_start
-        rule /[a-zA-Z_]\w*/, Name, :method_call
-        rule /\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
+        rule %r/[a-zA-Z_]\w*[?!]/, Name, :expr_start
+        rule %r/[a-zA-Z_]\w*/, Name, :method_call
+        rule %r/\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
-        rule /[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
+        rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
         rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }
         rule %r<[\[({,:\\;/]>, Punctuation, :expr_start
         rule %r<[\])}]>, Punctuation
       end
 
       state :has_heredocs do
-        rule /(?<!\w)(<<[-~]?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
+        rule %r/(?<!\w)(<<[-~]?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
           @heredoc_queue << [['<<-', '<<~'].include?(m[1]), m[3]]
           push :heredoc_queue unless state? :heredoc_queue
         end
 
-        rule /(<<[-~]?)(["'])(\2)/ do |m|
+        rule %r/(<<[-~]?)(["'])(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
           @heredoc_queue << [['<<-', '<<~'].include?(m[1]), '']
@@ -246,7 +246,7 @@ module Rouge
       end
 
       state :heredoc_queue do
-        rule /(?=\n)/ do
+        rule %r/(?=\n)/ do
           goto :resolve_heredocs
         end
 
@@ -256,13 +256,13 @@ module Rouge
       state :resolve_heredocs do
         mixin :string_intp_escaped
 
-        rule /\n/, Str::Heredoc, :test_heredoc
-        rule /[#\\\n]/, Str::Heredoc
-        rule /[^#\\\n]+/, Str::Heredoc
+        rule %r/\n/, Str::Heredoc, :test_heredoc
+        rule %r/[#\\\n]/, Str::Heredoc
+        rule %r/[^#\\\n]+/, Str::Heredoc
       end
 
       state :test_heredoc do
-        rule /[^#\\\n]*$/ do |m|
+        rule %r/[^#\\\n]*$/ do |m|
           tolerant, heredoc_name = @heredoc_queue.first
           check = tolerant ? m[0].strip : m[0].rstrip
 
@@ -284,8 +284,8 @@ module Rouge
       end
 
       state :funcname do
-        rule /\s+/, Text
-        rule /\(/, Punctuation, :defexpr
+        rule %r/\s+/, Text
+        rule %r/\(/, Punctuation, :defexpr
         rule %r(
           (?:([a-zA-Z_][\w_]*)(\.))?
           (
@@ -303,20 +303,20 @@ module Rouge
       end
 
       state :classname do
-        rule /\s+/, Text
-        rule /\(/ do
+        rule %r/\s+/, Text
+        rule %r/\(/ do
           token Punctuation
           push :defexpr
           push :expr_start
         end
 
         # class << expr
-        rule /<</ do
+        rule %r/<</ do
           token Operator
           goto :expr_start
         end
 
-        rule /[A-Z_]\w*/, Name::Class, :pop!
+        rule %r/[A-Z_]\w*/, Name::Class, :pop!
 
         rule(//) { pop! }
       end
@@ -328,11 +328,11 @@ module Rouge
       end
 
       state :defexpr do
-        rule /(\))(\.|::)?/ do
+        rule %r/(\))(\.|::)?/ do
           groups Punctuation, Operator
           pop!
         end
-        rule /\(/ do
+        rule %r/\(/ do
           token Punctuation
           push :defexpr
           push :expr_start
@@ -342,20 +342,20 @@ module Rouge
       end
 
       state :in_interp do
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
         mixin :root
       end
 
       state :string_intp do
-        rule /[#][{]/, Str::Interpol, :in_interp
-        rule /#(@@?|\$)[a-z_]\w*/i, Str::Interpol
+        rule %r/[#][{]/, Str::Interpol, :in_interp
+        rule %r/#(@@?|\$)[a-z_]\w*/i, Str::Interpol
       end
 
       state :string_intp_escaped do
         mixin :string_intp
-        rule /\\([\\abefnrstv#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})/,
+        rule %r/\\([\\abefnrstv#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})/,
           Str::Escape
-        rule /\\./, Str::Escape
+        rule %r/\\./, Str::Escape
       end
 
       state :method_call do
@@ -408,7 +408,7 @@ module Rouge
 
         # special case for using a single space.  Ruby demands that
         # these be in a single line, otherwise it would make no sense.
-        rule /(\s*)(%[rqswQWxiI]? \S* )/ do
+        rule %r/(\s*)(%[rqswQWxiI]? \S* )/ do
           groups Text, Str::Other
           pop!
         end
@@ -432,7 +432,7 @@ module Rouge
 
       state :end_part do
         # eat up the rest of the stream as Comment::Preproc
-        rule /.+/m, Comment::Preproc, :pop!
+        rule %r/.+/m, Comment::Preproc, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -62,51 +62,51 @@ module Rouge
 
       state :start_line do
         mixin :whitespace
-        rule /\s+/, Text
-        rule /#\[/ do
+        rule %r/\s+/, Text
+        rule %r/#\[/ do
           token Name::Decorator; push :attribute
         end
         rule(//) { pop! }
-        rule /#\s[^\n]*/, Comment::Preproc
+        rule %r/#\s[^\n]*/, Comment::Preproc
       end
 
       state :attribute do
         mixin :whitespace
         mixin :has_literals
-        rule /[(,)=]/, Name::Decorator
-        rule /\]/, Name::Decorator, :pop!
+        rule %r/[(,)=]/, Name::Decorator
+        rule %r/\]/, Name::Decorator, :pop!
         rule id, Name::Decorator
       end
 
       state :whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//[^\n]*), Comment
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end
 
       state :root do
-        rule /\n/, Text, :start_line
+        rule %r/\n/, Text, :start_line
         mixin :whitespace
-        rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
+        rule %r/\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals
 
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
-        rule /[()\[\]{}|,:;]/, Punctuation
-        rule /[*!@~&+%^<>=-\?]|\.{2,3}/, Operator
+        rule %r/[()\[\]{}|,:;]/, Punctuation
+        rule %r/[*!@~&+%^<>=-\?]|\.{2,3}/, Operator
 
-        rule /([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
-        rule /[.]\s*#{id}/, Name::Property
-        rule /(#{id})(::)/m do
+        rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
+        rule %r/[.]\s*#{id}/, Name::Property
+        rule %r/(#{id})(::)/m do
           groups Name::Namespace, Punctuation
         end
 
         # macros
-        rule /\bmacro_rules!/, Name::Decorator, :macro_rules
-        rule /#{id}!/, Name::Decorator, :macro
+        rule %r/\bmacro_rules!/, Name::Decorator, :macro_rules
+        rule %r/#{id}!/, Name::Decorator, :macro
 
-        rule /'#{id}/, Name::Variable
-        rule /#{id}/ do |m|
+        rule %r/'#{id}/, Name::Variable
+        rule %r/#{id}/ do |m|
           name = m[0]
           if self.class.builtins.include? name
             token Name::Builtin
@@ -119,13 +119,13 @@ module Rouge
       state :macro do
         mixin :has_literals
 
-        rule /[\[{(]/ do |m|
+        rule %r/[\[{(]/ do |m|
           @macro_delims[delim_map[m[0]]] += 1
           puts "    macro_delims: #{@macro_delims.inspect}" if @debug
           token Punctuation
         end
 
-        rule /[\]})]/ do |m|
+        rule %r/[\]})]/ do |m|
           @macro_delims[m[0]] -= 1
           puts "    macro_delims: #{@macro_delims.inspect}" if @debug
           pop! if macro_closed?
@@ -133,29 +133,29 @@ module Rouge
         end
 
         # same as the rule in root, but don't push another macro state
-        rule /#{id}!/, Name::Decorator
+        rule %r/#{id}!/, Name::Decorator
         mixin :root
 
         # No syntax errors in macros
-        rule /./, Text
+        rule %r/./, Text
       end
 
       state :macro_rules do
-        rule /[$]#{id}(:#{id})?/, Name::Variable
-        rule /[$]/, Name::Variable
+        rule %r/[$]#{id}(:#{id})?/, Name::Variable
+        rule %r/[$]/, Name::Variable
 
         mixin :macro
       end
 
       state :has_literals do
         # constants
-        rule /\b(?:true|false|nil)\b/, Keyword::Constant
+        rule %r/\b(?:true|false|nil)\b/, Keyword::Constant
         # characters
         rule %r(
           ' (?: #{escapes} | [^\\] ) '
         )x, Str::Char
 
-        rule /"/, Str, :string
+        rule %r/"/, Str, :string
 
         # numbers
         dot = /[.][0-9_]+/
@@ -180,9 +180,9 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         rule escapes, Str::Escape
-        rule /%%/, Str::Interpol
+        rule %r/%%/, Str::Interpol
         rule %r(
           %
           ( [0-9]+ [$] )?  # Parameter
@@ -191,7 +191,7 @@ module Rouge
           ( [.] [0-9]+ )?  # Precision
           [bcdfiostuxX?]   # Type
         )x, Str::Interpol
-        rule /[^%"\\]+/m, Str
+        rule %r/[^%"\\]+/m, Str
       end
     end
   end

--- a/lib/rouge/lexers/sass.rb
+++ b/lib/rouge/lexers/sass.rb
@@ -18,7 +18,7 @@ module Rouge
       id = /[\w-]+/
 
       state :root do
-        rule /[ \t]*\n/, Text
+        rule %r/[ \t]*\n/, Text
         rule(/[ \t]*/) { |m| token Text; indentation(m[0]) }
       end
 
@@ -34,14 +34,14 @@ module Rouge
           pop!; starts_block :multi_comment
         end
 
-        rule /@import\b/, Keyword, :import
+        rule %r/@import\b/, Keyword, :import
 
         mixin :content_common
 
         rule %r(=#{id}), Name::Function, :value
         rule %r([+]#{id}), Name::Decorator, :value
 
-        rule /:/, Name::Attribute, :old_style_attr
+        rule %r/:/, Name::Attribute, :old_style_attr
 
         rule(/(?=[^\[\n]+?:([^a-z]|$))/) { push :attribute }
 
@@ -49,17 +49,17 @@ module Rouge
       end
 
       state :single_comment do
-        rule /.*?$/, Comment::Single, :pop!
+        rule %r/.*?$/, Comment::Single, :pop!
       end
 
       state :multi_comment do
-        rule /.*?\n/, Comment::Multiline, :pop!
+        rule %r/.*?\n/, Comment::Multiline, :pop!
       end
 
       state :import do
-        rule /[ \t]+/, Text
-        rule /\S+/, Str
-        rule /\n/, Text, :pop!
+        rule %r/[ \t]+/, Text
+        rule %r/\S+/, Str
+        rule %r/\n/, Text, :pop!
       end
 
       state :old_style_attr do

--- a/lib/rouge/lexers/sass/common.rb
+++ b/lib/rouge/lexers/sass/common.rb
@@ -8,30 +8,30 @@ module Rouge
       id = /[\w-]+/
 
       state :content_common do
-        rule /@for\b/, Keyword, :for
-        rule /@(debug|warn|if|each|while|else|return|media)/, Keyword, :value
+        rule %r/@for\b/, Keyword, :for
+        rule %r/@(debug|warn|if|each|while|else|return|media)/, Keyword, :value
 
-        rule /(@mixin)(\s+)(#{id})/ do
+        rule %r/(@mixin)(\s+)(#{id})/ do
           groups Keyword, Text, Name::Function
           push :value
         end
 
-        rule /(@function)(\s+)(#{id})/ do
+        rule %r/(@function)(\s+)(#{id})/ do
           groups Keyword, Text, Name::Function
           push :value
         end
 
-        rule /@extend\b/, Keyword, :selector
+        rule %r/@extend\b/, Keyword, :selector
 
-        rule /(@include)(\s+)(#{id})/ do
+        rule %r/(@include)(\s+)(#{id})/ do
           groups Keyword, Text, Name::Decorator
           push :value
         end
 
-        rule /@#{id}/, Keyword, :selector
+        rule %r/@#{id}/, Keyword, :selector
 
         # $variable: assignment
-        rule /([$]#{id})([ \t]*)(:)/ do
+        rule %r/([$]#{id})([ \t]*)(:)/ do
           groups Name::Variable, Text, Punctuation
           push :value
         end
@@ -39,26 +39,26 @@ module Rouge
 
       state :value do
         mixin :end_section
-        rule /[ \t]+/, Text
-        rule /[$]#{id}/, Name::Variable
-        rule /url[(]/, Str::Other, :string_url
-        rule /#{id}(?=\s*[(])/, Name::Function
-        rule /%#{id}/, Name::Decorator
+        rule %r/[ \t]+/, Text
+        rule %r/[$]#{id}/, Name::Variable
+        rule %r/url[(]/, Str::Other, :string_url
+        rule %r/#{id}(?=\s*[(])/, Name::Function
+        rule %r/%#{id}/, Name::Decorator
 
         # named literals
-        rule /(true|false)\b/, Name::Builtin::Pseudo
-        rule /(and|or|not)\b/, Operator::Word
+        rule %r/(true|false)\b/, Name::Builtin::Pseudo
+        rule %r/(and|or|not)\b/, Operator::Word
 
         # colors and numbers
-        rule /#[a-z0-9]{1,6}/i, Num::Hex
-        rule /-?\d+(%|[a-z]+)?/, Num
-        rule /-?\d*\.\d+(%|[a-z]+)?/, Num::Integer
+        rule %r/#[a-z0-9]{1,6}/i, Num::Hex
+        rule %r/-?\d+(%|[a-z]+)?/, Num
+        rule %r/-?\d*\.\d+(%|[a-z]+)?/, Num::Integer
 
         mixin :has_strings
         mixin :has_interp
 
-        rule /[~^*!&%<>\|+=@:,.\/?-]+/, Operator
-        rule /[\[\]()]+/, Punctuation
+        rule %r/[~^*!&%<>\|+=@:,.\/?-]+/, Operator
+        rule %r/[\[\]()]+/, Punctuation
         rule %r(/[*]), Comment::Multiline, :inline_comment
         rule %r(//[^\n]*), Comment::Single
 
@@ -75,16 +75,16 @@ module Rouge
       end
 
       state :has_interp do
-        rule /[#][{]/, Str::Interpol, :interpolation
+        rule %r/[#][{]/, Str::Interpol, :interpolation
       end
 
       state :has_strings do
-        rule /"/, Str::Double, :dq
-        rule /'/, Str::Single, :sq
+        rule %r/"/, Str::Double, :dq
+        rule %r/'/, Str::Single, :sq
       end
 
       state :interpolation do
-        rule /}/, Str::Interpol, :pop!
+        rule %r/}/, Str::Interpol, :pop!
         mixin :value
       end
 
@@ -93,31 +93,31 @@ module Rouge
 
         mixin :has_strings
         mixin :has_interp
-        rule /[ \t]+/, Text
-        rule /:/, Name::Decorator, :pseudo_class
-        rule /[.]/, Name::Class, :class
-        rule /#/, Name::Namespace, :id
-        rule /%/, Name::Variable, :placeholder
+        rule %r/[ \t]+/, Text
+        rule %r/:/, Name::Decorator, :pseudo_class
+        rule %r/[.]/, Name::Class, :class
+        rule %r/#/, Name::Namespace, :id
+        rule %r/%/, Name::Variable, :placeholder
         rule id, Name::Tag
-        rule /&/, Keyword
-        rule /[~^*!&\[\]()<>\|+=@:;,.\/?-]/, Operator
+        rule %r/&/, Keyword
+        rule %r/[~^*!&\[\]()<>\|+=@:;,.\/?-]/, Operator
       end
 
       state :dq do
-        rule /"/, Str::Double, :pop!
+        rule %r/"/, Str::Double, :pop!
         mixin :has_interp
-        rule /(\\.|#(?![{])|[^\n"#])+/, Str::Double
+        rule %r/(\\.|#(?![{])|[^\n"#])+/, Str::Double
       end
 
       state :sq do
-        rule /'/, Str::Single, :pop!
+        rule %r/'/, Str::Single, :pop!
         mixin :has_interp
-        rule /(\\.|#(?![{])|[^\n'#])+/, Str::Single
+        rule %r/(\\.|#(?![{])|[^\n'#])+/, Str::Single
       end
 
       state :string_url do
-        rule /[)]/, Str::Other, :pop!
-        rule /(\\.|#(?![{])|[^\n)#])+/, Str::Other
+        rule %r/[)]/, Str::Other, :pop!
+        rule %r/(\\.|#(?![{])|[^\n)#])+/, Str::Other
         mixin :has_interp
       end
 
@@ -147,7 +147,7 @@ module Rouge
       end
 
       state :for do
-        rule /(from|to|through)/, Operator::Word
+        rule %r/(from|to|through)/, Operator::Word
         mixin :value
       end
 
@@ -165,14 +165,14 @@ module Rouge
       state :attribute do
         mixin :attr_common
 
-        rule /([ \t]*)(:)/ do
+        rule %r/([ \t]*)(:)/ do
           groups Text, Punctuation
           push :value
         end
       end
 
       state :inline_comment do
-        rule /(\\#|#(?=[^\n{])|\*(?=[^\n\/])|[^\n#*])+/, Comment::Multiline
+        rule %r/(\\#|#(?=[^\n{])|\*(?=[^\n\/])|[^\n#*])+/, Comment::Multiline
         mixin :has_interp
         rule %r([*]/), Comment::Multiline, :pop!
       end

--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -36,41 +36,41 @@ module Rouge
       )
 
       state :root do
-        rule /(class|trait|object)(\s+)/ do
+        rule %r/(class|trait|object)(\s+)/ do
           groups Keyword, Text
           push :class
         end
-        rule /'#{idrest}[^']/, Str::Symbol
-        rule /[^\S\n]+/, Text
+        rule %r/'#{idrest}[^']/, Str::Symbol
+        rule %r/[^\S\n]+/, Text
 
         rule %r(//.*?\n), Comment::Single
         rule %r(/\*), Comment::Multiline, :comment
 
-        rule /@#{idrest}/, Name::Decorator
+        rule %r/@#{idrest}/, Name::Decorator
 
-        rule /(def)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+        rule %r/(def)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
           groups Keyword, Text, Name::Function, Text
         end
 
-        rule /(val)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
+        rule %r/(val)(\s+)(#{idrest}|#{op}+|`[^`]+`)(\s*)/ do
           groups Keyword, Text, Name::Variable, Text
         end
 
-        rule /(this)(\n*)(\.)(#{idrest})/ do
+        rule %r/(this)(\n*)(\.)(#{idrest})/ do
           groups Keyword, Text, Operator, Name::Property
         end
 
-        rule /(#{idrest}|_)(\n*)(\.)(#{idrest})/ do
+        rule %r/(#{idrest}|_)(\n*)(\.)(#{idrest})/ do
           groups Name::Variable, Text, Operator, Name::Property
         end
 
-        rule /#{upper}#{idrest}\b/, Name::Class
+        rule %r/#{upper}#{idrest}\b/, Name::Class
 
-        rule /(#{idrest})(#{whitespace}*)(\()/ do
+        rule %r/(#{idrest})(#{whitespace}*)(\()/ do
           groups Name::Function, Text, Operator
         end
 
-        rule /(\.)(#{idrest})/ do
+        rule %r/(\.)(#{idrest})/ do
           groups Operator, Name::Property
         end
 
@@ -78,80 +78,80 @@ module Rouge
           (#{keywords.join("|")})\b|
           (<[%:-]|=>|>:|[#=@_\u21D2\u2190])(\b|(?=\s)|$)
         )x, Keyword
-        rule /:(?!#{op})/, Keyword, :type        
-        rule /(true|false|null)\b/, Keyword::Constant
-        rule /(import|package)(\s+)/ do
+        rule %r/:(?!#{op})/, Keyword, :type        
+        rule %r/(true|false|null)\b/, Keyword::Constant
+        rule %r/(import|package)(\s+)/ do
           groups Keyword, Text
           push :import
         end
 
-        rule /(type)(\s+)/ do
+        rule %r/(type)(\s+)/ do
           groups Keyword, Text
           push :type
         end
 
-        rule /""".*?"""(?!")/m, Str
-        rule /"(\\\\|\\"|[^"])*"/, Str
-        rule /'\\.'|'[^\\]'|'\\u[0-9a-fA-F]{4}'/, Str::Char
+        rule %r/""".*?"""(?!")/m, Str
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
+        rule %r/'\\.'|'[^\\]'|'\\u[0-9a-fA-F]{4}'/, Str::Char
 
         rule idrest, Name
-        rule /`[^`]+`/, Name
+        rule %r/`[^`]+`/, Name
 
-        rule /\[/, Operator, :typeparam
-        rule /[\(\)\{\};,.#]/, Operator
-        rule /#{op}+/, Operator
+        rule %r/\[/, Operator, :typeparam
+        rule %r/[\(\)\{\};,.#]/, Operator
+        rule %r/#{op}+/, Operator
 
-        rule /([0-9][0-9]*\.[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?[fFdD]?/, Num::Float
-        rule /([0-9][0-9]*[fFdD])/, Num::Float
-        rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /[0-9]+L?/, Num::Integer
-        rule /\n/, Text
+        rule %r/([0-9][0-9]*\.[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?[fFdD]?/, Num::Float
+        rule %r/([0-9][0-9]*[fFdD])/, Num::Float
+        rule %r/0x[0-9a-fA-F]+/, Num::Hex
+        rule %r/[0-9]+L?/, Num::Integer
+        rule %r/\n/, Text
       end
 
       state :class do
-        rule /(#{idrest}|#{op}+|`[^`]+`)(\s*)(\[)/ do
+        rule %r/(#{idrest}|#{op}+|`[^`]+`)(\s*)(\[)/ do
           groups Name::Class, Text, Operator
           push :typeparam
         end
 
-        rule /\s+/, Text
-        rule /{/, Operator, :pop!
-        rule /\(/, Operator, :pop!
+        rule %r/\s+/, Text
+        rule %r/{/, Operator, :pop!
+        rule %r/\(/, Operator, :pop!
         rule %r(//.*?\n), Comment::Single, :pop!
         rule %r(#{idrest}|#{op}+|`[^`]+`), Name::Class, :pop!
       end
 
       state :type do
-        rule /\s+/, Text
-        rule /<[%:]|>:|[#_\u21D2]|forSome|type/, Keyword
-        rule /([,\);}]|=>|=)(\s*)/ do
+        rule %r/\s+/, Text
+        rule %r/<[%:]|>:|[#_\u21D2]|forSome|type/, Keyword
+        rule %r/([,\);}]|=>|=)(\s*)/ do
           groups Operator, Text
           pop!
         end
-        rule /[\(\{]/, Operator, :type
+        rule %r/[\(\{]/, Operator, :type
 
         typechunk = /(?:#{idrest}|#{op}+\`[^`]+`)/
-        rule /(#{typechunk}(?:\.#{typechunk})*)(\s*)(\[)/ do
+        rule %r/(#{typechunk}(?:\.#{typechunk})*)(\s*)(\[)/ do
           groups Keyword::Type, Text, Operator
           pop!
           push :typeparam
         end
 
-        rule /(#{typechunk}(?:\.#{typechunk})*)(\s*)$/ do
+        rule %r/(#{typechunk}(?:\.#{typechunk})*)(\s*)$/ do
           groups Keyword::Type, Text
           pop!
         end
 
         rule %r(//.*?\n), Comment::Single, :pop!
-        rule /\.|#{idrest}|#{op}+|`[^`]+`/, Keyword::Type
+        rule %r/\.|#{idrest}|#{op}+|`[^`]+`/, Keyword::Type
       end
 
       state :typeparam do
-        rule /[\s,]+/, Text
-        rule /<[%:]|=>|>:|[#_\u21D2]|forSome|type/, Keyword
-        rule /([\]\)\}])/, Operator, :pop!
-        rule /[\(\[\{]/, Operator, :typeparam
-        rule /\.|#{idrest}|#{op}+|`[^`]+`/, Keyword::Type
+        rule %r/[\s,]+/, Text
+        rule %r/<[%:]|=>|>:|[#_\u21D2]|forSome|type/, Keyword
+        rule %r/([\]\)\}])/, Operator, :pop!
+        rule %r/[\(\[\{]/, Operator, :typeparam
+        rule %r/\.|#{idrest}|#{op}+|`[^`]+`/, Keyword::Type
       end
 
       state :comment do

--- a/lib/rouge/lexers/scheme.rb
+++ b/lib/rouge/lexers/scheme.rb
@@ -61,33 +61,33 @@ module Rouge
 
       state :root do
         # comments
-        rule /;.*$/, Comment::Single
-        rule /\s+/m, Text
-        rule /-?\d+\.\d+/, Num::Float
-        rule /-?\d+/, Num::Integer
+        rule %r/;.*$/, Comment::Single
+        rule %r/\s+/m, Text
+        rule %r/-?\d+\.\d+/, Num::Float
+        rule %r/-?\d+/, Num::Integer
 
         # Racket infinitites
-        rule /[+-]inf[.][f0]/, Num
+        rule %r/[+-]inf[.][f0]/, Num
 
-        rule /#b[01]+/, Num::Bin
-        rule /#o[0-7]+/, Num::Oct
-        rule /#d[0-9]+/, Num::Integer
-        rule /#x[0-9a-f]+/i, Num::Hex
-        rule /#[ei][\d.]+/, Num::Other
+        rule %r/#b[01]+/, Num::Bin
+        rule %r/#o[0-7]+/, Num::Oct
+        rule %r/#d[0-9]+/, Num::Integer
+        rule %r/#x[0-9a-f]+/i, Num::Hex
+        rule %r/#[ei][\d.]+/, Num::Other
 
-        rule /"(\\\\|\\"|[^"])*"/, Str
-        rule /'#{id}/i, Str::Symbol
-        rule /#\\([()\/'"._!\$%& ?=+-]{1}|[a-z0-9]+)/i,
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
+        rule %r/'#{id}/i, Str::Symbol
+        rule %r/#\\([()\/'"._!\$%& ?=+-]{1}|[a-z0-9]+)/i,
           Str::Char
-        rule /#t|#f/, Name::Constant
-        rule /(?:'|#|`|,@|,|\.)/, Operator
+        rule %r/#t|#f/, Name::Constant
+        rule %r/(?:'|#|`|,@|,|\.)/, Operator
 
-        rule /(['#])(\s*)(\()/m do
+        rule %r/(['#])(\s*)(\()/m do
           groups Str::Symbol, Text, Punctuation
         end
 
-        rule /\(|\[/, Punctuation, :command
-        rule /\)|\]/, Punctuation
+        rule %r/\(|\[/, Punctuation, :command
+        rule %r/\)|\]/, Punctuation
 
         rule id, Name::Variable
       end

--- a/lib/rouge/lexers/scss.rb
+++ b/lib/rouge/lexers/scss.rb
@@ -13,10 +13,10 @@ module Rouge
       mimetypes 'text/x-scss'
 
       state :root do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
-        rule /@import\b/, Keyword, :value
+        rule %r/@import\b/, Keyword, :value
 
         mixin :content_common
 
@@ -27,7 +27,7 @@ module Rouge
       end
 
       state :end_section do
-        rule /\n/, Text
+        rule %r/\n/, Text
         rule(/[;{}]/) { token Punctuation; reset_stack }
       end
     end

--- a/lib/rouge/lexers/sed.rb
+++ b/lib/rouge/lexers/sed.rb
@@ -17,15 +17,15 @@ module Rouge
 
       class Regex < RegexLexer
         state :root do
-          rule /\\./, Str::Escape
-          rule /\[/, Punctuation, :brackets
-          rule /[$^.*]/, Operator
-          rule /[()]/, Punctuation
-          rule /./, Str::Regex
+          rule %r/\\./, Str::Escape
+          rule %r/\[/, Punctuation, :brackets
+          rule %r/[$^.*]/, Operator
+          rule %r/[()]/, Punctuation
+          rule %r/./, Str::Regex
         end
 
         state :brackets do
-          rule /\^/ do
+          rule %r/\^/ do
             token Punctuation
             goto :brackets_int
           end
@@ -35,17 +35,17 @@ module Rouge
 
         state :brackets_int do
           # ranges
-          rule /.-./, Name::Variable
-          rule /\]/, Punctuation, :pop!
-          rule /./, Str::Regex
+          rule %r/.-./, Name::Variable
+          rule %r/\]/, Punctuation, :pop!
+          rule %r/./, Str::Regex
         end
       end
 
       class Replacement < RegexLexer
         state :root do
-          rule /\\./m, Str::Escape
-          rule /&/, Operator
-          rule /[^\\&]+/m, Text
+          rule %r/\\./m, Str::Escape
+          rule %r/&/, Operator
+          rule %r/[^\\&]+/m, Text
         end
       end
 
@@ -60,7 +60,7 @@ module Rouge
       start { regex.reset!; replacement.reset! }
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule(/#.*?\n/) { token Comment; reset_stack }
         rule(/\n/) { token Text; reset_stack }
         rule(/;/) { token Punctuation; reset_stack }
@@ -76,7 +76,7 @@ module Rouge
         mixin :whitespace
 
         # subst and transliteration
-        rule /(s)(.)(#{edot}*?)(\2)(#{edot}*?)(\2)/m do |m|
+        rule %r/(s)(.)(#{edot}*?)(\2)(#{edot}*?)(\2)/m do |m|
           token Keyword, m[1]
           token Punctuation, m[2]
           delegate regex, m[3]
@@ -88,7 +88,7 @@ module Rouge
           goto :flags
         end
 
-        rule /(y)(.)(#{edot}*?)(\2)(#{edot}*?)(\2)/m do |m|
+        rule %r/(y)(.)(#{edot}*?)(\2)(#{edot}*?)(\2)/m do |m|
           token Keyword, m[1]
           token Punctuation, m[2]
           delegate replacement, m[3]
@@ -100,29 +100,29 @@ module Rouge
         end
 
         # commands that take a text segment as an argument
-        rule /([aic])(\s*)/ do
+        rule %r/([aic])(\s*)/ do
           groups Keyword, Text; goto :text
         end
 
-        rule /[pd]/, Keyword
+        rule %r/[pd]/, Keyword
 
         # commands that take a number argument
-        rule /([qQl])(\s+)(\d+)/i do
+        rule %r/([qQl])(\s+)(\d+)/i do
           groups Keyword, Text, Num
           pop!
         end
 
         # no-argument commands
-        rule /[={}dDgGhHlnpPqx]/, Keyword, :pop!
+        rule %r/[={}dDgGhHlnpPqx]/, Keyword, :pop!
 
         # commands that take a filename argument
-        rule /([rRwW])(\s+)(\S+)/ do
+        rule %r/([rRwW])(\s+)(\S+)/ do
           groups Keyword, Text, Name
           pop!
         end
 
         # commands that take a label argument
-        rule /([:btT])(\s+)(\S+)/ do
+        rule %r/([:btT])(\s+)(\S+)/ do
           groups Keyword, Text, Name::Label
           pop!
         end
@@ -133,8 +133,8 @@ module Rouge
 
         ### address ranges ###
         addr_tok = Keyword::Namespace
-        rule /\d+/, addr_tok
-        rule /[$,~+!]/, addr_tok
+        rule %r/\d+/, addr_tok
+        rule %r/[$,~+!]/, addr_tok
 
         rule %r((/)((?:\\.|.)*?)(/)) do |m|
           token addr_tok, m[1]; delegate regex, m[2]; token addr_tok, m[3]
@@ -151,18 +151,18 @@ module Rouge
       end
 
       state :text do
-        rule /[^\\\n]+/, Str
-        rule /\\\n/, Str::Escape
-        rule /\\/, Str
-        rule /\n/, Text, :pop!
+        rule %r/[^\\\n]+/, Str
+        rule %r/\\\n/, Str::Escape
+        rule %r/\\/, Str
+        rule %r/\n/, Text, :pop!
       end
 
       state :flags do
-        rule /[gp]+/, Keyword, :pop!
+        rule %r/[gp]+/, Keyword, :pop!
 
         # writing to a file with the subst command.
         # who'da thunk...?
-        rule /([wW])(\s+)(\S+)/ do
+        rule %r/([wW])(\s+)(\S+)/ do
           token Keyword; token Text; token Name
         end
 

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -44,25 +44,25 @@ module Rouge
       ).join('|')
 
       state :basic do
-        rule /#.*$/, Comment
+        rule %r/#.*$/, Comment
 
-        rule /\b(#{KEYWORDS})\s*\b/, Keyword
-        rule /\bcase\b/, Keyword, :case
+        rule %r/\b(#{KEYWORDS})\s*\b/, Keyword
+        rule %r/\bcase\b/, Keyword, :case
 
-        rule /\b(#{BUILTINS})\s*\b(?!(\.|-))/, Name::Builtin
-        rule /[.](?=\s)/, Name::Builtin
+        rule %r/\b(#{BUILTINS})\s*\b(?!(\.|-))/, Name::Builtin
+        rule %r/[.](?=\s)/, Name::Builtin
 
-        rule /(\b\w+)(=)/ do |m|
+        rule %r/(\b\w+)(=)/ do |m|
           groups Name::Variable, Operator
         end
 
-        rule /[\[\]{}()!=>]/, Operator
-        rule /&&|\|\|/, Operator
+        rule %r/[\[\]{}()!=>]/, Operator
+        rule %r/&&|\|\|/, Operator
 
         # here-string
-        rule /<<</, Operator
+        rule %r/<<</, Operator
 
-        rule /(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
+        rule %r/(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
           groups Operator, Text, Str::Heredoc, Str::Heredoc, Name::Constant, Str::Heredoc
           @heredocstr = Regexp.escape(m[5])
           push :heredoc
@@ -70,14 +70,14 @@ module Rouge
       end
 
       state :heredoc do
-        rule /\n/, Str::Heredoc, :heredoc_nl
-        rule /[^$\n]+/, Str::Heredoc
+        rule %r/\n/, Str::Heredoc, :heredoc_nl
+        rule %r/[^$\n]+/, Str::Heredoc
         mixin :interp
-        rule /[$]/, Str::Heredoc
+        rule %r/[$]/, Str::Heredoc
       end
 
       state :heredoc_nl do
-        rule /\s*(\w+)\s*\n/ do |m|
+        rule %r/\s*(\w+)\s*\n/ do |m|
           if m[1] == @heredocstr
             token Name::Constant
             pop! 2
@@ -93,92 +93,92 @@ module Rouge
       state :double_quotes do
         # NB: "abc$" is literally the string abc$.
         # Here we prevent :interp from interpreting $" as a variable.
-        rule /(?:\$#?)?"/, Str::Double, :pop!
+        rule %r/(?:\$#?)?"/, Str::Double, :pop!
         mixin :interp
-        rule /[^"`\\$]+/, Str::Double
+        rule %r/[^"`\\$]+/, Str::Double
       end
 
       state :ansi_string do
-        rule /\\./, Str::Escape
-        rule /[^\\']+/, Str::Single
+        rule %r/\\./, Str::Escape
+        rule %r/[^\\']+/, Str::Single
         mixin :single_quotes
       end
 
       state :single_quotes do
-        rule /'/, Str::Single, :pop!
-        rule /[^']+/, Str::Single
+        rule %r/'/, Str::Single, :pop!
+        rule %r/[^']+/, Str::Single
       end
 
       state :data do
-        rule /\s+/, Text
-        rule /\\./, Str::Escape
-        rule /\$?"/, Str::Double, :double_quotes
-        rule /\$'/, Str::Single, :ansi_string
+        rule %r/\s+/, Text
+        rule %r/\\./, Str::Escape
+        rule %r/\$?"/, Str::Double, :double_quotes
+        rule %r/\$'/, Str::Single, :ansi_string
 
         # single quotes are much easier than double quotes - we can
         # literally just scan until the next single quote.
         # POSIX: Enclosing characters in single-quotes ( '' )
         # shall preserve the literal value of each character within the
         # single-quotes. A single-quote cannot occur within single-quotes.
-        rule /'/, Str::Single, :single_quotes
+        rule %r/'/, Str::Single, :single_quotes
 
-        rule /\*/, Keyword
+        rule %r/\*/, Keyword
 
-        rule /;/, Punctuation
+        rule %r/;/, Punctuation
 
-        rule /--?[\w-]+/, Name::Tag
-        rule /[^=\*\s{}()$"'`;\\<]+/, Text
-        rule /\d+(?= |\Z)/, Num
-        rule /</, Text
+        rule %r/--?[\w-]+/, Name::Tag
+        rule %r/[^=\*\s{}()$"'`;\\<]+/, Text
+        rule %r/\d+(?= |\Z)/, Num
+        rule %r/</, Text
         mixin :interp
       end
 
       state :curly do
-        rule /}/, Keyword, :pop!
-        rule /:-/, Keyword
-        rule /[a-zA-Z0-9_]+/, Name::Variable
-        rule /[^}:"`'$]+/, Punctuation
+        rule %r/}/, Keyword, :pop!
+        rule %r/:-/, Keyword
+        rule %r/[a-zA-Z0-9_]+/, Name::Variable
+        rule %r/[^}:"`'$]+/, Punctuation
         mixin :root
       end
 
       state :paren do
-        rule /\)/, Keyword, :pop!
+        rule %r/\)/, Keyword, :pop!
         mixin :root
       end
 
       state :math do
-        rule /\)\)/, Keyword, :pop!
+        rule %r/\)\)/, Keyword, :pop!
         rule %r([-+*/%^|&!]|\*\*|\|\|), Operator
-        rule /\d+(#\w+)?/, Num
+        rule %r/\d+(#\w+)?/, Num
         mixin :root
       end
 
       state :case do
-        rule /\besac\b/, Keyword, :pop!
-        rule /\|/, Punctuation
-        rule /\)/, Punctuation, :case_stanza
+        rule %r/\besac\b/, Keyword, :pop!
+        rule %r/\|/, Punctuation
+        rule %r/\)/, Punctuation, :case_stanza
         mixin :root
       end
 
       state :case_stanza do
-        rule /;;/, Punctuation, :pop!
+        rule %r/;;/, Punctuation, :pop!
         mixin :root
       end
 
       state :backticks do
-        rule /`/, Str::Backtick, :pop!
+        rule %r/`/, Str::Backtick, :pop!
         mixin :root
       end
 
       state :interp do
-        rule /\\$/, Str::Escape # line continuation
-        rule /\\./, Str::Escape
-        rule /\$\(\(/, Keyword, :math
-        rule /\$\(/, Keyword, :paren
-        rule /\${#?/, Keyword, :curly
-        rule /`/, Str::Backtick, :backticks
-        rule /\$#?(\w+|.)/, Name::Variable
-        rule /\$[*@]/, Name::Variable
+        rule %r/\\$/, Str::Escape # line continuation
+        rule %r/\\./, Str::Escape
+        rule %r/\$\(\(/, Keyword, :math
+        rule %r/\$\(/, Keyword, :paren
+        rule %r/\${#?/, Keyword, :curly
+        rule %r/`/, Str::Backtick, :backticks
+        rule %r/\$#?(\w+|.)/, Name::Variable
+        rule %r/\$[*@]/, Name::Variable
       end
 
       state :root do

--- a/lib/rouge/lexers/sieve.rb
+++ b/lib/rouge/lexers/sieve.rb
@@ -57,23 +57,23 @@ module Rouge
       end
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
+        rule %r/\s+/, Text
         rule %r(#.*?\n), Comment::Single
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end
 
       state :string do
-        rule /\\./, Str::Escape
-        rule /"/, Str::Double, :pop!
+        rule %r/\\./, Str::Escape
+        rule %r/"/, Str::Double, :pop!
         # Variables Extension (rfc5229)
-        rule /\${(?:[0-9][.0-9]*|[a-zA-Z_][.a-zA-Z0-9_]*)}/, Str::Interpol
-        rule /./, Str::Double
+        rule %r/\${(?:[0-9][.0-9]*|[a-zA-Z_][.a-zA-Z0-9_]*)}/, Str::Interpol
+        rule %r/./, Str::Double
       end
 
       state :root do
         mixin :comments_and_whitespace
 
-        rule /[\[\](),;{}]/, Punctuation
+        rule %r/[\[\](),;{}]/, Punctuation
 
         rule id do |m|
           if self.class.controls.include? m[0]
@@ -89,8 +89,8 @@ module Rouge
           end
         end
 
-        rule /"/, Str::Double, :string
-        rule /[0-9]+[KMG]/, Num::Integer
+        rule %r/"/, Str::Double, :string
+        rule %r/[0-9]+[KMG]/, Num::Integer
       end
     end
   end

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -45,22 +45,22 @@ module Rouge
       start { ruby.reset!; html.reset! }
 
       state :root do
-        rule /\s*\n/, Text
+        rule %r/\s*\n/, Text
         rule(/\s*/) { |m| token Text; indentation(m[0]) }
       end
 
       state :content do
         mixin :css
 
-        rule /\/#{dot}*/, Comment, :indented_block
+        rule %r/\/#{dot}*/, Comment, :indented_block
 
-        rule /(doctype)(\s+)(.*)/ do
+        rule %r/(doctype)(\s+)(.*)/ do
           groups Name::Namespace, Text::Whitespace, Text
           pop!
         end
 
         # filters, shamelessly ripped from HAML
-        rule /(\w*):\s*\n/ do |m|
+        rule %r/(\w*):\s*\n/ do |m|
           token Name::Decorator
           pop!
           starts_block :filter_block
@@ -81,29 +81,29 @@ module Rouge
           goto :plain_block
         end
 
-        rule /-|==|=/, Punctuation, :ruby_line
+        rule %r/-|==|=/, Punctuation, :ruby_line
 
         # Dynamic tags
-        rule /(\*)(#{ruby_chars}+\(.*?\))/ do |m|
+        rule %r/(\*)(#{ruby_chars}+\(.*?\))/ do |m|
           token Punctuation, m[1]
           delegate ruby, m[2]
           push :tag
         end
 
-        rule /(\*)(#{ruby_chars}+)/ do |m|
+        rule %r/(\*)(#{ruby_chars}+)/ do |m|
           token Punctuation, m[1]
           delegate ruby, m[2]
           push :tag
         end
 
-        #rule /<\w+(?=.*>)/, Keyword::Constant, :tag # Maybe do this, look ahead and stuff
+        #rule %r/<\w+(?=.*>)/, Keyword::Constant, :tag # Maybe do this, look ahead and stuff
         rule %r((</?[\w\s\=\'\"]+?/?>)) do |m| # Dirty html
           delegate html, m[1]
           pop!
         end
 
         # Ordinary slim tags
-        rule /\w+/, Name::Tag, :tag
+        rule %r/\w+/, Name::Tag, :tag
 
       end
 
@@ -113,24 +113,24 @@ module Rouge
         mixin :interpolation
 
         # Whitespace control
-        rule /[<>]/, Punctuation
+        rule %r/[<>]/, Punctuation
 
         # Trim whitespace
-        rule /\s+?/, Text::Whitespace
+        rule %r/\s+?/, Text::Whitespace
 
         # Splats, these two might be mergable?
-        rule /(\*)(#{ruby_chars}+)/ do |m|
+        rule %r/(\*)(#{ruby_chars}+)/ do |m|
           token Punctuation, m[1]
           delegate ruby, m[2]
         end
 
-        rule /(\*)(\{#{dot}+?\})/ do |m|
+        rule %r/(\*)(\{#{dot}+?\})/ do |m|
           token Punctuation, m[1]
           delegate ruby, m[2]
         end
 
         # Attributes
-        rule /([\w\-]+)(\s*)(\=)/ do |m|
+        rule %r/([\w\-]+)(\s*)(\=)/ do |m|
           token Name::Attribute, m[1]
           token Text::Whitespace, m[2]
           token Punctuation, m[3]
@@ -138,7 +138,7 @@ module Rouge
         end
 
         # Ruby value
-        rule /(\=)(#{dot}+)/ do |m|
+        rule %r/(\=)(#{dot}+)/ do |m|
           token Punctuation, m[1]
           #token Keyword::Constant, m[2]
           delegate ruby, m[2]
@@ -147,9 +147,9 @@ module Rouge
         # HTML Entities
         rule(/&\S*?;/, Name::Entity)
 
-        rule /#{dot}+?/, Text
+        rule %r/#{dot}+?/, Text
 
-        rule /\s*\n/, Text::Whitespace, :pop!
+        rule %r/\s*\n/, Text::Whitespace, :pop!
       end
 
       state :css do
@@ -165,7 +165,7 @@ module Rouge
         rule(/(#{ruby_chars}+\(.*?\))/) { |m| delegate ruby, m[1]; pop! }
         rule(/(#{ruby_chars}+)/) { |m| delegate ruby, m[1]; pop! }
 
-        rule /\s+/, Text::Whitespace
+        rule %r/\s+/, Text::Whitespace
       end
 
       state :ruby_line do
@@ -173,12 +173,12 @@ module Rouge
         mixin :indented_block
 
         rule(/[,\\]\s*\n/) { delegate ruby }
-        rule /[ ]\|[ \t]*\n/, Str::Escape
+        rule %r/[ ]\|[ \t]*\n/, Str::Escape
         rule(/.*?(?=([,\\]$| \|)?[ \t]*$)/) { delegate ruby }
       end
 
       state :filter_block do
-        rule /([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
+        rule %r/([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
           if @filter_lexer
             delegate @filter_lexer
           else
@@ -200,18 +200,18 @@ module Rouge
         # HTML Entities
         rule(/&\S*?;/, Name::Entity)
 
-        #rule /([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
-        rule /#{dot}+?/, Text
+        #rule %r/([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
+        rule %r/#{dot}+?/, Text
 
         mixin :indented_block
       end
 
       state :interpolation do
-        rule /#[{]/, Str::Interpol, :ruby_interp
+        rule %r/#[{]/, Str::Interpol, :ruby_interp
       end
 
       state :ruby_interp do
-        rule /[}]/, Str::Interpol, :pop!
+        rule %r/[}]/, Str::Interpol, :pop!
         mixin :ruby_interp_inner
       end
 

--- a/lib/rouge/lexers/smalltalk.rb
+++ b/lib/rouge/lexers/smalltalk.rb
@@ -15,29 +15,29 @@ module Rouge
       ops = %r([-+*/\\~<>=|&!?,@%])
 
       state :root do
-        rule /(<)(\w+:)(.*?)(>)/ do
+        rule %r/(<)(\w+:)(.*?)(>)/ do
           groups Punctuation, Keyword, Text, Punctuation
         end
 
         # mixin :squeak_fileout
         mixin :whitespaces
         mixin :method_definition
-        rule /([|])([\w\s]*)([|])/ do
+        rule %r/([|])([\w\s]*)([|])/ do
           groups Punctuation, Name::Variable, Punctuation
         end
         mixin :objects
-        rule /\^|:=|_/, Operator
+        rule %r/\^|:=|_/, Operator
 
-        rule /[)}\]]/, Punctuation, :after_object
-        rule /[({\[!]/, Punctuation
+        rule %r/[)}\]]/, Punctuation, :after_object
+        rule %r/[({\[!]/, Punctuation
       end
 
       state :method_definition do
-        rule /([a-z]\w*:)(\s*)(\w+)/i do
+        rule %r/([a-z]\w*:)(\s*)(\w+)/i do
           groups Name::Function, Text, Name::Variable
         end
 
-        rule /^(\s*)(\b[a-z]\w*\b)(\s*)$/i do
+        rule %r/^(\s*)(\b[a-z]\w*\b)(\s*)$/i do
           groups Text, Name::Function, Text
         end
 
@@ -48,27 +48,27 @@ module Rouge
 
       state :block_variables do
         mixin :whitespaces
-        rule /(:)(\s*)(\w+)/ do
+        rule %r/(:)(\s*)(\w+)/ do
           groups Operator, Text, Name::Variable
         end
 
-        rule /[|]/, Punctuation, :pop!
+        rule %r/[|]/, Punctuation, :pop!
 
         rule(//) { pop! }
       end
 
       state :literals do
-        rule /'(''|.)*?'/m, Str, :after_object
-        rule /[$]./, Str::Char, :after_object
-        rule /#[(]/, Str::Symbol, :parenth
-        rule /(\d+r)?-?\d+(\.\d+)?(e-?\d+)?/,
+        rule %r/'(''|.)*?'/m, Str, :after_object
+        rule %r/[$]./, Str::Char, :after_object
+        rule %r/#[(]/, Str::Symbol, :parenth
+        rule %r/(\d+r)?-?\d+(\.\d+)?(e-?\d+)?/,
           Num, :after_object
-        rule /#("[^"]*"|#{ops}+|[\w:]+)/,
+        rule %r/#("[^"]*"|#{ops}+|[\w:]+)/,
           Str::Symbol, :after_object
       end
 
       state :parenth do
-        rule /[)]/ do
+        rule %r/[)]/ do
           token Str::Symbol
           goto :after_object
         end
@@ -77,39 +77,39 @@ module Rouge
       end
 
       state :inner_parenth do
-        rule /#[(]/, Str::Symbol, :inner_parenth
-        rule /[)]/, Str::Symbol, :pop!
+        rule %r/#[(]/, Str::Symbol, :inner_parenth
+        rule %r/[)]/, Str::Symbol, :pop!
         mixin :whitespaces
         mixin :literals
-        rule /(#{ops}|[\w:])+/, Str::Symbol
+        rule %r/(#{ops}|[\w:])+/, Str::Symbol
       end
 
       state :whitespaces do
-        rule /! !$/, Keyword # squeak chunk delimiter
-        rule /\s+/m, Text
-        rule /".*?"/m, Comment
+        rule %r/! !$/, Keyword # squeak chunk delimiter
+        rule %r/\s+/m, Text
+        rule %r/".*?"/m, Comment
       end
 
       state :objects do
-        rule /\[/, Punctuation, :block_variables
-        rule /(self|super|true|false|nil|thisContext)\b/,
+        rule %r/\[/, Punctuation, :block_variables
+        rule %r/(self|super|true|false|nil|thisContext)\b/,
           Name::Builtin::Pseudo, :after_object
-        rule /[A-Z]\w*(?!:)\b/, Name::Class, :after_object
-        rule /[a-z]\w*(?!:)\b/, Name::Variable, :after_object
+        rule %r/[A-Z]\w*(?!:)\b/, Name::Class, :after_object
+        rule %r/[a-z]\w*(?!:)\b/, Name::Variable, :after_object
         mixin :literals
       end
 
       state :after_object do
         mixin :whitespaces
-        rule /(ifTrue|ifFalse|whileTrue|whileFalse|timesRepeat):/,
+        rule %r/(ifTrue|ifFalse|whileTrue|whileFalse|timesRepeat):/,
           Name::Builtin, :pop!
-        rule /new(?!:)\b/, Name::Builtin
-        rule /:=|_/, Operator, :pop!
-        rule /[a-z]+\w*:/i, Name::Function, :pop!
-        rule /[a-z]+\w*/i, Name::Function
-        rule /#{ops}+/, Name::Function, :pop!
-        rule /[.]/, Punctuation, :pop!
-        rule /;/, Punctuation
+        rule %r/new(?!:)\b/, Name::Builtin
+        rule %r/:=|_/, Operator, :pop!
+        rule %r/[a-z]+\w*:/i, Name::Function, :pop!
+        rule %r/[a-z]+\w*/i, Name::Function
+        rule %r/#{ops}+/, Name::Function, :pop!
+        rule %r/[.]/, Punctuation, :pop!
+        rule %r/;/, Punctuation
         rule(//) { pop! }
       end
     end

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -33,9 +33,9 @@ module Rouge
         rule(/\{\s+/) { delegate parent }
 
         # block comments
-        rule /\{\*.*?\*\}/m, Comment
+        rule %r/\{\*.*?\*\}/m, Comment
 
-        rule /\{\/?(?![\s*])/ do
+        rule %r/\{\/?(?![\s*])/ do
           token Keyword
           push :smarty
         end
@@ -53,21 +53,21 @@ module Rouge
 
       state :smarty do
         # allow nested tags
-        rule /\{\/?(?![\s*])/ do
+        rule %r/\{\/?(?![\s*])/ do
           token Keyword
           push :smarty
         end
 
-        rule /}/, Keyword, :pop!
-        rule /\s+/m, Text
+        rule %r/}/, Keyword, :pop!
+        rule %r/\s+/m, Text
         rule %r([~!%^&*()+=|\[\]:;,.<>/@?-]), Operator
-        rule /#[a-zA-Z_]\w*#/, Name::Variable
-        rule /\$[a-zA-Z_]\w*(\.\w+)*/, Name::Variable
-        rule /(true|false|null)\b/, Keyword::Constant
-	rule /[0-9](\.[0-9]*)?(eE[+-][0-9])?[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?/, Num
-	rule /"(\\.|.)*?"/, Str::Double
-        rule /'(\\.|.)*?'/, Str::Single
-	rule /([a-zA-Z_]\w*)/ do |m|
+        rule %r/#[a-zA-Z_]\w*#/, Name::Variable
+        rule %r/\$[a-zA-Z_]\w*(\.\w+)*/, Name::Variable
+        rule %r/(true|false|null)\b/, Keyword::Constant
+	rule %r/[0-9](\.[0-9]*)?(eE[+-][0-9])?[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?/, Num
+	rule %r/"(\\.|.)*?"/, Str::Double
+        rule %r/'(\\.|.)*?'/, Str::Single
+	rule %r/([a-zA-Z_]\w*)/ do |m|
 	  if self.class.builtins.include? m[0]
 	    token Name::Builtin
 	  else

--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -30,25 +30,25 @@ module Rouge
       symbol = %r([!%&$#/:<=>?@\\~`^|*+-]+)
 
       state :whitespace do
-        rule /\s+/m, Text
-        rule /[(][*]/, Comment, :comment
+        rule %r/\s+/m, Text
+        rule %r/[(][*]/, Comment, :comment
       end
 
       state :delimiters do
-        rule /[(\[{]/, Punctuation, :main
-        rule /[)\]}]/, Punctuation, :pop!
+        rule %r/[(\[{]/, Punctuation, :main
+        rule %r/[)\]}]/, Punctuation, :pop!
 
-        rule /\b(let|if|local)\b(?!')/ do
+        rule %r/\b(let|if|local)\b(?!')/ do
           token Keyword::Reserved
           push; push
         end
 
-        rule /\b(struct|sig|while)\b(?!')/ do
+        rule %r/\b(struct|sig|while)\b(?!')/ do
           token Keyword::Reserved
           push
         end
 
-        rule /\b(do|else|end|in|then)\b(?!')/, Keyword::Reserved, :pop!
+        rule %r/\b(do|else|end|in|then)\b(?!')/, Keyword::Reserved, :pop!
       end
 
       def token_for_id_with_dot(id)
@@ -78,28 +78,28 @@ module Rouge
       end
 
       state :core do
-        rule /[()\[\]{},;_]|[.][.][.]/, Punctuation
-        rule /#"/, Str::Char, :char
-        rule /"/, Str::Double, :string
-        rule /~?0x[0-9a-fA-F]+/, Num::Hex
-        rule /0wx[0-9a-fA-F]+/, Num::Hex
-        rule /0w\d+/, Num::Integer
-        rule /~?\d+([.]\d+)?[eE]~?\d+/, Num::Float
-        rule /~?\d+[.]\d+/, Num::Float
-        rule /~?\d+/, Num::Integer
+        rule %r/[()\[\]{},;_]|[.][.][.]/, Punctuation
+        rule %r/#"/, Str::Char, :char
+        rule %r/"/, Str::Double, :string
+        rule %r/~?0x[0-9a-fA-F]+/, Num::Hex
+        rule %r/0wx[0-9a-fA-F]+/, Num::Hex
+        rule %r/0w\d+/, Num::Integer
+        rule %r/~?\d+([.]\d+)?[eE]~?\d+/, Num::Float
+        rule %r/~?\d+[.]\d+/, Num::Float
+        rule %r/~?\d+/, Num::Integer
 
-        rule /#\s*[1-9][0-9]*/, Name::Label
-        rule /#\s*#{id}/, Name::Label
-        rule /#\s+#{symbol}/, Name::Label
+        rule %r/#\s*[1-9][0-9]*/, Name::Label
+        rule %r/#\s*#{id}/, Name::Label
+        rule %r/#\s+#{symbol}/, Name::Label
 
-        rule /\b(datatype|abstype)\b(?!')/, Keyword::Reserved, :dname
+        rule %r/\b(datatype|abstype)\b(?!')/, Keyword::Reserved, :dname
         rule(/(?=\bexception\b(?!'))/) { push :ename }
-        rule /\b(functor|include|open|signature|structure)\b(?!')/,
+        rule %r/\b(functor|include|open|signature|structure)\b(?!')/,
           Keyword::Reserved, :sname
-        rule /\b(type|eqtype)\b(?!')/, Keyword::Reserved, :tname
+        rule %r/\b(type|eqtype)\b(?!')/, Keyword::Reserved, :tname
 
-        rule /'#{id}/, Name::Decorator
-        rule /(#{id})([.])/ do |m|
+        rule %r/'#{id}/, Name::Decorator
+        rule %r/(#{id})([.])/ do |m|
           groups(token_for_id_with_dot(m[1]), Punctuation)
           push :dotted
         end
@@ -114,7 +114,7 @@ module Rouge
       end
 
       state :dotted do
-        rule /(#{id})([.])/ do |m|
+        rule %r/(#{id})([.])/ do |m|
           groups(token_for_id_with_dot(m[1]), Punctuation)
         end
 
@@ -130,15 +130,15 @@ module Rouge
       end
 
       state :root do
-        rule /#!.*?\n/, Comment::Preproc
+        rule %r/#!.*?\n/, Comment::Preproc
         rule(//) { push :main }
       end
 
       state :main do
         mixin :whitespace
 
-        rule /\b(val|and)\b(?!')/, Keyword::Reserved, :vname
-        rule /\b(fun)\b(?!')/ do
+        rule %r/\b(val|and)\b(?!')/, Keyword::Reserved, :vname
+        rule %r/\b(fun)\b(?!')/ do
           token Keyword::Reserved
           goto :main_fun
           push :fname
@@ -150,15 +150,15 @@ module Rouge
 
       state :main_fun do
         mixin :whitespace
-        rule /\b(fun|and)\b(?!')/, Keyword::Reserved, :fname
-        rule /\bval\b(?!')/ do
+        rule %r/\b(fun|and)\b(?!')/, Keyword::Reserved, :fname
+        rule %r/\bval\b(?!')/ do
           token Keyword::Reserved
           goto :main
           push :vname
         end
 
-        rule /[|]/, Punctuation, :fname
-        rule /\b(case|handle)\b(?!')/ do
+        rule %r/[|]/, Punctuation, :fname
+        rule %r/\b(case|handle)\b(?!')/ do
           token Keyword::Reserved
           goto :main
         end
@@ -168,27 +168,27 @@ module Rouge
       end
 
       state :has_escapes do
-        rule /\\[\\"abtnvfr]/, Str::Escape
-        rule /\\\^[\x40-\x5e]/, Str::Escape
-        rule /\\[0-9]{3}/, Str::Escape
-        rule /\\u\h{4}/, Str::Escape
-        rule /\\\s+\\/, Str::Interpol
+        rule %r/\\[\\"abtnvfr]/, Str::Escape
+        rule %r/\\\^[\x40-\x5e]/, Str::Escape
+        rule %r/\\[0-9]{3}/, Str::Escape
+        rule %r/\\u\h{4}/, Str::Escape
+        rule %r/\\\s+\\/, Str::Interpol
       end
 
       state :string do
-        rule /[^"\\]+/, Str::Double
-        rule /"/, Str::Double, :pop!
+        rule %r/[^"\\]+/, Str::Double
+        rule %r/"/, Str::Double, :pop!
         mixin :has_escapes
       end
 
       state :char do
-        rule /[^"\\]+/, Str::Char
-        rule /"/, Str::Char, :pop!
+        rule %r/[^"\\]+/, Str::Char
+        rule %r/"/, Str::Char, :pop!
         mixin :has_escapes
       end
 
       state :breakout do
-        rule /(?=\b(#{SML.keywords.to_a.join('|')})\b(?!'))/ do
+        rule %r/(?=\b(#{SML.keywords.to_a.join('|')})\b(?!'))/ do
           pop!
         end
       end
@@ -201,8 +201,8 @@ module Rouge
       end
 
       state :has_annotations do
-        rule /'[\w']*/, Name::Decorator
-        rule /[(]/, Punctuation, :tyvarseq
+        rule %r/'[\w']*/, Name::Decorator
+        rule %r/[(]/, Punctuation, :tyvarseq
       end
 
       state :fname do
@@ -217,12 +217,12 @@ module Rouge
         mixin :whitespace
         mixin :has_annotations
 
-        rule /(#{id})(\s*)(=(?!#{symbol}))/m do
+        rule %r/(#{id})(\s*)(=(?!#{symbol}))/m do
           groups Name::Variable, Text, Punctuation
           pop!
         end
 
-        rule /(#{symbol})(\s*)(=(?!#{symbol}))/m do
+        rule %r/(#{symbol})(\s*)(=(?!#{symbol}))/m do
           groups Name::Variable, Text, Punctuation
         end
 
@@ -237,8 +237,8 @@ module Rouge
         mixin :breakout
         mixin :has_annotations
 
-        rule /'[\w']*/, Name::Decorator
-        rule /[(]/, Punctuation, :tyvarseq
+        rule %r/'[\w']*/, Name::Decorator
+        rule %r/[(]/, Punctuation, :tyvarseq
 
         rule %r(=(?!#{symbol})) do
           token Punctuation
@@ -252,7 +252,7 @@ module Rouge
       state :typbind do
         mixin :whitespace
 
-        rule /\b(and)\b(?!')/ do
+        rule %r/\b(and)\b(?!')/ do
           token Keyword::Reserved
           goto :tname
         end
@@ -266,7 +266,7 @@ module Rouge
         mixin :breakout
         mixin :has_annotations
 
-        rule /(=)(\s*)(datatype)\b/ do
+        rule %r/(=)(\s*)(datatype)\b/ do
           groups Punctuation, Text, Keyword::Reserved
           pop!
         end
@@ -283,18 +283,18 @@ module Rouge
 
       state :datbind do
         mixin :whitespace
-        rule /\b(and)\b(?!')/ do
+        rule %r/\b(and)\b(?!')/ do
           token Keyword::Reserved; goto :dname
         end
-        rule /\b(withtype)\b(?!')/ do
+        rule %r/\b(withtype)\b(?!')/ do
           token Keyword::Reserved; goto :tname
         end
-        rule /\bof\b(?!')/, Keyword::Reserved
-        rule /([|])(\s*)(#{id})/ do
+        rule %r/\bof\b(?!')/, Keyword::Reserved
+        rule %r/([|])(\s*)(#{id})/ do
           groups(Punctuation, Text, Name::Class)
         end
 
-        rule /([|])(\s+)(#{symbol})/ do
+        rule %r/([|])(\s+)(#{symbol})/ do
           groups(Punctuation, Text, Name::Class)
         end
 
@@ -304,15 +304,15 @@ module Rouge
 
       state :ename do
         mixin :whitespace
-        rule /(exception|and)(\s+)(#{id})/ do
+        rule %r/(exception|and)(\s+)(#{id})/ do
           groups Keyword::Reserved, Text, Name::Class
         end
 
-        rule /(exception|and)(\s*)(#{symbol})/ do
+        rule %r/(exception|and)(\s*)(#{symbol})/ do
           groups Keyword::Reserved, Text, Name::Class
         end
 
-        rule /\b(of)\b(?!')/, Keyword::Reserved
+        rule %r/\b(of)\b(?!')/, Keyword::Reserved
         mixin :breakout
         mixin :core
       end
@@ -325,20 +325,20 @@ module Rouge
 
       state :tyvarseq do
         mixin :whitespace
-        rule /'[\w']*/, Name::Decorator
+        rule %r/'[\w']*/, Name::Decorator
         rule id, Name
-        rule /,/, Punctuation
-        rule /[)]/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/[)]/, Punctuation, :pop!
         rule symbol, Name
       end
 
       state :comment do
-        rule /[^(*)]+/, Comment::Multiline
-        rule /[(][*]/ do
+        rule %r/[^(*)]+/, Comment::Multiline
+        rule %r/[(][*]/ do
           token Comment::Multiline; push
         end
-        rule /[*][)]/, Comment::Multiline, :pop!
-        rule /[(*)]/, Comment::Multiline
+        rule %r/[*][)]/, Comment::Multiline, :pop!
+        rule %r/[(*)]/, Comment::Multiline
       end
     end
   end

--- a/lib/rouge/lexers/sql.rb
+++ b/lib/rouge/lexers/sql.rb
@@ -89,15 +89,15 @@ module Rouge
       end
 
       state :root do
-        rule /\s+/m, Text
-        rule /--.*/, Comment::Single
+        rule %r/\s+/m, Text
+        rule %r/--.*/, Comment::Single
         rule %r(/\*), Comment::Multiline, :multiline_comments
-        rule /\d+/, Num::Integer
-        rule /'/, Str::Single, :single_string
-        rule /"/, Name::Variable, :double_string
-        rule /`/, Name::Variable, :backtick
+        rule %r/\d+/, Num::Integer
+        rule %r/'/, Str::Single, :single_string
+        rule %r/"/, Name::Variable, :double_string
+        rule %r/`/, Name::Variable, :backtick
 
-        rule /\w[\w\d]*/ do |m|
+        rule %r/\w[\w\d]*/ do |m|
           if self.class.keywords.include? m[0].upcase
             token Keyword
           else
@@ -106,7 +106,7 @@ module Rouge
         end
 
         rule %r([+*/<>=~!@#%^&|?^-]), Operator
-        rule /[;:()\[\],.]/, Punctuation
+        rule %r/[;:()\[\],.]/, Punctuation
       end
 
       state :multiline_comments do
@@ -117,24 +117,24 @@ module Rouge
       end
 
       state :backtick do
-        rule /\\./, Str::Escape
-        rule /``/, Str::Escape
-        rule /`/, Name::Variable, :pop!
-        rule /[^\\`]+/, Name::Variable
+        rule %r/\\./, Str::Escape
+        rule %r/``/, Str::Escape
+        rule %r/`/, Name::Variable, :pop!
+        rule %r/[^\\`]+/, Name::Variable
       end
 
       state :single_string do
-        rule /\\./, Str::Escape
-        rule /''/, Str::Escape
-        rule /'/, Str::Single, :pop!
-        rule /[^\\']+/, Str::Single
+        rule %r/\\./, Str::Escape
+        rule %r/''/, Str::Escape
+        rule %r/'/, Str::Single, :pop!
+        rule %r/[^\\']+/, Str::Single
       end
 
       state :double_string do
-        rule /\\./, Str::Escape
-        rule /""/, Str::Escape
-        rule /"/, Name::Variable, :pop!
-        rule /[^\\"]+/, Name::Variable
+        rule %r/\\./, Str::Escape
+        rule %r/""/, Str::Escape
+        rule %r/"/, Name::Variable, :pop!
+        rule %r/[^\\"]+/, Name::Variable
       end
     end
   end

--- a/lib/rouge/lexers/supercollider.rb
+++ b/lib/rouge/lexers/supercollider.rb
@@ -35,7 +35,7 @@ module Rouge
       end
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
       end
 
       state :comments do
@@ -50,43 +50,43 @@ module Rouge
         rule %r(/[*]), Comment::Multiline, :nested_comment
         rule %r([*]/), Comment::Multiline, :pop!
         rule %r([^*/]+)m, Comment::Multiline
-        rule /./, Comment::Multiline
+        rule %r/./, Comment::Multiline
       end
 
       state :root do
         mixin :whitespace
         mixin :comments
 
-        rule /[\-+]?0[xX]\h+/, Num::Hex
+        rule %r/[\-+]?0[xX]\h+/, Num::Hex
 
         # radix float
-        rule /[\-+]?\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, Num::Float
+        rule %r/[\-+]?\d+r[0-9a-zA-Z]*(\.[0-9A-Z]*)?/, Num::Float
 
         # normal float
-        rule /[\-+]?((\d+(\.\d+)?([eE][\-+]?\d+)?(pi)?)|pi)/, Num::Float
+        rule %r/[\-+]?((\d+(\.\d+)?([eE][\-+]?\d+)?(pi)?)|pi)/, Num::Float
 
-        rule /[\-+]?\d+/, Num::Integer
+        rule %r/[\-+]?\d+/, Num::Integer
 
-        rule /\$(\\.|.)/, Str::Char
+        rule %r/\$(\\.|.)/, Str::Char
 
-        rule /"([^\\"]|\\.)*"/, Str
+        rule %r/"([^\\"]|\\.)*"/, Str
 
         # symbols (single-quote notation)
-        rule /'([^\\']|\\.)*'/, Str::Other
+        rule %r/'([^\\']|\\.)*'/, Str::Other
 
         # symbols (backslash notation)
-        rule /\\\w+/, Str::Other
+        rule %r/\\\w+/, Str::Other
 
         # symbol arg
-        rule /[A-Za-z_]\w*:/, Name::Label
+        rule %r/[A-Za-z_]\w*:/, Name::Label
 
-        rule /[A-Z]\w*/, Name::Class
+        rule %r/[A-Z]\w*/, Name::Class
 
         # primitive
-        rule /_\w+/, Name::Function
+        rule %r/_\w+/, Name::Function
 
         # main identifiers section
-        rule /[a-z]\w*/ do |m|
+        rule %r/[a-z]\w*/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           elsif self.class.constants.include? m[0]
@@ -99,16 +99,16 @@ module Rouge
         end
 
         # environment variables
-        rule /~\w+/, Name::Variable::Global
+        rule %r/~\w+/, Name::Variable::Global
 
-        rule /[\{\}()\[\];,\.]/, Punctuation
+        rule %r/[\{\}()\[\];,\.]/, Punctuation
 
         # operators. treat # (array unpack) as an operator
-        rule /[\+\-\*\/&\|%<>=]+/, Operator
-        rule /[\^:#]/, Operator
+        rule %r/[\+\-\*\/&\|%<>=]+/, Operator
+        rule %r/[\^:#]/, Operator
 
         # treat curry argument as a special operator
-        rule /\b_\b/, Name::Builtin
+        rule %r/\b_\b/, Name::Builtin
       end
     end
   end

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -34,7 +34,7 @@ module Rouge
 
       # beginning of line
       state :bol do
-        rule /#.*/, Comment::Preproc
+        rule %r/#.*/, Comment::Preproc
 
         mixin :inline_whitespace
 
@@ -42,12 +42,12 @@ module Rouge
       end
 
       state :inline_whitespace do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         mixin :has_comments
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :bol
+        rule %r/\n+/m, Text, :bol
         rule %r(\/\/.*?$), Comment::Single, :bol
         mixin :inline_whitespace
       end
@@ -60,27 +60,27 @@ module Rouge
         mixin :has_comments
         rule %r([*]/), Comment::Multiline, :pop!
         rule %r([^*/]+)m, Comment::Multiline
-        rule /./, Comment::Multiline
+        rule %r/./, Comment::Multiline
       end
 
       state :root do
         mixin :whitespace
-        rule /\$(([1-9]\d*)?\d)/, Name::Variable
+        rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
 
         rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r([-/=+*%<>!&|^.~]+), Operator
-        rule /@?"/, Str, :dq
-        rule /'(\\.|.)'/, Str::Char
-        rule /(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
-        rule /\d+e[+-]?[0-9]+/i, Num::Float
-        rule /0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
-        rule /0b[01]+(?:_[01]+)*/, Num::Bin
+        rule %r/@?"/, Str, :dq
+        rule %r/'(\\.|.)'/, Str::Char
+        rule %r/(\d+\*|\d*\.\d+)(e[+-]?[0-9]+)?/i, Num::Float
+        rule %r/\d+e[+-]?[0-9]+/i, Num::Float
+        rule %r/0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
+        rule %r/0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
+        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 
-        rule /@#{id}(\([^)]+\))?/, Keyword::Declaration
+        rule %r/@#{id}(\([^)]+\))?/, Keyword::Declaration
 
-        rule /(private|internal)(\([ ]*)(\w+)([ ]*\))/ do |m|
+        rule %r/(private|internal)(\([ ]*)(\w+)([ ]*\))/ do |m|
           if m[3] == 'set'
             token Keyword::Declaration
           else
@@ -88,7 +88,7 @@ module Rouge
           end
         end
 
-        rule /(unowned\([ ]*)(\w+)([ ]*\))/ do |m|
+        rule %r/(unowned\([ ]*)(\w+)([ ]*\))/ do |m|
           if m[2] == 'safe' || m[2] == 'unsafe'
             token Keyword::Declaration
           else
@@ -96,24 +96,24 @@ module Rouge
           end
         end
         
-        rule /#available\([^)]+\)/, Keyword::Declaration
+        rule %r/#available\([^)]+\)/, Keyword::Declaration
         
-        rule /(#(?:selector|keyPath)\()([^)]+?(?:[(].*?[)])?)(\))/ do
+        rule %r/(#(?:selector|keyPath)\()([^)]+?(?:[(].*?[)])?)(\))/ do
           groups Keyword::Declaration, Name::Function, Keyword::Declaration
         end
         
-        rule /#(line|file|column|function|dsohandle)/, Keyword::Declaration
+        rule %r/#(line|file|column|function|dsohandle)/, Keyword::Declaration
 
-        rule /(let|var)\b(\s*)(#{id})/ do
+        rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable
         end
 
-        rule /(let|var)\b(\s*)([(])/ do
+        rule %r/(let|var)\b(\s*)([(])/ do
           groups Keyword, Text, Punctuation
           push :tuple
         end
 
-        rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
+        rule %r/(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
           if m[0] =~ /^[[:upper:]]/
             token Keyword::Type
           else
@@ -121,10 +121,10 @@ module Rouge
           end
         end
         
-        rule /as[?!]?(?=\s)/, Keyword
-        rule /try[!]?(?=\s)/, Keyword
+        rule %r/as[?!]?(?=\s)/, Keyword
+        rule %r/try[!]?(?=\s)/, Keyword
 
-        rule /(#?(?!default)(?![[:upper:]])#{id})(\s*)(:)/ do
+        rule %r/(#?(?!default)(?![[:upper:]])#{id})(\s*)(:)/ do
           groups Name::Variable, Text, Punctuation
         end
 
@@ -142,39 +142,39 @@ module Rouge
           end
         end
 
-        rule /(`)(#{id})(`)/ do
+        rule %r/(`)(#{id})(`)/ do
           groups Punctuation, Name::Variable, Punctuation
         end
       end
 
       state :tuple do
-        rule /(#{id})/, Name::Variable
-        rule /(`)(#{id})(`)/ do
+        rule %r/(#{id})/, Name::Variable
+        rule %r/(`)(#{id})(`)/ do
             groups Punctuation, Name::Variable, Punctuation
         end
-        rule /,/, Punctuation
-        rule /[(]/, Punctuation, :push
-        rule /[)]/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/[(]/, Punctuation, :push
+        rule %r/[)]/, Punctuation, :pop!
         mixin :inline_whitespace
       end
 
       state :dq do
-        rule /\\[\\0tnr'"]/, Str::Escape
-        rule /\\[(]/, Str::Escape, :interp
-        rule /\\u\{\h{1,8}\}/, Str::Escape
-        rule /[^\\"]+/, Str
-        rule /"/, Str, :pop!
+        rule %r/\\[\\0tnr'"]/, Str::Escape
+        rule %r/\\[(]/, Str::Escape, :interp
+        rule %r/\\u\{\h{1,8}\}/, Str::Escape
+        rule %r/[^\\"]+/, Str
+        rule %r/"/, Str, :pop!
       end
 
       state :interp do
-        rule /[(]/, Punctuation, :interp_inner
-        rule /[)]/, Str::Escape, :pop!
+        rule %r/[(]/, Punctuation, :interp_inner
+        rule %r/[)]/, Str::Escape, :pop!
         mixin :root
       end
 
       state :interp_inner do
-        rule /[(]/, Punctuation, :push
-        rule /[)]/, Punctuation, :pop!
+        rule %r/[(]/, Punctuation, :push
+        rule %r/[)]/, Punctuation, :pop!
         mixin :root
       end
     end

--- a/lib/rouge/lexers/tap.rb
+++ b/lib/rouge/lexers/tap.rb
@@ -13,72 +13,72 @@ module Rouge
 
       state :root do
         # A TAP version may be specified.
-        rule /^TAP version \d+\n/, Name::Namespace
+        rule %r/^TAP version \d+\n/, Name::Namespace
 
         # Specify a plan with a plan line.
-        rule /^1\.\.\d+/, Keyword::Declaration, :plan
+        rule %r/^1\.\.\d+/, Keyword::Declaration, :plan
 
         # A test failure
-        rule /^(not ok)([^\S\n]*)(\d*)/ do
+        rule %r/^(not ok)([^\S\n]*)(\d*)/ do
           groups Generic::Error, Text, Literal::Number::Integer
           push :test
         end
 
         # A test success
-        rule /^(ok)([^\S\n]*)(\d*)/ do
+        rule %r/^(ok)([^\S\n]*)(\d*)/ do
           groups Keyword::Reserved, Text, Literal::Number::Integer
           push :test
         end
 
         # Diagnostics start with a hash.
-        rule /^#.*\n/, Comment
+        rule %r/^#.*\n/, Comment
 
         # TAP's version of an abort statement.
-        rule /^Bail out!.*\n/, Generic::Error
+        rule %r/^Bail out!.*\n/, Generic::Error
 
         # # TAP ignores any unrecognized lines.
-        rule /^.*\n/, Text
+        rule %r/^.*\n/, Text
       end
 
       state :plan do
         # Consume whitespace (but not newline).
-        rule /[^\S\n]+/, Text
+        rule %r/[^\S\n]+/, Text
 
         # A plan may have a directive with it.
-        rule /#/, Comment, :directive
+        rule %r/#/, Comment, :directive
 
         # Or it could just end.
-        rule /\n/, Comment, :pop!
+        rule %r/\n/, Comment, :pop!
 
         # Anything else is wrong.
-        rule /.*\n/, Generic::Error, :pop!
+        rule %r/.*\n/, Generic::Error, :pop!
       end
 
       state :test do
         # Consume whitespace (but not newline).
-        rule /[^\S\n]+/, Text
+        rule %r/[^\S\n]+/, Text
 
         # A test may have a directive with it.
-        rule /#/, Comment, :directive
+        rule %r/#/, Comment, :directive
 
-        rule /\S+/, Text
+        rule %r/\S+/, Text
 
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
       end
 
       state :directive do
         # Consume whitespace (but not newline).
-        rule /[^\S\n]+/, Comment
+        rule %r/[^\S\n]+/, Comment
 
         # Extract todo items.
-        rule /(?i)\bTODO\b/, Comment::Preproc
+        rule %r/(?i)\bTODO\b/, Comment::Preproc
 
         # Extract skip items.
-        rule /(?i)\bSKIP\S*/, Comment::Preproc
+        rule %r/(?i)\bSKIP\S*/, Comment::Preproc
 
-        rule /\S+/, Comment
+        rule %r/\S+/, Comment
 
-        rule /\n/ do
+        rule %r/\n/ do
           token Comment
           pop! 2
         end

--- a/lib/rouge/lexers/tcl.rb
+++ b/lib/rouge/lexers/tcl.rb
@@ -45,27 +45,27 @@ module Rouge
       NOT_CHARS = lambda { |list| Regexp.new %/[^#{list.join}]/ }
 
       state :word do
-        rule /\{\*\}/, Keyword
+        rule %r/\{\*\}/, Keyword
 
         mixin :brace_abort
         mixin :interp
-        rule /\{/, Punctuation, :brace
-        rule /\(/, Punctuation,   :paren
-        rule /"/,  Str::Double, :string
-        rule /#{NOT_CHARS[END_WORD]}+?(?=#{CHARS[OPEN+['\\\\']]})/, Text
+        rule %r/\{/, Punctuation, :brace
+        rule %r/\(/, Punctuation,   :paren
+        rule %r/"/,  Str::Double, :string
+        rule %r/#{NOT_CHARS[END_WORD]}+?(?=#{CHARS[OPEN+['\\\\']]})/, Text
       end
 
       def self.gen_command_state(name='')
         state(:"command#{name}") do
           mixin :word
 
-          rule /##{NOT_CHARS[END_LINE]}+/, Comment::Single
+          rule %r/##{NOT_CHARS[END_LINE]}+/, Comment::Single
 
-          rule /(?=#{CHARS[END_WORD]})/ do
+          rule %r/(?=#{CHARS[END_WORD]})/ do
             push :"params#{name}"
           end
 
-          rule /#{NOT_CHARS[END_WORD]}+/ do |m|
+          rule %r/#{NOT_CHARS[END_WORD]}+/ do |m|
             if KEYWORDS.include? m[0]
               token Keyword
             elsif BUILTINS.include? m[0]
@@ -116,7 +116,7 @@ module Rouge
       # such things as [ abc" ] are a runtime error, but will still
       # parse.  Currently something like this will muck up the lex.
       state :brace_abort do
-        rule /}/ do
+        rule %r/}/ do
           if in_state? :brace
             pop! until state? :brace
             pop!
@@ -128,12 +128,12 @@ module Rouge
       end
 
       state :params do
-        rule /;/, Punctuation, :pop!
-        rule /\n/, Text, :pop!
-        rule /else|elseif|then/, Keyword
+        rule %r/;/, Punctuation, :pop!
+        rule %r/\n/, Text, :pop!
+        rule %r/else|elseif|then/, Keyword
         mixin :word
         mixin :whitespace
-        rule /#{NOT_CHARS[END_WORD]}+/, Text
+        rule %r/#{NOT_CHARS[END_WORD]}+/, Text
       end
 
       gen_delimiter_states :brace,   /\}/, :strict => false
@@ -147,37 +147,37 @@ module Rouge
 
       state :whitespace do
         # not a multiline regex because we want to capture \n sometimes
-        rule /\s+/, Text
+        rule %r/\s+/, Text
       end
 
       state :interp do
-        rule /\[/, Punctuation, :bracket
-        rule /\$[a-z0-9.:-]+/, Name::Variable
-        rule /\$\{.*?\}/m, Name::Variable
-        rule /\$/, Text
+        rule %r/\[/, Punctuation, :bracket
+        rule %r/\$[a-z0-9.:-]+/, Name::Variable
+        rule %r/\$\{.*?\}/m, Name::Variable
+        rule %r/\$/, Text
 
         # escape sequences
-        rule /\\[0-7]{3}/, Str::Escape
-        rule /\\x[0-9a-f]{2}/i, Str::Escape
-        rule /\\u[0-9a-f]{4}/i, Str::Escape
-        rule /\\./m, Str::Escape
+        rule %r/\\[0-7]{3}/, Str::Escape
+        rule %r/\\x[0-9a-f]{2}/i, Str::Escape
+        rule %r/\\u[0-9a-f]{4}/i, Str::Escape
+        rule %r/\\./m, Str::Escape
       end
 
       state :string do
-        rule /"/, Str::Double, :pop!
+        rule %r/"/, Str::Double, :pop!
         mixin :interp
-        rule /[^\\\[\$"{}]+/m, Str::Double
+        rule %r/[^\\\[\$"{}]+/m, Str::Double
 
         # strings have to keep count of their internal braces, to support
         # for example { "{ }" }.
-        rule /{/ do
+        rule %r/{/ do
           @brace_count ||= 0
           @brace_count += 1
 
           token Str::Double
         end
 
-        rule /}/ do
+        rule %r/}/ do
           if in_state? :brace and @brace_count.to_i == 0
             pop! until state? :brace
             pop!

--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -38,34 +38,34 @@ module Rouge
       end
 
       state :strings do
-        rule /\\./, Str::Escape
-        rule /\$\{/ do
+        rule %r/\\./, Str::Escape
+        rule %r/\$\{/ do
           token Keyword
           push :interpolation
         end
       end
 
       state :dq do
-        rule /[^\\"\$]+/, Str::Double
+        rule %r/[^\\"\$]+/, Str::Double
         mixin :strings
-        rule /"/, Str::Double, :pop!
+        rule %r/"/, Str::Double, :pop!
       end
 
       state :sq do
-        rule /[^\\'\$]+/, Str::Single
+        rule %r/[^\\'\$]+/, Str::Single
         mixin :strings
-        rule /'/, Str::Single, :pop!
+        rule %r/'/, Str::Single, :pop!
       end
 
       state :heredoc do
-        rule /\n/, Str::Heredoc, :heredoc_nl
-        rule /[^$\n\$]+/, Str::Heredoc
-        rule /[$]/, Str::Heredoc
+        rule %r/\n/, Str::Heredoc, :heredoc_nl
+        rule %r/[^$\n\$]+/, Str::Heredoc
+        rule %r/[$]/, Str::Heredoc
         mixin :strings
       end
 
       state :interpolation do
-        rule /\}/ do
+        rule %r/\}/ do
           token Keyword
           pop!
         end
@@ -77,12 +77,12 @@ module Rouge
 
       state :expression do
         mixin :primitives
-        rule /\s+/, Text
+        rule %r/\s+/, Text
 
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | == | != )x, Operator
         rule %r([-<>+*%&|\^/!=?:]=?), Operator
-        rule /[(\[,]/, Punctuation
-        rule /[)\].]/, Punctuation
+        rule %r/[(\[,]/, Punctuation
+        rule %r/[)\].]/, Punctuation
 
         rule id do |m|
           if self.class.keywords.include? m[0]

--- a/lib/rouge/lexers/tex.rb
+++ b/lib/rouge/lexers/tex.rb
@@ -19,50 +19,50 @@ module Rouge
       command = /\\([a-z]+|\s+|.)/i
 
       state :general do
-        rule /%.*$/, Comment
-        rule /[{}&_^]/, Punctuation
+        rule %r/%.*$/, Comment
+        rule %r/[{}&_^]/, Punctuation
       end
 
       state :root do
-        rule /\\\[/, Punctuation, :displaymath
-        rule /\\\(/, Punctuation, :inlinemath
-        rule /\$\$/, Punctuation, :displaymath
-        rule /\$/, Punctuation, :inlinemath
-        rule /\\(begin|end)\{.*?\}/, Name::Tag
+        rule %r/\\\[/, Punctuation, :displaymath
+        rule %r/\\\(/, Punctuation, :inlinemath
+        rule %r/\$\$/, Punctuation, :displaymath
+        rule %r/\$/, Punctuation, :inlinemath
+        rule %r/\\(begin|end)\{.*?\}/, Name::Tag
 
-        rule /(\\verb)\b(\S)(.*?)(\2)/ do |m|
+        rule %r/(\\verb)\b(\S)(.*?)(\2)/ do |m|
           groups Name::Builtin, Keyword::Pseudo, Str::Other, Keyword::Pseudo
         end
 
         rule command, Keyword, :command
         mixin :general
-        rule /[^\\$%&_^{}]+/, Text
+        rule %r/[^\\$%&_^{}]+/, Text
       end
 
       state :math do
         rule command, Name::Variable
         mixin :general
-        rule /[0-9]+/, Num
-        rule /[-=!+*\/()\[\]]/, Operator
-        rule /[^=!+*\/()\[\]\\$%&_^{}0-9-]+/, Name::Builtin
+        rule %r/[0-9]+/, Num
+        rule %r/[-=!+*\/()\[\]]/, Operator
+        rule %r/[^=!+*\/()\[\]\\$%&_^{}0-9-]+/, Name::Builtin
       end
 
       state :inlinemath do
-        rule /\\\)/, Punctuation, :pop!
-        rule /\$/, Punctuation, :pop!
+        rule %r/\\\)/, Punctuation, :pop!
+        rule %r/\$/, Punctuation, :pop!
         mixin :math
       end
 
       state :displaymath do
-        rule /\\\]/, Punctuation, :pop!
-        rule /\$\$/, Punctuation, :pop!
-        rule /\$/, Name::Builtin
+        rule %r/\\\]/, Punctuation, :pop!
+        rule %r/\$\$/, Punctuation, :pop!
+        rule %r/\$/, Name::Builtin
         mixin :math
       end
 
       state :command do
-        rule /\[.*?\]/, Name::Attribute
-        rule /\*/, Keyword
+        rule %r/\[.*?\]/, Name::Attribute
+        rule %r/\*/, Keyword
         rule(//) { pop! }
       end
     end

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -14,22 +14,22 @@ module Rouge
       identifier = /[\w.\S]+/
 
       state :basic do
-        rule /\s+/, Text
-        rule /#.*?$/, Comment
-        rule /(true|false)/, Keyword::Constant
-        rule /(?<!=)\s*\[[\w\d\S]+\]/, Name::Namespace
+        rule %r/\s+/, Text
+        rule %r/#.*?$/, Comment
+        rule %r/(true|false)/, Keyword::Constant
+        rule %r/(?<!=)\s*\[[\w\d\S]+\]/, Name::Namespace
 
-        rule /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
+        rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
-        rule /(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?/, Num::Float
-        rule /\d+[eE][+-]?[0-9]+j?/, Num::Float
-        rule /\-?\d+/, Num::Integer
+        rule %r/(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?/, Num::Float
+        rule %r/\d+[eE][+-]?[0-9]+j?/, Num::Float
+        rule %r/\-?\d+/, Num::Integer
       end
 
       state :root do
         mixin :basic
 
-        rule /(#{identifier})(\s*)(=)/ do
+        rule %r/(#{identifier})(\s*)(=)/ do
           groups Name::Property, Text, Punctuation
           push :value
         end
@@ -37,31 +37,31 @@ module Rouge
       end
 
       state :value do
-        rule /\n/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         mixin :content
       end
 
       state :content do
         mixin :basic
-        rule /"/, Str, :dq
+        rule %r/"/, Str, :dq
         mixin :esc_str
-        rule /\,/, Punctuation
-        rule /\[/, Punctuation, :array
+        rule %r/\,/, Punctuation
+        rule %r/\[/, Punctuation, :array
       end
 
       state :dq do
-        rule /"/, Str, :pop!
+        rule %r/"/, Str, :pop!
         mixin :esc_str
-        rule /[^\\"]+/, Str
+        rule %r/[^\\"]+/, Str
       end
 
       state :esc_str do
-        rule /\\[0t\tn\n "\\ r]/, Str::Escape
+        rule %r/\\[0t\tn\n "\\ r]/, Str::Escape
       end
 
       state :array do
         mixin :content
-        rule /\]/, Punctuation, :pop!
+        rule %r/\]/, Punctuation, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/tulip.rb
+++ b/lib/rouge/lexers/tulip.rb
@@ -19,77 +19,77 @@ module Rouge
       upper_id = /[A-Z][\w-]*/
 
       state :comments_and_whitespace do
-        rule /\s+/, Text
-        rule /#.*?$/, Comment
+        rule %r/\s+/, Text
+        rule %r/#.*?$/, Comment
       end
 
       state :root do
         mixin :comments_and_whitespace
 
-        rule /@#{id}/, Keyword
+        rule %r/@#{id}/, Keyword
 
 
-        rule /(\\#{id})([{])/ do
+        rule %r/(\\#{id})([{])/ do
           groups Name::Function, Str
           push :nested_string
         end
 
-        rule /([+]#{id})([{])/ do
+        rule %r/([+]#{id})([{])/ do
           groups Name::Decorator, Str
           push :nested_string
         end
 
-        rule /\\#{id}/, Name::Function
-        rule /[+]#{id}/, Name::Decorator
+        rule %r/\\#{id}/, Name::Function
+        rule %r/[+]#{id}/, Name::Decorator
 
-        rule /"[{]/, Str, :dqi
-        rule /"/, Str, :dq
+        rule %r/"[{]/, Str, :dqi
+        rule %r/"/, Str, :dq
 
-        rule /'{/, Str, :nested_string
-        rule /'#{id}/, Str
+        rule %r/'{/, Str, :nested_string
+        rule %r/'#{id}/, Str
 
-        rule /[.]#{id}/, Name::Tag
-        rule /[$]#{id}?/, Name::Variable
-        rule /-#{id}:?/, Name::Label
-        rule /%#{id}/, Name::Function
-        rule /`#{id}/, Operator::Word
+        rule %r/[.]#{id}/, Name::Tag
+        rule %r/[$]#{id}?/, Name::Variable
+        rule %r/-#{id}:?/, Name::Label
+        rule %r/%#{id}/, Name::Function
+        rule %r/`#{id}/, Operator::Word
 
-        rule /[?~%._>,!\[\]:{}()=;\/-]/, Punctuation
+        rule %r/[?~%._>,!\[\]:{}()=;\/-]/, Punctuation
 
-        rule /[0-9]+([.][0-9]+)?/, Num
+        rule %r/[0-9]+([.][0-9]+)?/, Num
 
-        rule /#{id}/, Name
+        rule %r/#{id}/, Name
 
-        rule /</, Comment::Preproc, :angle_brackets
+        rule %r/</, Comment::Preproc, :angle_brackets
       end
 
       state :dq do
-        rule /[^\\"]+/, Str
-        rule /"/, Str, :pop!
-        rule /\\./, Str::Escape
+        rule %r/[^\\"]+/, Str
+        rule %r/"/, Str, :pop!
+        rule %r/\\./, Str::Escape
       end
 
       state :dqi do
-        rule /[$][(]/, Str::Interpol, :interp_root
-        rule /[{]/, Str, :dqi
-        rule /[}]/, Str, :pop!
-        rule /[^{}$]+/, Str
-        rule /./, Str
+        rule %r/[$][(]/, Str::Interpol, :interp_root
+        rule %r/[{]/, Str, :dqi
+        rule %r/[}]/, Str, :pop!
+        rule %r/[^{}$]+/, Str
+        rule %r/./, Str
       end
 
       state :interp_root do
-        rule /[)]/, Str::Interpol, :pop!
+        rule %r/[)]/, Str::Interpol, :pop!
         mixin :interp
       end
 
       state :interp do
-        rule /[(]/, Punctuation, :interp
-        rule /[)]/, Punctuation, :pop!
+        rule %r/[(]/, Punctuation, :interp
+        rule %r/[)]/, Punctuation, :pop!
         mixin :root
       end
 
       state :nested_string do
-        rule /\\./, Str::Escape
+        rule %r/\\./, Str::Escape
         rule(/{/) { token Str; push :nested_string }
         rule(/}/) { token Str; pop! }
         rule(/[^{}\\]+/) { token Str }
@@ -97,10 +97,10 @@ module Rouge
 
       state :angle_brackets do
         mixin :comments_and_whitespace
-        rule />/, Comment::Preproc, :pop!
-        rule /[*:]/, Punctuation
-        rule /#{upper_id}/, Keyword::Type
-        rule /#{id}/, Name::Variable
+        rule %r/>/, Comment::Preproc, :pop!
+        rule %r/[*:]/, Punctuation
+        rule %r/#{upper_id}/, Keyword::Type
+        rule %r/#{id}/, Name::Variable
       end
     end
   end

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -7,57 +7,54 @@ module Rouge
       title "Turtle/TriG"
       desc "Terse RDF Triple Language, TriG"
       tag 'turtle'
-      filenames *%w(*.ttl *.trig)
-      mimetypes *%w(
-        text/turtle
-        application/trig
-      )
+      filenames '*.ttl', '*.trig'
+      mimetypes 'text/turtle', 'application/trig'
 
       state :root do
-        rule /@base\b/, Keyword::Declaration
-        rule /@prefix\b/, Keyword::Declaration
-        rule /true\b/, Keyword::Constant
-        rule /false\b/, Keyword::Constant
+        rule %r/@base\b/, Keyword::Declaration
+        rule %r/@prefix\b/, Keyword::Declaration
+        rule %r/true\b/, Keyword::Constant
+        rule %r/false\b/, Keyword::Constant
 
-        rule /""".*?"""/m, Literal::String
-        rule /"([^"\\]|\\.)*"/, Literal::String
-        rule /'''.*?'''/m, Literal::String
-        rule /'([^'\\]|\\.)*'/, Literal::String
+        rule %r/""".*?"""/m, Literal::String
+        rule %r/"([^"\\]|\\.)*"/, Literal::String
+        rule %r/'''.*?'''/m, Literal::String
+        rule %r/'([^'\\]|\\.)*'/, Literal::String
 
-        rule /#.*$/, Comment::Single
+        rule %r/#.*$/, Comment::Single
 
-        rule /@[^\s,.; ]+/, Name::Attribute
+        rule %r/@[^\s,.; ]+/, Name::Attribute
 
-        rule /[+-]?[0-9]+\.[0-9]*E[+-]?[0-9]+/, Literal::Number::Float
-        rule /[+-]?\.[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
-        rule /[+-]?[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
+        rule %r/[+-]?[0-9]+\.[0-9]*E[+-]?[0-9]+/, Literal::Number::Float
+        rule %r/[+-]?\.[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
+        rule %r/[+-]?[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
 
-        rule /[+-]?[0-9]*\.[0-9]+?/, Literal::Number::Float
+        rule %r/[+-]?[0-9]*\.[0-9]+?/, Literal::Number::Float
 
-        rule /[+-]?[0-9]+/, Literal::Number::Integer
+        rule %r/[+-]?[0-9]+/, Literal::Number::Integer
 
-        rule /\./, Punctuation
-        rule /,/, Punctuation
-        rule /;/, Punctuation
-        rule /\(/, Punctuation
-        rule /\)/, Punctuation
-        rule /\{/, Punctuation
-        rule /\}/, Punctuation
-        rule /\[/, Punctuation
-        rule /\]/, Punctuation
-        rule /\^\^/, Punctuation
+        rule %r/\./, Punctuation
+        rule %r/,/, Punctuation
+        rule %r/;/, Punctuation
+        rule %r/\(/, Punctuation
+        rule %r/\)/, Punctuation
+        rule %r/\{/, Punctuation
+        rule %r/\}/, Punctuation
+        rule %r/\[/, Punctuation
+        rule %r/\]/, Punctuation
+        rule %r/\^\^/, Punctuation
 
-        rule /<[^>]*>/, Name::Label
+        rule %r/<[^>]*>/, Name::Label
 
-        rule /base\b/i, Keyword::Declaration
-        rule /prefix\b/i, Keyword::Declaration
-        rule /GRAPH\b/, Keyword
-        rule /a\b/, Keyword
+        rule %r/base\b/i, Keyword::Declaration
+        rule %r/prefix\b/i, Keyword::Declaration
+        rule %r/GRAPH\b/, Keyword
+        rule %r/a\b/, Keyword
 
-        rule /\s+/, Text::Whitespace
+        rule %r/\s+/, Text::Whitespace
 
-        rule /[^:;<>#\@"\(\).\[\]\{\} ]+:/, Name::Namespace
-        rule /[^:;<>#\@"\(\).\[\]\{\} ]+/, Name
+        rule %r/[^:;<>#\@"\(\).\[\]\{\} ]+:/, Name::Namespace
+        rule %r/[^:;<>#\@"\(\).\[\]\{\} ]+/, Name
       end
     end
   end

--- a/lib/rouge/lexers/vala.rb
+++ b/lib/rouge/lexers/vala.rb
@@ -29,7 +29,7 @@ module Rouge
       )
 
       state :whitespace do
-        rule /\s+/m, Text
+        rule %r/\s+/m, Text
         rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end
@@ -37,30 +37,30 @@ module Rouge
       state :root do
         mixin :whitespace
 
-        rule /^\s*\[.*?\]/, Name::Attribute
+        rule %r/^\s*\[.*?\]/, Name::Attribute
 
-        rule /(<\[)\s*(#{id}:)?/, Keyword
-        rule /\]>/, Keyword
+        rule %r/(<\[)\s*(#{id}:)?/, Keyword
+        rule %r/\]>/, Keyword
 
-        rule /[~!%^&*()+=|\[\]{}:;,.<>\/?-]/, Punctuation
-        rule /@"(\\.|.)*?"/, Str
-        rule /"(\\.|.)*?["\n]/, Str
-        rule /'(\\.|.)'/, Str::Char
-        rule /0x[0-9a-f]+[lu]?/i, Num
+        rule %r/[~!%^&*()+=|\[\]{}:;,.<>\/?-]/, Punctuation
+        rule %r/@"(\\.|.)*?"/, Str
+        rule %r/"(\\.|.)*?["\n]/, Str
+        rule %r/'(\\.|.)'/, Str::Char
+        rule %r/0x[0-9a-f]+[lu]?/i, Num
         rule %r(
           [0-9]
           ([.][0-9]*)? # decimal
           (e[+-][0-9]+)? # exponent
           [fldu]? # type
         )ix, Num
-        rule /\b(#{keywords.join('|')})\b/, Keyword
-        rule /\b(#{keywords_type.join('|')})\b/, Keyword::Type
-        rule /class|struct/, Keyword, :class
-        rule /namespace|using/, Keyword, :namespace
-        rule /#{id}(?=\s*[(])/, Name::Function
+        rule %r/\b(#{keywords.join('|')})\b/, Keyword
+        rule %r/\b(#{keywords_type.join('|')})\b/, Keyword::Type
+        rule %r/class|struct/, Keyword, :class
+        rule %r/namespace|using/, Keyword, :namespace
+        rule %r/#{id}(?=\s*[(])/, Name::Function
         rule id, Name
 
-        rule /#.*/, Comment::Preproc
+        rule %r/#.*/, Comment::Preproc
       end
 
       state :class do
@@ -70,8 +70,8 @@ module Rouge
 
       state :namespace do
         mixin :whitespace
-        rule /(?=[(])/, Text, :pop!
-        rule /(#{id}|[.])+/, Name::Namespace, :pop!
+        rule %r/(?=[(])/, Text, :pop!
+        rule %r/(#{id}|[.])+/, Name::Namespace, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/vb.rb
+++ b/lib/rouge/lexers/vb.rb
@@ -54,16 +54,16 @@ module Rouge
       upper_id = /[A-Z]\w*/
 
       state :whitespace do
-        rule /\s+/, Text
-        rule /\n/, Text, :bol
-        rule /rem\b.*?$/i, Comment::Single
+        rule %r/\s+/, Text
+        rule %r/\n/, Text, :bol
+        rule %r/rem\b.*?$/i, Comment::Single
         rule %r(%\{.*?%\})m, Comment::Multiline
-        rule /'.*$/, Comment::Single
+        rule %r/'.*$/, Comment::Single
       end
 
       state :bol do
-        rule /\s+/, Text
-        rule /<.*?>/, Name::Attribute
+        rule %r/\s+/, Text
+        rule %r/<.*?>/, Name::Attribute
         rule(//) { :pop! }
       end
 
@@ -80,15 +80,15 @@ module Rouge
           | [#]End \s+ Region
           | [#]ExternalChecksum
         )x, Comment::Preproc
-        rule /[.]/, Punctuation, :dotted
-        rule /[(){}!#,:]/, Punctuation
-        rule /Option\s+(Strict|Explicit|Compare)\s+(On|Off|Binary|Text)/,
+        rule %r/[.]/, Punctuation, :dotted
+        rule %r/[(){}!#,:]/, Punctuation
+        rule %r/Option\s+(Strict|Explicit|Compare)\s+(On|Off|Binary|Text)/,
           Keyword::Declaration
-        rule /End\b/, Keyword, :end
-        rule /(Dim|Const)\b/, Keyword, :dim
-        rule /(Function|Sub|Property)\b/, Keyword, :funcname
-        rule /(Class|Structure|Enum)\b/, Keyword, :classname
-        rule /(Module|Namespace|Imports)\b/, Keyword, :namespace
+        rule %r/End\b/, Keyword, :end
+        rule %r/(Dim|Const)\b/, Keyword, :dim
+        rule %r/(Function|Sub|Property)\b/, Keyword, :funcname
+        rule %r/(Class|Structure|Enum)\b/, Keyword, :classname
+        rule %r/(Module|Namespace|Imports)\b/, Keyword, :namespace
 
         rule upper_id do |m|
           match = m[0]
@@ -110,16 +110,16 @@ module Rouge
           Operator
         )
 
-        rule /"/, Str, :string
-        rule /#{id}[%&@!#\$]?/, Name
-        rule /#.*?#/, Literal::Date
+        rule %r/"/, Str, :string
+        rule %r/#{id}[%&@!#\$]?/, Name
+        rule %r/#.*?#/, Literal::Date
 
-        rule /(\d+\.\d*|\d*\.\d+)(f[+-]?\d+)?/i, Num::Float
-        rule /\d+([SILDFR]|US|UI|UL)?/, Num::Integer
-        rule /&H[0-9a-f]+([SILDFR]|US|UI|UL)?/, Num::Integer
-        rule /&O[0-7]+([SILDFR]|US|UI|UL)?/, Num::Integer
+        rule %r/(\d+\.\d*|\d*\.\d+)(f[+-]?\d+)?/i, Num::Float
+        rule %r/\d+([SILDFR]|US|UI|UL)?/, Num::Integer
+        rule %r/&H[0-9a-f]+([SILDFR]|US|UI|UL)?/, Num::Integer
+        rule %r/&O[0-7]+([SILDFR]|US|UI|UL)?/, Num::Integer
 
-        rule /_\n/, Keyword
+        rule %r/_\n/, Keyword
       end
 
       state :dotted do
@@ -128,9 +128,9 @@ module Rouge
       end
 
       state :string do
-        rule /""/, Str::Escape
-        rule /"C?/, Str, :pop!
-        rule /[^"]+/, Str
+        rule %r/""/, Str::Escape
+        rule %r/"C?/, Str, :pop!
+        rule %r/[^"]+/, Str
       end
 
       state :dim do
@@ -151,12 +151,12 @@ module Rouge
 
       state :namespace do
         mixin :whitespace
-        rule /#{id}([.]#{id})*/, Name::Namespace, :pop!
+        rule %r/#{id}([.]#{id})*/, Name::Namespace, :pop!
       end
 
       state :end do
         mixin :whitespace
-        rule /(Function|Sub|Property|Class|Structure|Enum|Module|Namespace)\b/,
+        rule %r/(Function|Sub|Property|Class|Structure|Enum|Module|Namespace)\b/,
           Keyword, :pop!
         rule(//) { pop! }
       end

--- a/lib/rouge/lexers/verilog.rb
+++ b/lib/rouge/lexers/verilog.rb
@@ -82,7 +82,7 @@ module Rouge
 
       state :expr_bol do
         mixin :inline_whitespace
-        rule /`define/, Comment::Preproc, :macro
+        rule %r/`define/, Comment::Preproc, :macro
 
         rule(//) { pop! }
       end
@@ -90,47 +90,47 @@ module Rouge
       # :expr_bol is the same as :bol but without labels, since
       # labels can only appear at the beginning of a statement.
       state :bol do
-        rule /#{id}:(?!:)/, Name::Label
+        rule %r/#{id}:(?!:)/, Name::Label
         mixin :expr_bol
       end
 
       state :inline_whitespace do
-        rule /[ \t\r]+/, Text
-        rule /\\\n/, Text # line continuation
+        rule %r/[ \t\r]+/, Text
+        rule %r/\\\n/, Text # line continuation
         rule %r(/(\\\n)?[*].*?[*](\\\n)?/)m, Comment::Multiline
       end
 
       state :whitespace do
-        rule /\n+/m, Text, :bol
+        rule %r/\n+/m, Text, :bol
         rule %r(//(\\.|.)*?\n), Comment::Single, :bol
         mixin :inline_whitespace
       end
 
       state :expr_whitespace do
-        rule /\n+/m, Text, :expr_bol
+        rule %r/\n+/m, Text, :expr_bol
         mixin :whitespace
       end
 
       state :string do
-        rule /"/, Str, :pop!
-        rule /\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
-        rule /[^\\"\n]+/, Str
-        rule /\\\n/, Str
-        rule /\\/, Str # stray backslash
+        rule %r/"/, Str, :pop!
+        rule %r/\\([\\abfnrtv"']|x[a-fA-F0-9]{2,4}|[0-7]{1,3})/, Str::Escape
+        rule %r/[^\\"\n]+/, Str
+        rule %r/\\\n/, Str
+        rule %r/\\/, Str # stray backslash
       end
 
       state :statement do
         mixin :whitespace
-        rule /L?"/, Str, :string
-        rule /([0-9_]+\.[0-9_]*|[0-9_]*\.[0-9_]+)(e[+-]?[0-9_]+)?/i, Num::Float
-        rule /[0-9_]+e[+-]?[0-9_]+/i, Num::Float
-        rule /[0-9]*'h[0-9a-fA-F_?]+/, Num::Hex
-        rule /[0-9]*'b?[01xz_?]+/, Num::Bin
-        rule /[0-9]*'d[0-9_?]+/, Num::Integer
-        rule /[0-9_]+[lu]*/i, Num::Integer
+        rule %r/L?"/, Str, :string
+        rule %r/([0-9_]+\.[0-9_]*|[0-9_]*\.[0-9_]+)(e[+-]?[0-9_]+)?/i, Num::Float
+        rule %r/[0-9_]+e[+-]?[0-9_]+/i, Num::Float
+        rule %r/[0-9]*'h[0-9a-fA-F_?]+/, Num::Hex
+        rule %r/[0-9]*'b?[01xz_?]+/, Num::Bin
+        rule %r/[0-9]*'d[0-9_?]+/, Num::Integer
+        rule %r/[0-9_]+[lu]*/i, Num::Integer
         rule %r([~!%^&*+-=\|?:<>/@{}]), Operator
-        rule /[()\[\],.$\#]/, Punctuation
-        rule /`(\w+)/, Comment::Preproc
+        rule %r/[()\[\],.$\#]/, Punctuation
+        rule %r/`(\w+)/, Comment::Preproc
 
         rule id do |m|
           name = m[0]
@@ -153,11 +153,11 @@ module Rouge
       end
 
       state :macro do
-        rule /\n/, Comment::Preproc, :pop!
+        rule %r/\n/, Comment::Preproc, :pop!
         mixin :inline_whitespace
-        rule /;/, Punctuation
-        rule /\=/, Operator
-        rule /(\w+)/, Text
+        rule %r/;/, Punctuation
+        rule %r/\=/, Operator
+        rule %r/(\w+)/, Text
       end
 
     end

--- a/lib/rouge/lexers/vhdl.rb
+++ b/lib/rouge/lexers/vhdl.rb
@@ -41,30 +41,30 @@ module Rouge
       id = /[a-zA-Z][a-zA-Z0-9_]*/
 
       state :whitespace do
-        rule /\s+/, Text
-        rule /\n/, Text
+        rule %r/\s+/, Text
+        rule %r/\n/, Text
         # Find Comments (VHDL doesn't support multiline comments)
-        rule /--.*$/, Comment::Single
+        rule %r/--.*$/, Comment::Single
       end
 
       state :statements do
 
         # Find Numbers
-        rule /-?\d+/i, Num::Integer
-        rule /-?\d+[.]\d+/i, Num::Float
+        rule %r/-?\d+/i, Num::Integer
+        rule %r/-?\d+[.]\d+/i, Num::Float
 
         # Find Strings
-        rule /[box]?"[^"]*"/i, Str::Single
-        rule /'[^']?'/i, Str::Char
+        rule %r/[box]?"[^"]*"/i, Str::Single
+        rule %r/'[^']?'/i, Str::Char
 
         # Find Attributes
-        rule /'#{id}/i, Name::Attribute
+        rule %r/'#{id}/i, Name::Attribute
         
         # Punctuations
-        rule /[(),:;]/, Punctuation
+        rule %r/[(),:;]/, Punctuation
 
         # Boolean and NULL
-        rule /(?:true|false|null)\b/i, Name::Builtin
+        rule %r/(?:true|false|null)\b/i, Name::Builtin
 
         rule id do |m|
           match = m[0].downcase   #convert to lower case

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -19,13 +19,13 @@ module Rouge
       end
 
       state :root do
-        rule /^(\s*)(".*?)$/ do
+        rule %r/^(\s*)(".*?)$/ do
           groups Text, Comment
         end
 
-        rule /^\s*\\/, Str::Escape
+        rule %r/^\s*\\/, Str::Escape
 
-        rule /[ \t]+/, Text
+        rule %r/[ \t]+/, Text
 
         # TODO: regexes can have other delimiters
         rule %r(/(\\\\|\\/|[^\n/])*/), Str::Regex
@@ -33,19 +33,19 @@ module Rouge
         rule %r('(\\\\|\\'|[^\n'])*'), Str::Single
 
         # if it's not a string, it's a comment.
-        rule /(?<=\s)"[^-:.%#=*].*?$/, Comment
+        rule %r/(?<=\s)"[^-:.%#=*].*?$/, Comment
 
-        rule /-?\d+/, Num
-        rule /#[0-9a-f]{6}/i, Num::Hex
-        rule /^:/, Punctuation
-        rule /[():<>+=!\[\]{}\|,~.-]/, Punctuation
-        rule /\b(let|if|else|endif|elseif|fun|function|endfunction)\b/,
+        rule %r/-?\d+/, Num
+        rule %r/#[0-9a-f]{6}/i, Num::Hex
+        rule %r/^:/, Punctuation
+        rule %r/[():<>+=!\[\]{}\|,~.-]/, Punctuation
+        rule %r/\b(let|if|else|endif|elseif|fun|function|endfunction)\b/,
           Keyword
 
-        rule /\b(NONE|bold|italic|underline|dark|light)\b/, Name::Builtin
+        rule %r/\b(NONE|bold|italic|underline|dark|light)\b/, Name::Builtin
 
-        rule /[absg]:\w+\b/, Name::Variable
-        rule /\b\w+\b/ do |m|
+        rule %r/[absg]:\w+\b/, Name::Variable
+        rule %r/\b\w+\b/ do |m|
           name = m[0]
           keywords = self.class.keywords
 
@@ -61,7 +61,7 @@ module Rouge
         end
 
         # no errors in VimL!
-        rule /./m, Text
+        rule %r/./m, Text
       end
 
       def mapping_contains?(mapping, word)

--- a/lib/rouge/lexers/vue.rb
+++ b/lib/rouge/lexers/vue.rb
@@ -36,21 +36,21 @@ module Rouge
       start { @js.reset! }
 
       prepend :root do
-        rule /(<)(\s*)(template)/ do
+        rule %r/(<)(\s*)(template)/ do
           groups Name::Tag, Text, Keyword
           @lang = HTML
           push :template
           push :lang_tag
         end
 
-        rule /(<)(\s*)(style)/ do
+        rule %r/(<)(\s*)(style)/ do
           groups Name::Tag, Text, Keyword
           @lang = CSS
           push :style
           push :lang_tag
         end
 
-        rule /(<)(\s*)(script)/ do
+        rule %r/(<)(\s*)(script)/ do
           groups Name::Tag, Text, Keyword
           @lang = Javascript
           push :script
@@ -59,7 +59,7 @@ module Rouge
       end
 
       state :style do
-        rule /(<\s*\/\s*)(style)(\s*>)/ do
+        rule %r/(<\s*\/\s*)(style)(\s*>)/ do
           groups Name::Tag, Keyword, Name::Tag
           pop!
         end
@@ -69,7 +69,7 @@ module Rouge
       end
 
       state :script do
-        rule /(<\s*\/\s*)(script)(\s*>)/ do
+        rule %r/(<\s*\/\s*)(script)(\s*>)/ do
           groups Name::Tag, Keyword, Name::Tag
           pop!
         end
@@ -79,7 +79,7 @@ module Rouge
       end
 
       state :lang_tag do
-        rule /(lang\s*=)(\s*)("(?:\\.|[^\\])*?"|'(\\.|[^\\])*?'|[^\s>]+)/ do |m|
+        rule %r/(lang\s*=)(\s*)("(?:\\.|[^\\])*?"|'(\\.|[^\\])*?'|[^\s>]+)/ do |m|
           groups Name::Attribute, Text, Str
           @lang = lookup_lang(m[3])
         end
@@ -93,7 +93,7 @@ module Rouge
           pop!
         end
 
-        rule /{{/ do
+        rule %r/{{/ do
           token Str::Interpol
           push :template_interpol
           @js.reset!
@@ -103,8 +103,8 @@ module Rouge
       end
 
       state :template_interpol do
-        rule /}}/, Str::Interpol, :pop!
-        rule /}/, Error
+        rule %r/}}/, Str::Interpol, :pop!
+        rule %r/}/, Error
         mixin :template_interpol_inner
       end
 

--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -7,7 +7,7 @@ module Rouge
       title 'Wollok'
       desc 'Wollok lang'
       tag 'wollok'
-      filenames *%w(*.wlk *.wtest *.wpgm)
+      filenames '*.wlk', '*.wtest', '*.wpgm'
 
       keywords = %w(new super return if else var const override constructor)
 
@@ -17,23 +17,23 @@ module Rouge
       entities = []
 
       state :whitespaces_and_comments do
-        rule /\s+/m, Text::Whitespace
-        rule /$+/m, Text::Whitespace
+        rule %r/\s+/m, Text::Whitespace
+        rule %r/$+/m, Text::Whitespace
         rule %r(//.*$), Comment::Single
         rule %r(/\*(.|\s)*?\*/)m, Comment::Multiline
       end
 
       state :root do
         mixin :whitespaces_and_comments
-        rule /(import)(.+$)/ do
+        rule %r/(import)(.+$)/ do
           groups Keyword::Reserved, Text
         end
-        rule /(class|object|mixin)/, Keyword::Reserved, :foo
-        rule /test|program/, Keyword::Reserved #, :chunk_naming
-        rule /(package)(\s+)(#{entity_name})/ do
+        rule %r/(class|object|mixin)/, Keyword::Reserved, :foo
+        rule %r/test|program/, Keyword::Reserved #, :chunk_naming
+        rule %r/(package)(\s+)(#{entity_name})/ do
           groups Keyword::Reserved, Text::Whitespace, Name::Class
         end
-        rule /{|}/, Text
+        rule %r/{|}/, Text
         mixin :keywords
         mixin :symbols
         mixin :objects
@@ -41,13 +41,13 @@ module Rouge
 
       state :foo do
         mixin :whitespaces_and_comments
-        rule /inherits|mixed|with|and/, Keyword::Reserved
-        rule /#{entity_name}(?=\s*{)/ do |m|
+        rule %r/inherits|mixed|with|and/, Keyword::Reserved
+        rule %r/#{entity_name}(?=\s*{)/ do |m|
           token Name::Class
           entities << m[0]
           pop!
         end
-        rule /#{entity_name}/ do |m|
+        rule %r/#{entity_name}/ do |m|
           token Name::Class
           entities << m[0]
         end
@@ -58,9 +58,9 @@ module Rouge
           /#{expressions.map { |keyword| "#{keyword}\\b" }.join('|')}/
         end
 
-        rule /self\b/, Name::Builtin::Pseudo
+        rule %r/self\b/, Name::Builtin::Pseudo
         rule any(keywords), Keyword::Reserved
-        rule /(method)(\s+)(#{variable_naming})/ do
+        rule %r/(method)(\s+)(#{variable_naming})/ do
           groups Keyword::Reserved, Text::Whitespace, Text
         end
       end
@@ -74,30 +74,30 @@ module Rouge
             token Keyword::Variable
           end
         end
-        rule /\.#{entity_name}/, Text
+        rule %r/\.#{entity_name}/, Text
         mixin :literals
       end
 
       state :literals do
         mixin :whitespaces_and_comments
-        rule /[0-9]+\.?[0-9]*/, Literal::Number
-        rule /"[^"]*"/m, Literal::String
-        rule /\[|\#{/, Punctuation, :lists
+        rule %r/[0-9]+\.?[0-9]*/, Literal::Number
+        rule %r/"[^"]*"/m, Literal::String
+        rule %r/\[|\#{/, Punctuation, :lists
       end
 
       state :lists do
-        rule /,/, Punctuation
-        rule /]|}/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        rule %r/]|}/, Punctuation, :pop!
         mixin :objects
       end
 
       state :symbols do
-        rule /\+\+|--|\+=|-=|\*\*|!/, Operator
-        rule /\+|-|\*|\/|%/, Operator
-        rule /<=|=>|===|==|<|>/, Operator
-        rule /and\b|or\b|not\b/, Operator
-        rule /\(|\)|=/, Text
-        rule /,/, Punctuation
+        rule %r/\+\+|--|\+=|-=|\*\*|!/, Operator
+        rule %r/\+|-|\*|\/|%/, Operator
+        rule %r/<=|=>|===|==|<|>/, Operator
+        rule %r/and\b|or\b|not\b/, Operator
+        rule %r/\(|\)|=/, Text
+        rule %r/,/, Punctuation
       end
     end
   end

--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -7,14 +7,10 @@ module Rouge
       title "XML"
       desc %q(<desc for="this-lexer">XML</desc>)
       tag 'xml'
-      filenames *%w(*.xml *.xsl *.rss *.xslt *.xsd *.wsdl *.svg *.plist)
-      mimetypes *%w(
-        text/xml
-        application/xml
-        image/svg+xml
-        application/rss+xml
-        application/atom+xml
-      )
+      filenames '*.xml', '*.xsl', '*.rss', '*.xslt', '*.xsd', '*.wsdl', '*.svg',
+                '*.plist'
+      mimetypes 'text/xml', 'application/xml', 'image/svg+xml', 
+                'application/rss+xml', 'application/atom+xml'
 
       def self.detect?(text)
         return false if text.doctype?(/html/)
@@ -23,12 +19,12 @@ module Rouge
       end
 
       state :root do
-        rule /[^<&]+/, Text
-        rule /&\S*?;/, Name::Entity
-        rule /<!\[CDATA\[.*?\]\]\>/, Comment::Preproc
-        rule /<!--/, Comment, :comment
-        rule /<\?.*?\?>/, Comment::Preproc
-        rule /<![^>]*>/, Comment::Preproc
+        rule %r/[^<&]+/, Text
+        rule %r/&\S*?;/, Name::Entity
+        rule %r/<!\[CDATA\[.*?\]\]\>/, Comment::Preproc
+        rule %r/<!--/, Comment, :comment
+        rule %r/<\?.*?\?>/, Comment::Preproc
+        rule %r/<![^>]*>/, Comment::Preproc
 
         # open tags
         rule %r(<\s*[\w:.-]+)m, Name::Tag, :tag
@@ -38,20 +34,20 @@ module Rouge
       end
 
       state :comment do
-        rule /[^-]+/m, Comment
-        rule /-->/, Comment, :pop!
-        rule /-/, Comment
+        rule %r/[^-]+/m, Comment
+        rule %r/-->/, Comment, :pop!
+        rule %r/-/, Comment
       end
 
       state :tag do
-        rule /\s+/m, Text
-        rule /[\w.:-]+\s*=/m, Name::Attribute, :attr
+        rule %r/\s+/m, Text
+        rule %r/[\w.:-]+\s*=/m, Name::Attribute, :attr
         rule %r(/?\s*>), Name::Tag, :pop!
       end
 
       state :attr do
-        rule /\s+/m, Text
-        rule /".*?"|'.*?'|[^\s>]+/m, Str, :pop!
+        rule %r/\s+/m, Text
+        rule %r/".*?"|'.*?'|[^\s>]+/m, Str, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/xojo.rb
+++ b/lib/rouge/lexers/xojo.rb
@@ -37,7 +37,7 @@ module Rouge
         rule %r/\s+/, Text::Whitespace
 
         rule %r/rem\b.*?$/i, Comment::Single
-        rule %r/\/\/.*$/, Comment::Single
+        rule %r(//.*$), Comment::Single
         rule %r/\#tag Note.*\#tag EndNote/m, Comment::Preproc
         rule %r/\s*[#].*$/x, Comment::Preproc
 

--- a/lib/rouge/lexers/xojo.rb
+++ b/lib/rouge/lexers/xojo.rb
@@ -34,26 +34,26 @@ module Rouge
         )
 
       state :root do
-        rule /\s+/, Text::Whitespace
+        rule %r/\s+/, Text::Whitespace
 
-        rule /rem\b.*?$/i, Comment::Single
-        rule /\/\/.*$/, Comment::Single
-        rule /\#tag Note.*\#tag EndNote/m, Comment::Preproc
-        rule /\s*[#].*$/x, Comment::Preproc
+        rule %r/rem\b.*?$/i, Comment::Single
+        rule %r/\/\/.*$/, Comment::Single
+        rule %r/\#tag Note.*\#tag EndNote/m, Comment::Preproc
+        rule %r/\s*[#].*$/x, Comment::Preproc
 
-        rule /".*?"/, Literal::String::Double
-        rule /[(){}!#,:]/, Punctuation
+        rule %r/".*?"/, Literal::String::Double
+        rule %r/[(){}!#,:]/, Punctuation
 
-        rule /\b(?:#{keywords.join('|')})\b/i, Keyword
-        rule /\b(?:#{keywords_type.join('|')})\b/i, Keyword::Declaration
+        rule %r/\b(?:#{keywords.join('|')})\b/i, Keyword
+        rule %r/\b(?:#{keywords_type.join('|')})\b/i, Keyword::Declaration
 
-        rule /\b(?:#{operator_words.join('|')})\b/i, Operator
-        rule /[+-]?(\d+\.\d*|\d*\.\d+)/i, Literal::Number::Float
-        rule /[+-]?\d+/, Literal::Number::Integer
-        rule /&[CH][0-9a-f]+/i, Literal::Number::Hex
-        rule /&O[0-7]+/i, Literal::Number::Oct
+        rule %r/\b(?:#{operator_words.join('|')})\b/i, Operator
+        rule %r/[+-]?(\d+\.\d*|\d*\.\d+)/i, Literal::Number::Float
+        rule %r/[+-]?\d+/, Literal::Number::Integer
+        rule %r/&[CH][0-9a-f]+/i, Literal::Number::Hex
+        rule %r/&O[0-7]+/i, Literal::Number::Oct
 
-        rule /\b[\w\.]+\b/i, Text
+        rule %r/\b[\w\.]+\b/i, Text
         rule(%r(<=|>=|<>|[=><\+\-\*\/\\]), Operator)
       end
     end

--- a/lib/rouge/plugins/redcarpet.rb
+++ b/lib/rouge/plugins/redcarpet.rb
@@ -15,7 +15,7 @@ module Rouge
         # so we assume you're not using leading spaces that aren't tabs,
         # and just replace them here.
         if lexer.tag == 'make'
-          code.gsub! /^    /, "\t"
+          code.gsub! %r/^    /, "\t"
         end
 
         formatter = rouge_formatter(lexer)

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -23,8 +23,8 @@ describe Rouge::Lexer do
   it 'makes a simple lexer' do
     a_lexer = Class.new(Rouge::RegexLexer) do
       state :root do
-        rule /a/, 'A'
-        rule /b/, 'B'
+        rule %r/a/, 'A'
+        rule %r/b/, 'B'
       end
     end
 
@@ -41,13 +41,13 @@ describe Rouge::Lexer do
   it 'pushes and pops states' do
     a_lexer = Class.new(Rouge::RegexLexer) do
       state :brace do
-        rule /b/, 'B'
-        rule /}/, 'Brace', :pop!
+        rule %r/b/, 'B'
+        rule %r/}/, 'Brace', :pop!
       end
 
       state :root do
-        rule /{/, 'Brace', :brace
-        rule /a/, 'A'
+        rule %r/{/, 'Brace', :brace
+        rule %r/a/, 'A'
       end
     end
 
@@ -69,7 +69,7 @@ describe Rouge::Lexer do
   it 'does callbacks and grouping' do
     callback_lexer = Class.new(Rouge::RegexLexer) do
       state :root do
-        rule /(a)(b)/ do |s|
+        rule %r/(a)(b)/ do |s|
           groups('A', 'B')
         end
       end
@@ -85,16 +85,16 @@ describe Rouge::Lexer do
   it 'pops from the callback' do
     callback_lexer = Class.new(Rouge::RegexLexer) do
       state :root do
-        rule /a/, 'A', :a
-        rule /d/, 'D'
+        rule %r/a/, 'A', :a
+        rule %r/d/, 'D'
       end
 
       state :a do
-        rule /b/, 'B', :b
+        rule %r/b/, 'B', :b
       end
 
       state :b do
-        rule /c/ do |ss|
+        rule %r/c/ do |ss|
           token 'C'
           pop!; pop! # go back to the root
         end
@@ -111,12 +111,12 @@ describe Rouge::Lexer do
       end
 
       state :root do
-        rule /\d+/ do |ss|
+        rule %r/\d+/ do |ss|
           token 'digit'
           @count = ss[0].to_i
         end
 
-        rule /\+/ do |ss|
+        rule %r/\+/ do |ss|
           incr
           token(@count <= 5 ? 'lt' : 'gt')
         end
@@ -131,8 +131,8 @@ describe Rouge::Lexer do
   it 'delegates' do
     class MasterLexer < Rouge::RegexLexer
       state :root do
-        rule /a/, 'A'
-        rule /{(.*?)}/ do |m|
+        rule %r/a/, 'A'
+        rule %r/{(.*?)}/ do |m|
           token 'brace', '{'
           delegate BracesLexer.new, m[1]
           token 'brace', '}'
@@ -142,7 +142,7 @@ describe Rouge::Lexer do
 
     class BracesLexer < Rouge::RegexLexer
       state :root do
-        rule /b/, 'B'
+        rule %r/b/, 'B'
       end
     end
 
@@ -152,8 +152,8 @@ describe Rouge::Lexer do
   it 'detects the beginnings of lines with ^ rules' do
     class MyLexer < Rouge::RegexLexer
       state :root do
-        rule /^a/, 'start'
-        rule /a/, 'not-start'
+        rule %r/^a/, 'start'
+        rule %r/a/, 'not-start'
       end
     end
 

--- a/spec/lexers/brainfuck_spec.rb
+++ b/spec/lexers/brainfuck_spec.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Brainfuck do
+  let(:subject) { Rouge::Lexers::Brainfuck.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.b'
+      assert_guess :filename => 'FOO.bf', :source => 'foo'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-brainfuck'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one-line comments not followed by a newline (#796)' do
+      assert_tokens_equal 'comment', ['Comment.Single', 'comment']
+    end
+  end
+end

--- a/spec/lexers/python_spec.rb
+++ b/spec/lexers/python_spec.rb
@@ -23,9 +23,11 @@ describe Rouge::Lexers::Python do
 
     it 'guesses by source' do
       assert_guess :source => '#!/usr/bin/env python'
-      assert_guess :source => '#!/usr/local/bin/python3'
       assert_guess :source => '#!/usr/bin/python2'
       assert_guess :source => '#!/usr/bin/python2.7'
+      assert_guess :source => '#!/usr/local/bin/python3'
+      assert_guess :source => '#!/usr/local/bin/python3.5'
+      assert_guess :source => '#!/usr/local/bin/python3.14'
       deny_guess   :source => '#!/usr/bin/env python4'
     end
   end

--- a/spec/visual/samples/brainfuck
+++ b/spec/visual/samples/brainfuck
@@ -1,0 +1,20 @@
+[
+This program will print "Hello world!"
+]
+++++++++++
+[
+   >+++++++>++++++++++>+++>+<<<<-
+]
+>++. Initial loop (it will be printed an H)
+>+. e
++++++++. l
+. l
++++. o
+>++. space
+<<+++++++++++++++. W
+>. o
++++. r
+------. l
+--------. d
+>+. !
+>.


### PR DESCRIPTION
Rouge currently disables Rubocop's AmbiguousRegexpLiteral cop and its Lint/AmbiguousOperator. Presumably this was because of the large number of regular expressions used in Rouge that are defined using the `/.../` literal syntax.

This commit prepends all regular expressions of that form with `%r`. It also tidies up a few uses of the `*%w()` construct that are present in the codebase. This allows these warnings to be turned on without causing any issues.

It should be noted that having the warnings disabled is not a problem in and of itself. However, these constructs also raise warnings when running Ruby with the `-w` switch. Getting Rouge to a point where it can be run with the `-w` switch will allow for a safer development environment.