### PR TITLE
Reset instance variable only if it is defined

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -213,7 +213,7 @@ module Rouge
       # @private
       def register(name, lexer)
         # reset an existing list of lexers
-        @all = nil if @all
+        @all = nil if defined?(@all)
         registry[name.to_s] = lexer
       end
 


### PR DESCRIPTION
This is to remove interpreter warning issued when the variable has not yet been defined but attempted to be read nevertheless.