### PR TITLE
Disable RuboCop's AmbiguousRegexpLiteral cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,26 +20,29 @@ Bundler:
 Performance/RedundantBlockCall:
   Enabled: false
 
-Lint/UselessAssignment:
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Lint/UnusedBlockArgument:
+Lint/EmptyWhen:
   Enabled: false
 
 Lint/EndAlignment:
   Enabled: false
 
-Lint/EmptyWhen:
+Lint/IneffectiveAccessModifier:
   Enabled: false
 
 Lint/UnneededSplatExpansion:
   Enabled: false
 
-Lint/IneffectiveAccessModifier:
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessAssignment:
   Enabled: false


### PR DESCRIPTION
RuboCop checks for ambiguous regular expression literals by default. The concern is avoiding situations where it is ambiguous whether the argument being passed is a regular expression literal or a call to the `/` method defined on the relevant object.

@jneen and I discussed this and we are of the view that the risk of this occurring in Rouge is insubstantial and, just as importantly, is offset by the negative impact on the clarity of Rouge's DSL.

This PR disables the cop.