### PR TITLE
shell: balance parentheses inside $(...) interpolation

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -141,8 +141,17 @@ module Rouge
         mixin :root
       end
 
-      state :paren do
+      # the state inside $(...)
+      state :paren_interp do
         rule %r/\)/, Keyword, :pop!
+        rule %r/\(/, Operator, :paren_inner
+        mixin :root
+      end
+
+      # used to balance parentheses inside interpolation
+      state :paren_inner do
+        rule %r/\(/, Operator, :push
+        rule %r/\)/, Operator, :pop!
         mixin :root
       end
 
@@ -174,7 +183,7 @@ module Rouge
         rule %r/\\$/, Str::Escape # line continuation
         rule %r/\\./, Str::Escape
         rule %r/\$\(\(/, Keyword, :math
-        rule %r/\$\(/, Keyword, :paren
+        rule %r/\$\(/, Keyword, :paren_interp
         rule %r/\${#?/, Keyword, :curly
         rule %r/`/, Str::Backtick, :backticks
         rule %r/\$#?(\w+|.)/, Name::Variable

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -71,7 +71,7 @@ module Rouge
 
       state :heredoc do
         rule %r/\n/, Str::Heredoc, :heredoc_nl
-        rule %r/[^$\n]+/, Str::Heredoc
+        rule %r/[^$\n\\]+/, Str::Heredoc
         mixin :interp
         rule %r/[$]/, Str::Heredoc
       end

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -143,7 +143,7 @@ module Rouge
 
       # the state inside $(...)
       state :paren_interp do
-        rule %r/\)/, Keyword, :pop!
+        rule %r/\)/, Str::Interpol, :pop!
         rule %r/\(/, Operator, :paren_inner
         mixin :root
       end
@@ -183,7 +183,7 @@ module Rouge
         rule %r/\\$/, Str::Escape # line continuation
         rule %r/\\./, Str::Escape
         rule %r/\$\(\(/, Keyword, :math
-        rule %r/\$\(/, Keyword, :paren_interp
+        rule %r/\$\(/, Str::Interpol, :paren_interp
         rule %r/\${#?/, Keyword, :curly
         rule %r/`/, Str::Backtick, :backticks
         rule %r/\$#?(\w+|.)/, Name::Variable

--- a/spec/visual/samples/shell
+++ b/spec/visual/samples/shell
@@ -17,6 +17,9 @@ if [ -n "$BASH_VERSION" ]; then . "$RY_PREFIX/lib/ry.bash_completion"; fi
 
 echo $((16#0F)) # should be 15
 
+echo "Balanced paren interpolation: $( if (( a == b )) ; then echo "equal" ; fi )"
+echo "Balanced paren interpolation: $( ( seq 10; seq 10 ) | grep 0 )"
+
 # ltmain.sh - Provide generalized library-building support services.
 # NOTE: Changing this file will not affect anything until you rerun configure.
 #


### PR DESCRIPTION
Fixes #812

To lex correctly, we must make sure that interpolation does not end
until the balanced parenthesis. For this we need to use the state stack
to track the parenthesis depth.