### PR TITLE
Fix invalid parenthesis state in PowerShell lexer

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -633,7 +633,7 @@ module Rouge
         rule %r/`$/, Str::Escape # line continuation
         rule %r/`./, Str::Escape
         rule %r/\$\(\(/, Keyword, :math
-        rule %r/\$\(/, Keyword, :paren
+        rule %r/\$\(/, Str::Interpol, :paren_interp
         rule %r/\${#?/, Keyword, :curly
         rule %r/\$#?(\w+|.)/, Name::Variable
       end


### PR DESCRIPTION
The update to the Shell lexer made as a result of #1216 should have included an update to the PowerShell lexer. This is because the Shell lexer renamed the `:paren` state. Since the PowerShell lexer relies on this state, it needed to be updated to refer to the new state. This PR does that and fixes #1221.