### PR TITLE
Fix highlighting of YAML block strings

### DIFF
--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -246,7 +246,7 @@ module Rouge
           end
         end
 
-        rule %r/[^\n\r\f\v]+/, Name::Constant
+        rule %r/[^\n\r\f\v]+/, Str
       end
 
       state :block_scalar_header do

--- a/spec/visual/samples/yaml
+++ b/spec/visual/samples/yaml
@@ -182,9 +182,12 @@ not a number: .NaN
 # Miscellaneous
 ---
 null: ~
-true: boolean
-false: boolean
+bool_true: true
+str_true: 'true'
+bool_false: false
+str_false: "false"
 string: '12345'
+number: 12345
 
 # Timestamps
 ---
@@ -205,6 +208,7 @@ application specific tag: !something |
  The semantics of the tag
  above may be different for
  different documents.
+email_regex: !ruby/regexp '/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i'
 
 # Global tags
 %TAG ! tag:clarkevans.com,2002:


### PR DESCRIPTION
Currently, YAML block strings are allotted as `Name::Constant` tokens.
(Note that the `[String] "Mark McGwire"` and block strings are colored differently).

![YAML Visual Test - before](https://user-images.githubusercontent.com/12479464/60400192-642f6600-9b8e-11e9-925e-5384b37bf3ee.png)

Ideally, there shouldn't be a differentiation.
Result after fix:

![YAML Visual Test - after](https://user-images.githubusercontent.com/12479464/60400265-db64fa00-9b8e-11e9-9730-a20b0944c0d9.png)
