### PR TITLE
Remove italics from preprocessor style rules

### DIFF
--- a/lib/rouge/themes/magritte.rb
+++ b/lib/rouge/themes/magritte.rb
@@ -32,7 +32,7 @@ module Rouge
       # style Generic::Prompt,            :fg => :chilly, :bold => true
 
       style Comment,                      :fg => :dragon, :italic => true
-      style Comment::Preproc,             :fg => :chocolate, :bold => true, :italic => true
+      style Comment::Preproc,             :fg => :chocolate, :bold => true
       style Error,                        :fg => :eggshell, :bg => :cherry
       style Generic::Error,               :fg => :cherry, :italic => true, :bold => true
       style Keyword,                      :fg => :royal, :bold => true

--- a/lib/rouge/themes/thankful_eyes.rb
+++ b/lib/rouge/themes/thankful_eyes.rb
@@ -29,7 +29,7 @@ module Rouge
       style Generic::Prompt, :fg => :chilly, :bold => true
 
       style Comment, :fg => :cool_as_ice, :italic => true
-      style Comment::Preproc, :fg => :go_get_it, :bold => true, :italic => true
+      style Comment::Preproc, :fg => :go_get_it, :bold => true
       style Error, :fg => :aluminum1, :bg => :scarletred2
       style Generic::Error, :fg => :scarletred2, :italic => true, :bold => true
       style Keyword, :fg => :sandy, :bold => true

--- a/lib/rouge/themes/tulip.rb
+++ b/lib/rouge/themes/tulip.rb
@@ -24,7 +24,7 @@ module Rouge
       style Text, :fg => :white, :bg => :dark_purple
 
       style Comment, :fg => :gray, :italic => true
-      style Comment::Preproc, :fg => :lgreen, :bold => true, :italic => true
+      style Comment::Preproc, :fg => :lgreen, :bold => true
       style Error,
             Generic::Error, :fg => :white, :bg => :red
       style Keyword, :fg => :yellow, :bold => true


### PR DESCRIPTION
Three of the default themes that come with Rouge italicise text tokenised with the `Comment::Preproc` token. This is consistent with the styling applied to other tokens within the `Comment` group but is not appropriate for a token that is typically used with code that can include characters like `/` (the `Comment::Preproc` token is the recommended token for PHP and ERB, for example).

This commit removes the italics attribute from the themes Magritte, Thankful Eyes and Tulip. The styles are otherwise left unchanged. It is expected that this change will precede a separate PR that will address #1237.