### PR TITLE
add a `rake similarity[lexer_name]` and Similarity tester

### DIFF
--- a/spec/support/similarity.rb
+++ b/spec/support/similarity.rb
@@ -1,11 +1,16 @@
 module Similarity
   def self.test(lexer_class)
-    state_names = Set.new(lexer_class.state_definitions.keys)
+    # state_defintions is an InheritableHash, so we use `own_keys` to
+    # exclude states inherited from superclasses
+    state_names = Set.new(lexer_class.state_definitions.own_keys)
 
     candidates = Rouge::Lexer.all.select do |x|
-      next false if x == lexer_class
+      # we can only compare to RegexLexers which have state_definitions
       next false unless x < Rouge::RegexLexer
-      next false if x < lexer_class || lexer_class < x
+
+      # don't compare a lexer to itself or any subclasses
+      next false if x <= lexer_class
+
       true
     end
 

--- a/spec/support/similarity.rb
+++ b/spec/support/similarity.rb
@@ -1,0 +1,26 @@
+module Similarity
+  def self.test(lexer_class)
+    state_names = Set.new(lexer_class.state_definitions.keys)
+
+    candidates = Rouge::Lexer.all.select do |x|
+      next false if x == lexer_class
+      next false unless x < Rouge::RegexLexer
+      next false if x < lexer_class || lexer_class < x
+      true
+    end
+
+    max_score = 1
+    matches = []
+    candidates.each do |candidate|
+      score = (state_names & candidate.state_definitions.keys).size
+      if score > max_score
+        max_score = score
+        matches = [candidate]
+      elsif score == max_score
+        matches << candidate
+      end
+    end
+
+    [max_score, matches]
+  end
+end

--- a/tasks/similarity.rake
+++ b/tasks/similarity.rake
@@ -1,16 +1,27 @@
+def test_similarity(lexer_class)
+  score, matches = Similarity.test(lexer_class)
+
+  if score == 1
+    puts "[none]"
+  else
+    puts "[#{score}] #{matches.map(&:tag).join(', ')}"
+  end
+end
+
 desc "tests the similarity with existing lexers"
 task :similarity, [:language] do |t, args|
   require 'rouge'
   require "#{File.dirname(File.dirname(__FILE__))}/spec/support/similarity.rb"
 
   language = args.language
-  lexer_class = Rouge::Lexer.find(language)
 
-  score, matches = Similarity.test(lexer_class)
-
-  if score == 1
-    puts "No similarity found"
+  if language
+    test_similarity Rouge::Lexer.find(language)
   else
-    puts "Similarity index #{score} with #{matches.map(&:tag).join(', ')}"
+    Rouge::Lexer.all.each do |lexer_class|
+      print "#{lexer_class.tag}: "
+      test_similarity lexer_class if lexer_class < Rouge::RegexLexer
+    end
   end
+
 end

--- a/tasks/similarity.rake
+++ b/tasks/similarity.rake
@@ -1,0 +1,16 @@
+desc "tests the similarity with existing lexers"
+task :similarity, [:language] do |t, args|
+  require 'rouge'
+  require "#{File.dirname(File.dirname(__FILE__))}/spec/support/similarity.rb"
+
+  language = args.language
+  lexer_class = Rouge::Lexer.find(language)
+
+  score, matches = Similarity.test(lexer_class)
+
+  if score == 1
+    puts "No similarity found"
+  else
+    puts "Similarity index #{score} with #{matches.map(&:tag).join(', ')}"
+  end
+end

--- a/tasks/similarity.rake
+++ b/tasks/similarity.rake
@@ -11,7 +11,7 @@ end
 desc "tests the similarity with existing lexers"
 task :similarity, [:language] do |t, args|
   require 'rouge'
-  require "#{File.dirname(File.dirname(__FILE__))}/spec/support/similarity.rb"
+  require "#{File.dirname(__dir__)}/spec/support/similarity.rb"
 
   language = args.language
 
@@ -23,5 +23,4 @@ task :similarity, [:language] do |t, args|
       test_similarity lexer_class if lexer_class < Rouge::RegexLexer
     end
   end
-
 end


### PR DESCRIPTION
This finds lexers that are similar (in state names only, for now) to a
given lexer. This will be useful in maintenance to flag a submitted
lexer as a likely copy-paste job.