### PR TITLE
Update the GraphQL with extend and front-matter

### DIFF
--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -20,25 +20,26 @@ module Rouge
         end
 
         rule %r/\bfragment\b/, Keyword, :fragment_definition
+        
         rule %r/\bscalar\b/, Keyword, :value
-        rule %r/\bextend\sscalar\b/, Keyword, :value
 
         rule %r/\b(?:type|interface|enum)\b/, Keyword, :type_definition
-        rule %r/\b(?:extend\s+type|extend\s+interface|extend\s+enum)\b/, Keyword, :type_definition
 
         rule %r/\b(?:input|schema)\b/, Keyword, :type_definition
-        rule %r/\b(?:extend\sinput|extend\sschema)\b/, Keyword, :type_definition
 
         rule %r/\bunion\b/, Keyword, :union_definition
-        rule %r/\bextend\s+union\b/, Keyword, :union_definition
+
+        rule %r/\bextend\b/, Keyword
 
         mixin :basic
 
         # Markdown descriptions
-        rule %r/(""")(.*?)(""")/m do |m|
-          token Str::Double, m[1] + "\n"
-          delegate Markdown, m[2].strip
-          token Str::Double, "\n" + m[3]
+        rule %r/(""")(\n)(.*?)(\n)(""")/m do |m|
+          token Str::Double, m[1]
+          token Text::Whitespace, m[2]
+          delegate Markdown, m[3]
+          token Text::Whitespace, m[4]
+          token Str::Double, m[5]
         end
       end
 

--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -20,19 +20,25 @@ module Rouge
         end
 
         rule %r/\bfragment\b/, Keyword, :fragment_definition
+        rule %r/\bscalar\b/, Keyword, :value
+        rule %r/\bextend\sscalar\b/, Keyword, :value
 
         rule %r/\b(?:type|interface|enum)\b/, Keyword, :type_definition
+        rule %r/\b(?:extend\s+type|extend\s+interface|extend\s+enum)\b/, Keyword, :type_definition
+
         rule %r/\b(?:input|schema)\b/, Keyword, :type_definition
+        rule %r/\b(?:extend\sinput|extend\sschema)\b/, Keyword, :type_definition
 
         rule %r/\bunion\b/, Keyword, :union_definition
+        rule %r/\bextend\s+union\b/, Keyword, :union_definition
 
         mixin :basic
 
         # Markdown descriptions
         rule %r/(""")(.*?)(""")/m do |m|
-          token Str::Double, m[1]
-          delegate Markdown, m[2]
-          token Str::Double, m[3]
+          token Str::Double, m[1] + "\n"
+          delegate Markdown, m[2].strip
+          token Str::Double, "\n" + m[3]
         end
       end
 

--- a/spec/visual/samples/graphql
+++ b/spec/visual/samples/graphql
@@ -1,4 +1,14 @@
 """
+---
+frontmatter: Hello
+things:
+  - beer
+  - sugar
+---
+
+Markdown: Syntax
+================
+
 Decimal number serialized as string.
 
 Should match regexp: `/^[+-]?[0-9]+(\.[0-9]+)$/`
@@ -24,11 +34,17 @@ fragment on AnalysisImage @relay(plural: true) {
   href
 }
 
+scalar Help
+
 interface Character {
   id: ID!
   name: String!
   friends: [Character]
   appearsIn: [Episode]!
+}
+
+extend interface Character {
+  email: ID!
 }
 
 schema {
@@ -41,16 +57,28 @@ type Starship  implements Character {
   length(unit: LengthUnit = METER): Float
 }
 
+extend type User {
+  name: ID!
+}
+
 input Starship {
   id: ID!
   name: String!
   length(unit: LengthUnit = METER): Float
 }
 
+extend input Starship {
+  rockerlauncher: Bool!
+}
+
 enum Episode {
   NEWHOPE
   EMPIRE
   JEDI
+}
+
+extend enum Episode {
+  LOLCATS
 }
 
 union SearchResult = Human # maybe spans


### PR DESCRIPTION
Hi folks!

I'm updating GraphQL lexer in a very horrible way with (I have no clue how to write a lexer, even though I tried):

- Extending types from the June 2018 spec https://graphql.github.io/graphql-spec/June2018/#sec-Type-Extensions
- The Markdown delegate for comments does now parse it correctly and thus allows front matter by stripping the whitespace before the `---` tokens.

🦄 

Thank you all ❤️