### PR TITLE
Move to self-hosted documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,12 +22,12 @@ end
 
 # Needed for a Rake task
 gem 'git'
+gem 'yard'
 
 group :development do
   gem 'pry'
 
   # docs
-  gem 'yard'
   gem 'github-markup'
 
   # for visual tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://secure.travis-ci.org/rouge-ruby/rouge.svg)](https://travis-ci.org/rouge-ruby/rouge)
 [![Gem Version](https://badge.fury.io/rb/rouge.svg)](https://rubygems.org/gems/rouge)
+[![YARD Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rouge-ruby.github.io/docs/)
 
 [rouge]: http://rouge.jneen.net/
 
@@ -159,13 +160,13 @@ To test a lexer visually, run `rackup` from the root and go to `localhost:9292/#
 
 ### API Documentation
 
-is at http://rubydoc.info/gems/rouge/frames.
+is at https://rouge-ruby.github.io/docs/.
 
 ### Developing lexers
 
 We have [a guide][lexer-dev-doc] on lexer development in the documentation but you'll also learn a lot by reading through the existing lexers. 
 
-[lexer-dev-doc]: https://www.rubydoc.info/github/rouge-ruby/rouge/file/docs/LexerDevelopment.md
+[lexer-dev-doc]: https://rouge-ruby.github.io/docs/file.LexerDevelopment.html
 
 Please don't submit lexers that are largely copy-pasted from other files.
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,14 +5,15 @@ require "bundler/gem_tasks" # Adds the :build, :install and :release tasks
 require "rake/clean" # Adds the :clean and :clobber tasks
 require "rake/testtask"
 require "rubocop/rake_task"
+require "yard"
 
 # Add tasks
-task :check => ["check:specs", :newline, "check:style"]
+task :check => ["check:specs", "check:style"]
 task :default => [:check]
 task :test => [:check]
 
 # Add pre-requisites
-task :build => [:clean, :check]
+task :build => [:clean, :check, "generate:docs"]
 
 # Add utility tasks
 task :newline do

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT', 'BSD-2-Clause']
   s.required_ruby_version = '>= 2.0'
   s.metadata = {
-    'source_code_uri' => 'https://github.com/jneen/rouge',
-    'changelog_uri' => 'https://github.com/jneen/rouge/blob/master/CHANGELOG.md'
+    "bug_tracker_uri"   => "https://github.com/rouge-ruby/rouge/issues",
+    "changelog_uri"     => "https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://rouge-ruby.github.io/docs/",
+    "source_code_uri"   => "https://github.com/rouge-ruby/rouge"
   }
 end

--- a/tasks/generate/docs.rake
+++ b/tasks/generate/docs.rake
@@ -1,0 +1,8 @@
+namespace :generate do
+  desc "Generate YARD documentation"
+  YARD::Rake::YardocTask.new(:docs) do |t|
+    t.files   = ["lib/**/*.rb", "-", "docs/*.md"]
+    t.options = ["--no-private", "--protected", "--markup-provider=redcarpet",
+                 "--markup=markdown"]
+  end
+end


### PR DESCRIPTION
Rouge's official documentation is hosted on [RubyDoc.info](https://rubydoc.info/gems/rouge). Recently, that site has frequently responded with 500 errors. This is problematic for various reasons, not least of which is it makes it difficult to refer potential contributors to the documentation for help in creating new lexers.

This PR provides the facility to integrate self-hosted documentation into Rouge's development process. The documentation is hosted on GitHub at present but this could be changed at a later point if desired.

It should be noted that the documentation generated still needs to be pushed to [the docs repo](https://github.com/rouge-ruby/docs/) manually.