### PR TITLE
Configure Bundler to validate task dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require 'rake/clean'
 require 'pathname'
+require 'bundler/setup'
 require "bundler/gem_tasks"
 require "rake/testtask"
 


### PR DESCRIPTION
@pyrmont This should let one use our rake tasks without having to prepend `bundle exec`.

To test:
  - Test-1: Delete any existing `Gemfile.lock` and run `rake changelog:insert`
  - Test-2: Rename `vendor` directory (or wherever Bundler is configured to install) to something else and try running `rake`

Bundler should inform you if about `bundle install` if one of the dependencies have not been installed.