### PR TITLE
Fix empty-color bug

### DIFF
--- a/lib/rouge/tex_theme_renderer.rb
+++ b/lib/rouge/tex_theme_renderer.rb
@@ -35,8 +35,8 @@ module Rouge
 END
 
       base = @theme.class.base_style
-      yield "\\definecolor{#{@prefix}@fgcolor}{HTML}{#{inline_name(base.fg)}}"
-      yield "\\definecolor{#{@prefix}@bgcolor}{HTML}{#{inline_name(base.bg)}}"
+      yield "\\definecolor{#{@prefix}@fgcolor}{HTML}{#{inline_name(base.fg || '#000000')}}"
+      yield "\\definecolor{#{@prefix}@bgcolor}{HTML}{#{inline_name(base.bg || '#FFFFFF')}}"
 
       render_palette(@theme.palette, &b)
 


### PR DESCRIPTION
We were previously rendering no color for styles that had no specified
background color, which resulted in a TeX error. This fixes that by
defaulting the foreground to black and the background to white.

(observed in the theme `base16.solarized.light`)