### PR TITLE
add Lexer#with, for specifying options after initialization

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -313,6 +313,12 @@ module Rouge
       @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
+    def with(opts={})
+      new_options = @options.dup
+      opts.each { |k, v| new_options[k.to_s] = v }
+      self.class.new(new_options)
+    end
+
     def as_bool(val)
       case val
       when nil, false, 0, '0', 'off'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -38,25 +38,15 @@ module Rouge
         registry[name.to_s]
       end
 
-      # Find a lexer, with fancy shiny features.
+      # Same as ::find_fancy, except instead of returning an instantiated
+      # lexer, returns a pair of [lexer_class, options], so that you can
+      # modify or provide additional options to the lexer.
       #
-      # * The string you pass can include CGI-style options
-      #
-      #     Lexer.find_fancy('erb?parent=tex')
-      #
-      # * You can pass the special name 'guess' so we guess for you,
-      #   and you can pass a second argument of the code to guess by
-      #
-      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
-      #
-      # This is used in the Redcarpet plugin as well as Rouge's own
-      # markdown lexer for highlighting internal code blocks.
-      #
-      def find_fancy(str, code=nil, additional_options={})
-
+      # Rlease note: the lexer class might be nil!
+      def lookup_fancy(str, code=nil, additional_options={})
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
-          return lexer_class && lexer_class.new(additional_options)
+          return [lexer_class, additional_options]
         end
 
         name, opts = str ? str.split('?', 2) : [nil, '']
@@ -80,6 +70,26 @@ module Rouge
         when String
           self.find(name)
         end
+
+        [lexer_class, opts]
+      end
+
+      # Find a lexer, with fancy shiny features.
+      #
+      # * The string you pass can include CGI-style options
+      #
+      #     Lexer.find_fancy('erb?parent=tex')
+      #
+      # * You can pass the special name 'guess' so we guess for you,
+      #   and you can pass a second argument of the code to guess by
+      #
+      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
+      #
+      # This is used in the Redcarpet plugin as well as Rouge's own
+      # markdown lexer for highlighting internal code blocks.
+      #
+      def find_fancy(str, code=nil, additional_options={})
+        lexer_class, opts = lookup_fancy(str, code, additional_options)
 
         lexer_class && lexer_class.new(opts)
       end

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -185,4 +185,16 @@ describe Rouge::Lexer do
     refute { NonDetectableLexer.methods(false).include?(:detect?) }
     refute { NonDetectableLexer.detectable? }
   end
+
+  it 'extends options with #with' do
+    php = Rouge::Lexers::PHP.new
+
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+
+    inline_php = php.with(start_inline: true)
+    assert { inline_php.is_a?(Rouge::Lexers::PHP) }
+    assert { inline_php != php }
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+    assert { inline_php.instance_variable_get(:@start_inline) == true }
+  end
 end


### PR DESCRIPTION
cc @mojavelinux 

A common use case is to want to set options on the return value of something like `Lexer.find_fancy`, which returns an instance rather than a class. While in the future we may want to allow those options to be passed to the `#lex` method, we must wait for a major version release to clear the deprecation of the `:continue` option.

In the meanwhile, since lexer initializers are uniform, we can provide a method `:with` that returns a cloned lexer with extra options, which should satisfy most use cases.