### PR TITLE
Add missing magic comments

### DIFF
--- a/lib/rouge/formatters/tex.rb
+++ b/lib/rouge/formatters/tex.rb
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
 module Rouge
   module Formatters
     class Tex < Formatter

--- a/lib/rouge/lexers/escape.rb
+++ b/lib/rouge/lexers/escape.rb
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
 module Rouge
   module Lexers
     class Escape < Lexer

--- a/lib/rouge/tex_theme_renderer.rb
+++ b/lib/rouge/tex_theme_renderer.rb
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
 module Rouge
   class TexThemeRenderer
     def initialize(theme, opts={})


### PR DESCRIPTION
This adds the `frozen_string_literal` and `encoding` magic comments as found in every other Ruby file in the library.