### PR TITLE
Dupe and escape span values only if necessary

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -36,6 +36,15 @@ module Rouge
       }
 
     private
+      # A performance-oriented helper method to escape `&`, `<` and `>` for the rendered
+      # HTML from this formatter.
+      #
+      # `String#gsub` will always return a new string instance irrespective of whether
+      # a substitution occurs. This method however invokes `String#gsub` only if
+      # a substitution is imminent.
+      #
+      # Returns either the given `value` argument string as is or a new string with the
+      # special characters replaced with their escaped counterparts.
       def escape_special_html_chars(value)
         escape_regex = /[&<>]/
         return value unless value =~ escape_regex

--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -15,7 +15,7 @@ module Rouge
       def span(tok, val)
         return val if escape?(tok)
 
-        safe_span(tok, val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML))
+        safe_span(tok, escape_special_html_chars(val))
       end
 
       def safe_span(tok, safe_val)
@@ -29,12 +29,19 @@ module Rouge
         end
       end
 
-
       TABLE_FOR_ESCAPE_HTML = {
         '&' => '&amp;',
         '<' => '&lt;',
         '>' => '&gt;',
       }
+
+    private
+      def escape_special_html_chars(value)
+        escape_regex = /[&<>]/
+        return value unless value =~ escape_regex
+
+        value.gsub(escape_regex, TABLE_FOR_ESCAPE_HTML)
+      end
     end
   end
 end


### PR DESCRIPTION
## Rationale

`String.gsub` creates a copy of every string passed to it irrespective of whether a substitution occurs.
This can lead to unnecessary memory consumption.

## Summary

Use a private helper to substitute values conditionally.
Invoke `String.gsub` only if the string matches our pattern beforehand. Otherwise, return the given string itself.

## Impact

Local tests show a reduction in values reported by the `profile_memory` task.

<details>
<summary>Report diff of Travis logs</summary>

```diff
--- master https://travis-ci.org/rouge-ruby/rouge/jobs/553590198
+++ PR     https://travis-ci.org/rouge-ruby/rouge/jobs/553607013

- Total allocated: 12.66 MB (123308 objects)
- Total retained:  4.51 MB (31707 objects)
+ Total allocated: 12.56 MB (120831 objects)
+ Total retained:  4.51 MB (31709 objects)
```
</details>

Basic benchmarks show that the proposed route is *faster* for strings that don't need escaping, but *equally slower* for strings that do need escaping.

<details>
<summary>Benchmark script</summary>

```ruby
# frozen_string_literal: true

require 'benchmark/ips'

TABLE_FOR_ESCAPE_HTML = {
  '&' => '&amp;',
  '<' => '&lt;',
  '>' => '&gt;',
}

def escape(value)
  value.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
end

def cond_escape(value)
  escape_regex = /[&<>]/
  return value unless value =~ escape_regex

  value.gsub(escape_regex, TABLE_FOR_ESCAPE_HTML)
end

[
  ['plain', 'The quick brown badgers jumped over the lazy dog'],
  ['specl', 'The quick brown <fox> jumped & over the lazy dog']
].each do |key, value|
  Benchmark.ips do |x|
    x.report("esc #{key}") { escape(value) }
    x.report("cond_esc #{key}") { cond_escape(value) }
    x.compare!
  end
end
```
</details>

<details>
<summary>Benchmark results</summary>

```bash
Warming up --------------------------------------
           esc plain    50.502k i/100ms
      cond_esc plain    52.509k i/100ms
Calculating -------------------------------------
           esc plain    944.667k (A± 1.3%) i/s -      4.747M in   5.026118s
      cond_esc plain      1.056M (A± 0.4%) i/s -      5.303M in   5.024585s

Comparison:
      cond_esc plain:  1055512.1 i/s
           esc plain:   944666.6 i/s - 1.12x  slower

Warming up --------------------------------------
           esc specl    13.415k i/100ms
      cond_esc specl    12.547k i/100ms
Calculating -------------------------------------
           esc specl    169.639k (A± 0.7%) i/s -    858.560k in   5.061389s
      cond_esc specl    154.341k (A± 1.8%) i/s -    777.914k in   5.042006s

Comparison:
           esc specl:   169638.6 i/s
      cond_esc specl:   154341.2 i/s - 1.10x  slower
```
</details>