### PR TITLE
Configure Probot to close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
@@ -11,7 +11,7 @@ staleLabel: stale-contribution
 markComment: >
   This contribution has been automatically marked as stale because it has not
   had any activity for more than a year. It will be closed if no additional
-  activity occurs within the next seven days.
+  activity occurs within the next 14 days.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
 only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale-contribution
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This contribution has been automatically marked as stale because it has not
+  had any activity for more than a year. It will be closed if no additional
+  activity occurs within the next seven days.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+only: issues

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Rouge is only for UTF-8 strings.  If you'd like to highlight a string with a dif
 
 ## Contributing
 
+### Bug reports
+
+Rouge uses GitHub issues to report bugs. You can [choose][issue-chooser] from one of our templates or create a custom issue. Issues that have not been active for a year are automatically closed by GitHub's [Probot][].
+
+[issue-chooser]: https://github.com/rouge-ruby/rouge/issues/new/choose "Issue Template Chooser"
+[Probot]: https://probot.github.io "GitHub's Probot"
+
 ### Installing Ruby
 
 If you're here to implement a lexer for your awesome language, there's a good chance you don't already have a ruby development environment set up.  Follow the [instructions on the wiki](https://github.com/rouge-ruby/rouge/wiki/Setting-up-Ruby) to get up and running.  If you have trouble getting set up, let me know - I'm always happy to help.


### PR DESCRIPTION
GitHub's [Probot](https://probot.github.io/apps/stale/) can be configured to close stale issues.

This commit sets the period of non-activity to be one year. It exempts issues that are tagged with a 'security' label.