### PR TITLE
Add block support to Lexer.find_fancy

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -313,6 +313,12 @@ module Rouge
       @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
+    def with(opts={})
+      new_options = @options.dup
+      opts.each { |k, v| new_options[k.to_s] = v }
+      self.class.new(new_options)
+    end
+
     def as_bool(val)
       case val
       when nil, false, 0, '0', 'off'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -38,25 +38,15 @@ module Rouge
         registry[name.to_s]
       end
 
-      # Find a lexer, with fancy shiny features.
+      # Same as ::find_fancy, except instead of returning an instantiated
+      # lexer, returns a pair of [lexer_class, options], so that you can
+      # modify or provide additional options to the lexer.
       #
-      # * The string you pass can include CGI-style options
-      #
-      #     Lexer.find_fancy('erb?parent=tex')
-      #
-      # * You can pass the special name 'guess' so we guess for you,
-      #   and you can pass a second argument of the code to guess by
-      #
-      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
-      #
-      # This is used in the Redcarpet plugin as well as Rouge's own
-      # markdown lexer for highlighting internal code blocks.
-      #
-      def find_fancy(str, code=nil, additional_options={})
-
+      # Rlease note: the lexer class might be nil!
+      def lookup_fancy(str, code=nil, additional_options={})
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
-          return lexer_class && lexer_class.new(additional_options)
+          return [lexer_class, additional_options]
         end
 
         name, opts = str ? str.split('?', 2) : [nil, '']
@@ -80,6 +70,26 @@ module Rouge
         when String
           self.find(name)
         end
+
+        [lexer_class, opts]
+      end
+
+      # Find a lexer, with fancy shiny features.
+      #
+      # * The string you pass can include CGI-style options
+      #
+      #     Lexer.find_fancy('erb?parent=tex')
+      #
+      # * You can pass the special name 'guess' so we guess for you,
+      #   and you can pass a second argument of the code to guess by
+      #
+      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
+      #
+      # This is used in the Redcarpet plugin as well as Rouge's own
+      # markdown lexer for highlighting internal code blocks.
+      #
+      def find_fancy(str, code=nil, additional_options={})
+        lexer_class, opts = lookup_fancy(str, code, additional_options)
 
         lexer_class && lexer_class.new(opts)
       end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -43,7 +43,7 @@ module Rouge
       # modify or provide additional options to the lexer.
       #
       # Rlease note: the lexer class might be nil!
-      def lookup_fancy(str, code=nil, additional_options={})
+      def find_fancy_class(str, code=nil, additional_options={})
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
           return [lexer_class, additional_options]
@@ -88,10 +88,14 @@ module Rouge
       # This is used in the Redcarpet plugin as well as Rouge's own
       # markdown lexer for highlighting internal code blocks.
       #
-      def find_fancy(str, code=nil, additional_options={})
-        lexer_class, opts = lookup_fancy(str, code, additional_options)
+      def find_fancy(str, code=nil, additional_options={}, &b)
+        lexer_class, opts = find_fancy_class(str, code, additional_options)
 
-        lexer_class && lexer_class.new(opts)
+        if block_given?
+          yield lexer_class, opts
+        else
+          lexer_class && lexer_class.new(opts)
+        end
       end
 
       # Specify or get this lexer's title. Meant to be human-readable.

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -185,4 +185,16 @@ describe Rouge::Lexer do
     refute { NonDetectableLexer.methods(false).include?(:detect?) }
     refute { NonDetectableLexer.detectable? }
   end
+
+  it 'extends options with #with' do
+    php = Rouge::Lexers::PHP.new
+
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+
+    inline_php = php.with(start_inline: true)
+    assert { inline_php.is_a?(Rouge::Lexers::PHP) }
+    assert { inline_php != php }
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+    assert { inline_php.instance_variable_get(:@start_inline) == true }
+  end
 end

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -4,6 +4,26 @@
 describe Rouge::Lexer do
   include Support::Lexing
 
+  it 'finds a lexer using Lexer.find_fancy' do
+    assert { Rouge::Lexer.find_fancy('ruby').tag == 'ruby' }
+  end
+
+  it 'finds a lexer with options using Lexer.find_fancy' do
+    assert { Rouge::Lexer.find_fancy('ruby', nil, { option1: true }).options == { "option1" => true } }
+  end
+
+  it 'finds a lexer with embedded options using Lexer.find_fancy' do
+    assert { Rouge::Lexer.find_fancy('ruby?option1=true').options == { "option1" => "true" } }
+  end
+
+  it 'finds a lexer using Lexer.find_fancy and a block' do
+    lexer = Rouge::Lexer.find_fancy('ruby') do |lexer_class, opts|
+      lexer_class.new(opts)
+    end
+
+    assert { lexer.tag == 'ruby' }
+  end
+
   it 'guesses the lexer with Lexer.guess' do
     assert { Rouge::Lexer.guess(filename: 'foo.rb').tag == 'ruby' }
   end


### PR DESCRIPTION
_Discussion is intended to continue in #1188._

Currently,  revisions to `Lexer` are being discussed in #1188. This PR is intended to improve the solution provided in that branch. 

The code proposed in #1188 includes a method `Lexer.lookup_fancy` that returns a Lexer subclass. This is in addition to the existing method `Lexer.find_fancy` that returns an instance of a Lexer subclass. This difference is not evident from the names of the methods  and so this commit renames `lookup_fancy` to `find_fancy_class`.

Separately, the commit also adds support to consumers passing a block to `find_fancy`. It is not envisaged that block passing will be common but supporting it allows for consumers to use idiomatic Ruby to customise the instantiation of  a lexer. 

Finally, tests are added.