### PR TITLE
Add a Rake task to check warnings output by Ruby

### DIFF
--- a/tasks/check/warnings.rake
+++ b/tasks/check/warnings.rake
@@ -1,0 +1,10 @@
+namespace :check do
+  Rake::TestTask.new(:warnings) do |t|
+    t.libs << "lib"
+    t.ruby_opts << "-r./spec/spec_helper"
+    t.ruby_opts << "-W2"
+    t.warning = !!$VERBOSE
+    t.pattern = FileList['spec/**/*_spec.rb']
+  end
+end
+

--- a/tasks/check/warnings.rake
+++ b/tasks/check/warnings.rake
@@ -1,3 +1,5 @@
+# This task is intended to be the same as check:specs but with verbose warnings
+# output set by calling t.ruby_opts << "-W2"
 namespace :check do
   Rake::TestTask.new(:warnings) do |t|
     t.libs << "lib"


### PR DESCRIPTION
This commit adds a Rake task that runs the specs with Ruby's verbose warnings enabled.