### PR TITLE
Avoid allocating block parameters unnecessarily

### DIFF
--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -50,7 +50,7 @@ module Rouge
 
       state :section do
         # Match section arguments
-        rule %r/([^>]+)?(>(?:\r\n?|\n)?)/ do |m|
+        rule %r/([^>]+)?(>(?:\r\n?|\n)?)/ do
           groups Literal::String::Regex, Punctuation
           pop!
         end

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -18,25 +18,25 @@ module Rouge
 
       state :root do
         # Calls to helpers
-        rule %r/(call)(\s+)(\d+)/i do |m|
+        rule %r/(call)(\s+)(\d+)/i do
           groups Keyword, Text::Whitespace, Literal::Number::Integer
         end
 
         # Unconditional jumps
-        rule %r/(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do |m|
+        rule %r/(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 
         # Conditional jumps
-        rule %r/(if)(\s+)(r\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do |m|
+        rule %r/(if)(\s+)(r\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Literal::Number, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
-        rule %r/(if)(\s+)(r\d+)(\s*)([s!=<>]+)(\s*)(r\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do |m|
+        rule %r/(if)(\s+)(r\d+)(\s*)([s!=<>]+)(\s*)(r\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Name, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 
         # Dereferences
-        rule %r/(\*)(\s*)(\()(#{TYPE_KEYWORDS})(\s*)(\*)(\))/i do |m|
+        rule %r/(\*)(\s*)(\()(#{TYPE_KEYWORDS})(\s*)(\*)(\))/i do
           groups Operator, Text::Whitespace, Punctuation, Keyword::Type, Text::Whitespace, Operator, Punctuation
           push :address
         end
@@ -45,7 +45,7 @@ module Rouge
         rule %r/[+-\/\*&|><^s]{0,3}=/i, Operator
 
         # Registers
-        rule %r/([+-]?)(r\d+)/i do |m|
+        rule %r/([+-]?)(r\d+)/i do
           groups Punctuation, Name
         end
 
@@ -56,15 +56,15 @@ module Rouge
         rule %r/#{MISC_KEYWORDS}/i, Keyword
 
         # Literals and global objects (maps) refered by name
-        rule %r/(0x\h+|[-]?\d+)(\s*)(ll)?/i do |m|
+        rule %r/(0x\h+|[-]?\d+)(\s*)(ll)?/i do
           groups Literal::Number, Text::Whitespace, Keyword::Type
         end
-        rule %r/(\w+)(\s*)(ll)/i do |m|
+        rule %r/(\w+)(\s*)(ll)/i do
           groups Name, Text::Whitespace, Keyword::Type
         end
 
         # Labels
-        rule %r/(\w+)(\s*)(:)/i do |m|
+        rule %r/(\w+)(\s*)(:)/i do
           groups Name::Label, Text::Whitespace, Punctuation
         end
 
@@ -73,17 +73,17 @@ module Rouge
 
       state :address do
         # Address is offset from register
-        rule %r/(\()(r\d+)(\s*)([+-])(\s*)(\d+)(\))/i do |m|
+        rule %r/(\()(r\d+)(\s*)([+-])(\s*)(\d+)(\))/i do
           groups Punctuation, Name, Text::Whitespace, Operator, Text::Whitespace, Literal::Number::Integer, Punctuation
           pop!
         end
 
         # Address is array subscript
-        rule %r/(\w+)(\[)(\d+)(\])/i do |m|
+        rule %r/(\w+)(\[)(\d+)(\])/i do
           groups Name, Punctuation, Literal::Number::Integer, Punctuation
           pop!
         end
-        rule %r/(\w+)(\[)(r\d+)(\])/i do |m|
+        rule %r/(\w+)(\[)(r\d+)(\])/i do
           groups Name, Punctuation, Name, Punctuation
           pop!
         end

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -20,11 +20,11 @@ module Rouge
       state :root do
         rule %r/\s+/, Text
 
-        rule %r/^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do |m|
+        rule %r/^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do
           groups Keyword, Text::Whitespace, Keyword, Str
         end
 
-        rule %r/^(#{KEYWORDS})\b(.*)/io do |m|
+        rule %r/^(#{KEYWORDS})\b(.*)/io do
           groups Keyword, Str
         end
 

--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -72,7 +72,7 @@ module Rouge
       end
 
       state :content do
-        rule %r/.+/m do |m|
+        rule %r/.+/m do
           delegate(content_lexer)
         end
       end

--- a/lib/rouge/lexers/idlang.rb
+++ b/lib/rouge/lexers/idlang.rb
@@ -243,7 +243,7 @@ module Rouge
 
         rule %r{\#\#|\#|\&\&|\|\||/=|<=|>=|->|\@|\?|[-+*/<=~^{}]}, Operator
         # Structures and the like
-        rule %r/(#{name})(\.)([^\s,]*)/i do |m|
+        rule %r/(#{name})(\.)([^\s,]*)/i do
           groups Name, Operator, Name
           #delegate IDLang, m[3]
         end

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -69,7 +69,7 @@ module Rouge
       end
 
       state :block_body do
-        rule %r/(\t[\t ]*)([@-]?)/ do |m|
+        rule %r/(\t[\t ]*)([@-]?)/ do
           groups Text, Punctuation
           push :shell_line
         end

--- a/lib/rouge/lexers/nim.rb
+++ b/lib/rouge/lexers/nim.rb
@@ -133,11 +133,12 @@ module Rouge
         # Numbers
         # Note: Have to do this with a block to push multiple states first,
         #       since we can't pass array of states like w/ Pygments.
-        rule(/[0-9][0-9_]*(?=([eE.]|'?[fF](32|64)))/) do |number|
+        rule(/[0-9][0-9_]*(?=([eE.]|'?[fF](32|64)))/) do
          push :floatsuffix
          push :floatnumber
          token Num::Float
         end
+
         rule(/0[xX][a-fA-F0-9][a-fA-F0-9_]*/, Num::Hex,     :intsuffix)
         rule(/0[bB][01][01_]*/,               Num,          :intsuffix)
         rule(/0o[0-7][0-7_]*/,                Num::Oct,     :intsuffix)

--- a/lib/rouge/lexers/openedge.rb
+++ b/lib/rouge/lexers/openedge.rb
@@ -359,14 +359,14 @@ module Rouge
       state :root do
         rule %r(\s+), Text
 
-        rule %r((\.)(\s+)) do |m|
+        rule %r((\.)(\s+)) do
           groups Operator, Text
         end
 
         rule %r(//[^\n]*), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
 
-        rule %r/(\{?&)(\S+)/ do |m|
+        rule %r/(\{?&)(\S+)/ do
           groups Comment::Preproc, Name::Other
           push :preproc
         end
@@ -415,7 +415,7 @@ module Rouge
         rule %r/\n/, Text, :pop!
         rule %r/\s+/, Text
 
-        rule %r/({?&)(\S+)/ do |m|
+        rule %r/({?&)(\S+)/ do
           groups Comment::Preproc, Name::Other
         end
 

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -199,7 +199,7 @@ module Rouge
         end
         rule %r/(?:#{KEYWORDS})\b(?!-)/i, Keyword::Reserved
 
-        rule %r/(\w+)(\.)/ do |m|
+        rule %r/(\w+)(\.)/ do
           groups Name::Constant, Operator
         end
 

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -52,7 +52,7 @@ module Rouge
         rule %r/\b(#{BUILTINS})\s*\b(?!(\.|-))/, Name::Builtin
         rule %r/[.](?=\s)/, Name::Builtin
 
-        rule %r/(\b\w+)(=)/ do |m|
+        rule %r/(\b\w+)(=)/ do
           groups Name::Variable, Operator
         end
 

--- a/lib/rouge/lexers/tex.rb
+++ b/lib/rouge/lexers/tex.rb
@@ -30,7 +30,7 @@ module Rouge
         rule %r/\$/, Punctuation, :inlinemath
         rule %r/\\(begin|end)\{.*?\}/, Name::Tag
 
-        rule %r/(\\verb)\b(\S)(.*?)(\2)/ do |m|
+        rule %r/(\\verb)\b(\S)(.*?)(\2)/ do
           groups Name::Builtin, Keyword::Pseudo, Str::Other, Keyword::Pseudo
         end
 


### PR DESCRIPTION
If they won't be used, there's no point allocating memory for block parameters