### PR TITLE
Fix num literals in YAML scalar block highlighting

### DIFF
--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -328,7 +328,7 @@ module Rouge
       state :plain_scalar_in_block_context do
         # the : indicator ends a scalar
         rule %r/[ ]*(?=:[ \n]|:$)/, Text, :pop!
-        rule %r/[ ]*:/, Str
+        rule %r/[ ]*:\S+/, Str
         rule %r/[ ]+(?=#)/, Text, :pop!
         rule %r/[ ]+$/, Text
         # check for new documents or dedents at the new line
@@ -339,6 +339,8 @@ module Rouge
 
         rule %r/[ ]+/, Str
         rule SPECIAL_VALUES, Name::Constant
+        rule %r/\d+(?:\.\d+)?(?=(\r?\n)| +#)/, Literal::Number, :pop!
+
         # regular non-whitespace characters
         rule %r/[^\s:]+/, Str
       end

--- a/spec/visual/samples/yaml
+++ b/spec/visual/samples/yaml
@@ -32,6 +32,7 @@ national:
   name: Mark McGwire
   hr:   65
   avg:  0.278
+  addr: B 221 Block
 -
   name: Sammy Sosa
   hr:   63


### PR DESCRIPTION
Standalone num literals in a block scalar should be tokenized as `Literal::Number` not `Str`.
However if those literals are preceded or succeeded by other non-whitespace characters, then it would be a legit `Str` token.
The exception is if the next tokens are `whitespace` and a `comment`:

```yaml
# Mapping scalars to scalars
---
hr:  65    # Home runs
avg: 0.278 # Batting average
rbi: 147   # Runs Batted In
time: 20:03:20
staff:
  - name: Mark McGwire
    hr:   65
    avg:  0.278
    addr: B 221 Block
```
![YAML Visual Test](https://user-images.githubusercontent.com/12479464/60431607-c6837780-9c1d-11e9-871b-18f85d871617.png)
