### PR TITLE
Improve readability of lexer debug outputs

### DIFF
--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -102,21 +102,21 @@ module Rouge
         callback ||= case next_state
         when :pop!
           proc do |stream|
-            puts "    yielding #{tok.qualname}, #{stream[0].inspect}" if @debug
+            puts "    yielding: #{tok.qualname}, #{stream[0].inspect}" if @debug
             @output_stream.call(tok, stream[0])
             puts "    popping stack: 1" if @debug
             @stack.pop or raise 'empty stack!'
           end
         when :push
           proc do |stream|
-            puts "    yielding #{tok.qualname}, #{stream[0].inspect}" if @debug
+            puts "    yielding: #{tok.qualname}, #{stream[0].inspect}" if @debug
             @output_stream.call(tok, stream[0])
             puts "    pushing :#{@stack.last.name}" if @debug
             @stack.push(@stack.last)
           end
         when Symbol
           proc do |stream|
-            puts "    yielding #{tok.qualname}, #{stream[0].inspect}" if @debug
+            puts "    yielding: #{tok.qualname}, #{stream[0].inspect}" if @debug
             @output_stream.call(tok, stream[0])
             state = @states[next_state] || self.class.get_state(next_state)
             puts "    pushing :#{state.name}" if @debug
@@ -124,7 +124,7 @@ module Rouge
           end
         when nil
           proc do |stream|
-            puts "    yielding #{tok.qualname}, #{stream[0].inspect}" if @debug
+            puts "    yielding: #{tok.qualname}, #{stream[0].inspect}" if @debug
             @output_stream.call(tok, stream[0])
           end
         else
@@ -263,6 +263,7 @@ module Rouge
 
       until stream.eos?
         if @debug
+          puts
           puts "lexer: #{self.class.tag}"
           puts "stack: #{stack.map(&:name).map(&:to_sym).inspect}"
           puts "stream: #{stream.peek(20).inspect}"
@@ -289,11 +290,11 @@ module Rouge
     def step(state, stream)
       state.rules.each do |rule|
         if rule.is_a?(State)
-          puts "  entering mixin #{rule.name}" if @debug
+          puts "  entering: mixin :#{rule.name}" if @debug
           return true if step(rule, stream)
-          puts "  exiting  mixin #{rule.name}" if @debug
+          puts "  exiting:  mixin :#{rule.name}" if @debug
         else
-          puts "  trying #{rule.inspect}" if @debug
+          puts "  trying: #{rule.inspect}" if @debug
 
           # XXX HACK XXX
           # StringScanner's implementation of ^ is b0rken.
@@ -303,14 +304,14 @@ module Rouge
           next if rule.beginning_of_line && !stream.beginning_of_line?
 
           if (size = stream.skip(rule.re))
-            puts "    got #{stream[0].inspect}" if @debug
+            puts "    got: #{stream[0].inspect}" if @debug
 
             instance_exec(stream, &rule.callback)
 
             if size.zero?
               @null_steps += 1
               if @null_steps > MAX_NULL_SCANS
-                puts "    too many scans without consuming the string!" if @debug
+                puts "    warning: too many scans without consuming the string!" if @debug
                 return false
               end
             else
@@ -362,7 +363,7 @@ module Rouge
     # @param [String] text
     #   The text to delegate.  This defaults to the last matched string.
     def delegate(lexer, text=nil)
-      puts "    delegating to #{lexer.inspect}" if @debug
+      puts "    delegating to: #{lexer.inspect}" if @debug
       text ||= @current_stream[0]
 
       lexer.continue_lex(text) do |tok, val|
@@ -388,7 +389,7 @@ module Rouge
         self.state
       end
 
-      puts "    pushing :#{push_state.name}" if @debug
+      puts "    pushing: :#{push_state.name}" if @debug
       stack.push(push_state)
     end
 
@@ -408,7 +409,7 @@ module Rouge
     def goto(state_name)
       raise 'empty stack!' if stack.empty?
 
-      puts "    going to state :#{state_name} " if @debug
+      puts "    going to: state :#{state_name} " if @debug
       stack[-1] = get_state(state_name)
     end
 
@@ -435,7 +436,7 @@ module Rouge
   private
     def yield_token(tok, val)
       return if val.nil? || val.empty?
-      puts "    yielding #{tok.qualname}, #{val.inspect}" if @debug
+      puts "    yielding: #{tok.qualname}, #{val.inspect}" if @debug
       @output_stream.yield(tok, val)
     end
   end

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -292,7 +292,7 @@ module Rouge
         if rule.is_a?(State)
           puts "  entering: mixin :#{rule.name}" if @debug
           return true if step(rule, stream)
-          puts "  exiting:  mixin :#{rule.name}" if @debug
+          puts "  exiting: mixin :#{rule.name}" if @debug
         else
           puts "  trying: #{rule.inspect}" if @debug
 

--- a/lib/rouge/util.rb
+++ b/lib/rouge/util.rb
@@ -75,13 +75,13 @@ module Rouge
     def starts_block(block_state)
       @block_state = block_state
       @block_indentation = @last_indentation || ''
-      puts "    starts_block #{block_state.inspect}" if @debug
+      puts "    starts_block: #{block_state.inspect}" if @debug
       puts "    block_indentation: #{@block_indentation.inspect}" if @debug
     end
 
     # handle a single indented line
     def indentation(indent_str)
-      puts "    indentation #{indent_str.inspect}" if @debug
+      puts "    indentation: #{indent_str.inspect}" if @debug
       puts "    block_indentation: #{@block_indentation.inspect}" if @debug
       @last_indentation = indent_str
 


### PR DESCRIPTION
### Before
```
start blocks
    pushing :expr_start
lexer: ruby
stack: [:root, :expr_start]
stream: "#######\n# ruby 1.9 e"
  entering mixin inline_whitespace
  trying #<Rule /[ \t\r]+/>
  exiting  mixin inline_whitespace
  trying #<Rule /\//>
  trying #<Rule /
          [?](\\[MC]-)*     # modifiers
          (\\([\\abefnrstv\#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})|\S)
          (?!\w)
        /x>
  trying #<Rule /(\s*)(%[rqswQWxiI]? \S* )/>
  entering mixin sigil_strings
  trying #<Rule /%([rqswQWxiI])?([^\w\s])/>
  exiting  mixin sigil_strings
  trying #<Rule //>
    got ""
    popping stack: 1
lexer: ruby
stack: [:root]
stream: "#######\n# ruby 1.9 e"
  entering mixin whitespace
  entering mixin inline_whitespace
  trying #<Rule /[ \t\r]+/>
  exiting  mixin inline_whitespace
  trying #<Rule /\n\s*/m>
  trying #<Rule /#.*$/>
    got "#######"
    yielding Comment.Single, "#######"
lexer: ruby
stack: [:root]
stream: "\n# ruby 1.9 examples"
  entering mixin whitespace
  entering mixin inline_whitespace
  trying #<Rule /[ \t\r]+/>
  exiting  mixin inline_whitespace
  trying #<Rule /\n\s*/m>
    got "\n"
    yielding Text, "\n"
    pushing :expr_start
```

### After
```
start blocks
    pushing: :expr_start

lexer: ruby
stack: [:root, :expr_start]
stream: "#######\n# ruby 1.9 e"
  entering: mixin :inline_whitespace
  trying: #<Rule /[ \t\r]+/>
  exiting:  mixin :inline_whitespace
  trying: #<Rule /\//>
  trying: #<Rule /
          [?](\\[MC]-)*     # modifiers
          (\\([\\abefnrstv\#"']|x[a-fA-F0-9]{1,2}|[0-7]{1,3})|\S)
          (?!\w)
        /x>
  trying: #<Rule /(\s*)(%[rqswQWxiI]? \S* )/>
  entering: mixin :sigil_strings
  trying: #<Rule /%([rqswQWxiI])?([^\w\s])/>
  exiting:  mixin :sigil_strings
  trying: #<Rule //>
    got: ""
    popping stack: 1

lexer: ruby
stack: [:root]
stream: "#######\n# ruby 1.9 e"
  entering: mixin :whitespace
  entering: mixin :inline_whitespace
  trying: #<Rule /[ \t\r]+/>
  exiting:  mixin :inline_whitespace
  trying: #<Rule /\n\s*/m>
  trying: #<Rule /#.*$/>
    got: "#######"
    yielding: Comment.Single, "#######"

lexer: ruby
stack: [:root]
stream: "\n# ruby 1.9 examples"
  entering: mixin :whitespace
  entering: mixin :inline_whitespace
  trying: #<Rule /[ \t\r]+/>
  exiting:  mixin :inline_whitespace
  trying: #<Rule /\n\s*/m>
    got: "\n"
    yielding: Text, "\n"
    pushing :expr_start
```