### PR TITLE
Add support for transliteration in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -77,19 +77,17 @@ module Rouge
 
         rule %r/(?:eq|lt|gt|le|ge|ne|not|and|or|cmp)\b/, Operator::Word
 
-        # common delimiters
-        rule %r(s/(\\\\|\\/|[^/])*/(\\\\|\\/|[^/])*/[msixpodualngc]*), re_tok
-        rule %r(s!(\\\\|\\!|[^!])*!(\\\\|\\!|[^!])*![msixpodualngc]*), re_tok
-        rule %r(s\\(\\\\|[^\\])*\\(\\\\|[^\\])*\\[msixpodualngc]*), re_tok
-        rule %r(s@(\\\\|\\@|[^@])*@(\\\\|\\@|[^@])*@[msixpodualngc]*), re_tok
-        rule %r(s%(\\\\|\\%|[^%])*%(\\\\|\\%|[^%])*%[msixpodualngc]*), re_tok
+        # substitution/transliteration: balanced delimiters
+        rule %r((?:s|tr|y){(\\\\|\\}|[^}])*}\s*), re_tok, :balanced_regex
+        rule %r((?:s|tr|y)<(\\\\|\\>|[^>])*>\s*), re_tok, :balanced_regex
+        rule %r((?:s|tr|y)\[(\\\\|\\\]|[^\]])*\]\s*), re_tok, :balanced_regex
+        rule %r[(?:s|tr|y)\((\\\\|\\\)|[^\)])*\)\s*], re_tok, :balanced_regex
 
-        # balanced delimiters
-        rule %r(s{(\\\\|\\}|[^}])*}\s*), re_tok, :balanced_regex
-        rule %r(s<(\\\\|\\>|[^>])*>\s*), re_tok, :balanced_regex
-        rule %r(s\[(\\\\|\\\]|[^\]])*\]\s*), re_tok, :balanced_regex
-        rule %r[s\((\\\\|\\\)|[^\)])*\)\s*], re_tok, :balanced_regex
+        # substitution/transliteration: arbitrary non-whitespace delimiters
+        rule %r((?:s|tr|y)\s*([^\w\s])((\\\\|\\\1)|[^\1])*?\1((\\\\|\\\1)|[^\1])*?\1[msixpodualngcr]*)m, re_tok
+        rule %r((?:s|tr|y)\s+(\w)((\\\\|\\\1)|[^\1])*?\1((\\\\|\\\1)|[^\1])*?\1[msixpodualngcr]*)m, re_tok
 
+        # matches: common case, m-optional
         rule %r(m?/(\\\\|\\/|[^/\n])*/[msixpodualngc]*), re_tok
         rule %r(m(?=[/!\\{<\[\(@%\$])), re_tok, :balanced_regex
 
@@ -102,12 +100,12 @@ module Rouge
 
         rule %r/\s+/, Text
         rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
-        rule %r/((__(DATA|DIE|WARN)__)|(STD(IN|OUT|ERR)))\b/,
+        rule %r/((__(DIE|WARN)__)|(DATA|STD(IN|OUT|ERR)))\b/,
           Name::Builtin::Pseudo
 
         rule %r/<<([\'"]?)([a-zA-Z_][a-zA-Z0-9_]*)\1;?\n.*?\n\2\n/m, Str
 
-        rule %r/__END__\b/, Comment::Preproc, :end_part
+        rule %r/(__(END|DATA)__)\b/, Comment::Preproc, :end_part
         rule %r/\$\^[ADEFHILMOPSTWX]/, Name::Variable::Global
         rule %r/\$[\\"'\[\]&`+*.,;=%~?@$!<>(^\|\/-](?!\w)/, Name::Variable::Global
         rule %r/[-+\/*%=<>&^\|!\\~]=?/, Operator

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -53,6 +53,12 @@ my %countries =  ( england => 'English',
                    germany => 'German',
                    mozambique => 'Mozambican');
 
+# transliterations
+say "food" =~ tr/o/e/r;
+$r =~ tr ^y^z^;
+$s =~ y/[]|/()&/; # "backward" compatible
+
+
 # quoted strings
 my $a = "foo";
 
@@ -139,3 +145,11 @@ sub foo {
 my $moduloOperation = $totalNumber % $columns ? 1 : 0;
 $moduloOperation = 2;
 my $addOperation = $totalNumber + $myOtherVar;
+
+sub __END__but_not_really { 1 }
+
+__DATA__
+
+This is just some end text; everything after DATA can be accessed
+by the <DATA> filehandle.  __END__ does the same thing, without the
+filehandle, but we can't test both in the same file.


### PR DESCRIPTION
Add support for tr/// and y/// by hitching along with s/// from
substitutions.  Also reduce the number of substitution rules by
taking an arbitrary delimiter, as with match below, which has the
benefit of matching more substitutions correctly.

Also move __DATA__ down to live with __END__, because it also
signals the end of parsing.