### PR TITLE
Fix README command to run a single test

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If you're here to implement a lexer for your awesome language, there's a good ch
 
 ### Run the tests
 
-You can test the core of Rouge simply by running `rake` (no `bundle exec` required), or `rake spec TEST=spec/xxx_spec.rb`
+You can test the core of Rouge simply by running `rake` (no `bundle exec` required), or `rake spec TEST=spec/lexers/xxx_spec.rb`
 to run a single test file.
 
 It's also set up with `guard`, if you like.


### PR DESCRIPTION
This PR fixes the instructions to run a single test.

Currently, the `README` says to run `rake spec TEST=spec/xxx_spec.rb` to run a single test, but this does not work, as the test file is in `spec/lexers/xxx_spec.rb`, not `spec/xxx_spec.rb`

<details>
<summary>Console output</summary>
Old instructions: 

```bash
$ rake spec TEST=spec/ruby_spec.rb

File does not exist: /home/maxime/code/rouge/spec/ruby_spec.rb
```

Fixed instructions:

```bash
$ rake spec TEST=spec/lexers/ruby_spec.rb
Run options: --seed 22200

# Running:

...........

Finished in 0.084233s, 130.5899 runs/s, 546.1034 assertions/s.

11 runs, 46 assertions, 0 failures, 0 errors, 0 skips
```
