### PR TITLE
properly deprecate the options hash

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -423,15 +423,22 @@ module Rouge
     #
     # @note The use of `opts` has been deprecated. A warning is issued if run
     #   with `$VERBOSE` set to true.
-    def lex(string, opts={}, &b)
-      unless opts.nil?
-        warn 'The use of opts with Lexer.lex is deprecated' if $VERBOSE
+    def lex(string, opts=nil, &b)
+      if opts
+        if opts.empty?
+          warn 'the use of options with Lexer#lex is deprecated' if $VERBOSE
+        elsif opts.size == 1 && opts[:continue]
+          warn '`lex :continue => true` is deprecated, please use #continue_lex instead'
+          return continue_lex(string, &b)
+        else
+          raise ArgumentError.new("invalid options for Lexer#lex: #{opts.inspect}")
+        end
       end
 
-      return enum_for(:lex, string, opts) unless block_given?
+      return enum_for(:lex, string) unless block_given?
 
       Lexer.assert_utf8!(string)
-      reset! unless opts[:continue]
+      reset!
 
       continue_lex(string, &b)
     end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -425,13 +425,15 @@ module Rouge
     #   with `$VERBOSE` set to true.
     def lex(string, opts=nil, &b)
       if opts
-        if opts.empty?
-          warn 'the use of options with Lexer#lex is deprecated' if $VERBOSE
-        elsif opts.size == 1 && opts[:continue]
+        if (opts.keys - [:continue]).size > 0
+          # improper use of options hash
+          warn('Improper use of Lexer#lex - this method does not receive options.' +
+               ' This will become an error in a future version.')
+        end
+
+        if opts[:continue]
           warn '`lex :continue => true` is deprecated, please use #continue_lex instead'
           return continue_lex(string, &b)
-        else
-          raise ArgumentError.new("invalid options for Lexer#lex: #{opts.inspect}")
         end
       end
 

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -421,8 +421,11 @@ module Rouge
     # @option opts :continue
     #   Continue the lex from the previous state (i.e. don't call #reset!)
     #
-    # @note The use of `opts` has been deprecated. A warning is issued if run
-    #   with `$VERBOSE` set to true.
+    # @note The use of :continue => true has been deprecated. A warning is
+    #       issued if run with `$VERBOSE` set to true.
+    #
+    # @note The use of arbitrary `opts` has never been supported, but we
+    #       previously ignored them with no error. We now warn unconditionally.
     def lex(string, opts=nil, &b)
       if opts
         if (opts.keys - [:continue]).size > 0


### PR DESCRIPTION
Closes #1186 

The warnings were being generated because of the one-step recursion in `enum_for` passing an empty options hash. Thank you @mojavelinux for spotting this.

As it is now, in the common happy-path case in which no options are passed, we pay only the price of a single nil check. Otherwise, we detect the `:continue` option, which *unconditionally* outputs a warning. Empty hashes are only a warning with `-w`, though this will become an ArgumentError in the next major version. We also properly raise an ArgumentError if invalid options are passed.