### PR TITLE
Improve tokenising of numbers in Elixir lexer

### DIFF
--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -38,8 +38,11 @@ module Rouge
         rule %r/[a-zA-Z_!]\w*[!\?]?/, Name
         rule %r{::|[%(){};,/\|:\\\[\]]}, Punctuation
         rule %r/@[a-zA-Z_]\w*|&\d/, Name::Variable
-        rule %r{\b(0[xX][0-9A-Fa-f]+|\d(_?\d)*(\.(?![^\d\s])
-             (_?\d)*)?([eE][-+]?\d(_?\d)*)?|0[bB][01]+)\b}x, Num
+        rule %r{\b\d(_?\d)*(\.(?![^\d\s])(_?\d)+)([eE][-+]?\d(_?\d)*)?\b}, Num::Float
+        rule %r{\b0x[0-9A-Fa-f](_?[0-9A-Fa-f])*\b}, Num::Hex
+        rule %r{\b0o[0-7](_?[0-7])*\b}, Num::Oct
+        rule %r{\b0b[01](_?[01])*\b}, Num::Bin
+        rule %r{\b\d(_?\d)*\b}, Num::Integer
 
         mixin :strings
         mixin :sigil_strings

--- a/spec/visual/samples/elixir
+++ b/spec/visual/samples/elixir
@@ -1,3 +1,10 @@
+# numbers
+291         # integer
+0b100100011 # binary
+0o443       # octal
+0x123       # hexadecimal
+291.0       # float
+
 # keywords with no following whitespace
 (cond)
 (do)


### PR DESCRIPTION
The Elixir lexer does not include sophisticated rules for tokenising numbers. This commit adds rules for distinguishing between integer, float, hexadecimal, octal and binary representations. It incorporates the work of @thth from #1015.