### PR TITLE
Replace tab spaces with regular spaces

### DIFF
--- a/lib/rouge/lexers/igorpro.rb
+++ b/lib/rouge/lexers/igorpro.rb
@@ -20,7 +20,7 @@ module Rouge
           break return continue
           for endfor do while
           case default
-	  try catch endtry
+          try catch endtry
           abortonrte
         )
       end

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -64,18 +64,18 @@ module Rouge
         rule %r/#[a-zA-Z_]\w*#/, Name::Variable
         rule %r/\$[a-zA-Z_]\w*(\.\w+)*/, Name::Variable
         rule %r/(true|false|null)\b/, Keyword::Constant
-	rule %r/[0-9](\.[0-9]*)?(eE[+-][0-9])?[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?/, Num
-	rule %r/"(\\.|.)*?"/, Str::Double
+        rule %r/[0-9](\.[0-9]*)?(eE[+-][0-9])?[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?/, Num
+        rule %r/"(\\.|.)*?"/, Str::Double
         rule %r/'(\\.|.)*?'/, Str::Single
-	rule %r/([a-zA-Z_]\w*)/ do |m|
-	  if self.class.builtins.include? m[0]
-	    token Name::Builtin
-	  else
-	    token Name::Attribute
-	  end
-	end
-      end
 
+        rule %r/([a-zA-Z_]\w*)/ do |m|
+          if self.class.builtins.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Attribute
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Replaces some occurrences of `\t` with `\s`