### PR TITLE
gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
     for pygments.
   desc
   s.homepage = "http://rouge.jneen.net/"
-  s.rubyforge_project = "rouge"
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.