### PR TITLE
Add pr-open to Probot's  exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
+  - pr-open
 # Label to use when marking an issue as stale
 staleLabel: stale-issue
 # Comment to post when marking an issue as stale. Set to `false` to disable
@@ -12,7 +13,7 @@ markComment: >
   This issue has been automatically marked as stale because it has not
   had any activity for more than a year. It will be closed if no additional
   activity occurs within the next 14 days.
-
+   
   If you would like this issue to remain open, please reply and let us know if
   the issue is still reproducible.
 # Comment to post when closing a stale issue. Set to `false` to disable


### PR DESCRIPTION
GitHub's probot can exclude issues with certain labels from being marked stale. Issues that are the subject of an open PR should not be marked as stale. This commit fixes that.