### PR TITLE
Add disambiguation for C++ header files

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -75,6 +75,8 @@ module Rouge
       disambiguate '*.h' do
         next ObjectiveC if matches?(/@(end|implementation|protocol|property)\b/)
         next ObjectiveC if contains?('@"')
+        next Cpp if matches?(/^\s*(?:bool|class|namespace|private|public|
+                                   template|using)\b/x)
 
         C
       end

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -75,8 +75,8 @@ module Rouge
       disambiguate '*.h' do
         next ObjectiveC if matches?(/@(end|implementation|protocol|property)\b/)
         next ObjectiveC if contains?('@"')
-        next Cpp if matches?(/^\s*(?:bool|class|namespace|private|public|
-                                   template|using)\b/x)
+        next Cpp if matches?(/^\s*(?:catch|class|constexpr|namespace|private|
+                                   protected|public|template|throw|try|using)\b/x)
 
         C
       end

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -17,7 +17,7 @@ module Rouge
                 '*.cc',  '*.hh',
                 '*.cxx', '*.hxx',
                 '*.pde', '*.ino',
-                '*.tpp'
+                '*.tpp', '*.h'
       mimetypes 'text/x-c++hdr', 'text/x-c++src'
 
       def self.keywords

--- a/spec/lexers/cpp_spec.rb
+++ b/spec/lexers/cpp_spec.rb
@@ -17,6 +17,12 @@ describe Rouge::Lexers::Cpp do
       assert_guess :filename => 'foo.h++'
       assert_guess :filename => 'foo.hxx'
 
+      # Disambiguate with C
+      assert_guess :filename => 'foo.h', :source => 'namespace'
+      deny_guess :filename => 'foo.h', :source => 'namespaces'
+      deny_guess :filename => 'foo.h', :source => 'struct namespace'
+
+
       # Disambiguate with hacklang.org
       assert_guess :filename => 'foo.hh', :source => 'foo'
 

--- a/spec/lexers/cpp_spec.rb
+++ b/spec/lexers/cpp_spec.rb
@@ -22,7 +22,6 @@ describe Rouge::Lexers::Cpp do
       deny_guess :filename => 'foo.h', :source => 'namespaces'
       deny_guess :filename => 'foo.h', :source => 'struct namespace'
 
-
       # Disambiguate with hacklang.org
       assert_guess :filename => 'foo.hh', :source => 'foo'
 


### PR DESCRIPTION
C++ header files can use the `.h` extension. By default, Rouge highlights these files with the C lexer. This can lead to incorrect highlighting because certain keywords in C++ are not reserved in C. A similar situation can occur with Objective-C files but Rouge provides a disambiguation for Objective-C files to avoid this problem. This commit adds a similar disambiguation for C++.

This fixes #932.