### PR TITLE
Add _class and _while keywords to magik lexer

### DIFF
--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -22,8 +22,9 @@ module Rouge
            _throw
            _lock _endlock
            _if _then _elif _else _endif
-           _for _over _loop _endloop _loopbody _continue _leave
+           _for _over _while _loop _endloop _loopbody _continue _leave
            _return
+           _class
            _local _constant _recursive _global _dynamic _import
            _private _iter _abstract _method _endmethod
            _proc _endproc

--- a/spec/visual/samples/magik
+++ b/spec/visual/samples/magik
@@ -8,7 +8,8 @@ def_slotted_exemplar(
         :test_object,
         {
                 {:slot, _unset}
-        })
+        },
+        {_class |java.lang.Integer|})
 $
 
 _pragma(classify_level=basic, topic={test_topic, rouge})
@@ -25,6 +26,11 @@ _method test_object.method_name(arg_1, _gather args)
 
         _local l_y << _true
         l_y _and<< _true
+
+        _while _true
+        _loop
+                _leave
+        _endloop
 
         # numbers
         45, 0, -101


### PR DESCRIPTION
Add `_class` and `_while` keywords to magik lexer. Newer versions of the magik language support these new keywords.