### PR TITLE
Add missing bgColor for 'monokai.sublime' theme

### DIFF
--- a/lib/rouge/themes/monokai_sublime.rb
+++ b/lib/rouge/themes/monokai_sublime.rb
@@ -11,6 +11,7 @@ module Rouge
       palette :bright_pink    => '#f92672'
       palette :carmine        => '#960050'
       palette :dark           => '#49483e'
+      palette :dark_graphite  => '#272822'
       palette :dark_grey      => '#888888'
       palette :dark_red       => '#aa0000'
       palette :dimgrey        => '#75715e'
@@ -80,7 +81,7 @@ module Rouge
             Name::Variable,
             Text::Whitespace,
             Text,
-            Name,                             :fg => :white
+            Name,                             :fg => :white, :bg => :dark_graphite
       style Operator::Word,
             Name::Tag,
             Keyword,


### PR DESCRIPTION
`MonokaiSublime` theme is missing the style for `background-color`. A quick search online showed that Monokai generally uses a dark greyish color of value `#272822` in SublimeText 2 (Not sure of the value in ST3)

Instead of changing the value of `:dark`, this instead introduces `:dark_graphite` for backward-compatibility.

/cc @jneen 