### PR TITLE
Prefer faster __dir__ instead of dirname(__FILE__)

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -114,7 +114,7 @@ module Rouge
       def demo_file(arg=:absent)
         return @demo_file = Pathname.new(arg) unless arg == :absent
 
-        @demo_file = Pathname.new(__FILE__).dirname.join('demos', tag)
+        @demo_file = Pathname.new(File.join(__dir__, 'demos', tag))
       end
 
       # Specify or get a small demo string for this lexer

--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -15,7 +15,7 @@ module Rouge
         attr_reader :keywords
       end
       # Load Apache keywords from separate YML file
-      @keywords = ::YAML.load_file(Pathname.new(__FILE__).dirname.join('apache/keywords.yml')).tap do |h|
+      @keywords = ::YAML.load_file(File.join(__dir__, 'apache/keywords.yml')).tap do |h|
         h.each do |k,v|
           h[k] = Set.new v
         end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -19,7 +19,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('gherkin/keywords.rb')
+        load File.join(__dir__, 'gherkin/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -39,7 +39,7 @@ module Rouge
       end
 
       # Load Lasso keywords from separate YML file
-      @keywords = ::YAML.load_file(Pathname.new(__FILE__).dirname.join('lasso/keywords.yml')).tap do |h|
+      @keywords = ::YAML.load_file(File.join(__dir__, 'lasso/keywords.yml')).tap do |h|
         h.each do |k,v|
           h[k] = Set.new v
         end

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -25,7 +25,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('lua/builtins.rb')
+        load File.join(__dir__, 'lua/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -56,7 +56,7 @@ module Rouge
 
       # The list of built-in symbols comes from a wolfram server and is created automatically by rake
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('mathematica/builtins.rb')
+        load File.join(__dir__, 'mathematica/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -19,7 +19,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('matlab/builtins.rb')
+        load File.join(__dir__, 'matlab/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -29,7 +29,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('php/builtins.rb')
+        load File.join(__dir__, 'php/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/sqf.rb
+++ b/lib/rouge/lexers/sqf.rb
@@ -55,7 +55,7 @@ module Rouge
       end
 
       def self.commands
-        load Pathname.new(__FILE__).dirname.join("sqf/commands.rb")
+        load File.join(__dir__, "sqf/commands.rb")
         @commands = self.commands
       end
 

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -14,7 +14,7 @@ module Rouge
       mimetypes 'text/x-vim'
 
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('viml/keywords.rb')
+        load File.join(__dir__, 'viml/keywords.rb')
         self.keywords
       end
 


### PR DESCRIPTION
Except for `Lexer.demo_file`, all other lines changed are intermediate calls that can be easily changed to a better alternative that returns the same result.

`(Pathname.new(__FILE__).dirname.join(file_path)` creates intermediate objects. This can be avoided by opting for Ruby native `File.join(__dir__, file_path)` which doesn't allocate intermediate Ruby objects.

Since `Lexer.demo_file` returns a `Pathname` object, that behavior has been maintained with a slight optimization.