### PR TITLE
More robust escaping for TeX formatter

### DIFF
--- a/lib/rouge/formatters/tex.rb
+++ b/lib/rouge/formatters/tex.rb
@@ -22,6 +22,9 @@ module Rouge
         '^' => '{\textasciicircum}',
         '|' => '{\textbar}',
         '\\' => '{\textbackslash}',
+        '`' => '{\textasciigrave}',
+        "'" => "'{}",
+        '"' => '"{}',
         "\t" => '{\tab}',
       }
 

--- a/lib/rouge/formatters/tex.rb
+++ b/lib/rouge/formatters/tex.rb
@@ -62,24 +62,20 @@ module Rouge
       end
 
       def render_line(line, &b)
-        head, *rest = line
-        return unless head
-
-        tag_first(*head, &b)
-        rest.each do |(tok, val)|
-          yield tag(tok, val)
+        line.each do |(tok, val)|
+          hphantom_tag(tok, val, &b)
         end
       end
 
-      # special handling for the first token
-      # of a line. we replace all initial spaces
-      # with \hphantom{xxxx}, which renders an
-      # empty space equal to the size of the x's.
-      def tag_first(tok, val)
+      # Special handling for leading spaces, since they may be gobbled
+      # by a previous command.  We replace all initial spaces with
+      # \hphantom{xxxx}, which renders an empty space equal to the size
+      # of the x's.
+      def hphantom_tag(tok, val)
         leading = nil
         val.sub!(/^[ ]+/) { leading = $&.size; '' }
         yield "\\hphantom{#{'x' * leading}}" if leading
-        yield tag(tok, val)
+        yield tag(tok, val) unless val.empty?
       end
 
       def tag(tok, val)

--- a/lib/rouge/tex_theme_renderer.rb
+++ b/lib/rouge/tex_theme_renderer.rb
@@ -113,7 +113,7 @@ END
     end
 
     def render_style(tok, style, &b)
-      out = String.new
+      out = String.new('')
       out << "\\expandafter\\def#{token_name(tok)}#1{"
       out << "\\fboxsep=0pt\\colorbox{#{palette_name(style[:bg])}}{" if style[:bg]
       out << '\\textbf{' if style[:bold]

--- a/lib/rouge/tex_theme_renderer.rb
+++ b/lib/rouge/tex_theme_renderer.rb
@@ -113,7 +113,8 @@ END
     end
 
     def render_style(tok, style, &b)
-      out = "\\expandafter\\def#{token_name(tok)}#1{"
+      out = String.new
+      out << "\\expandafter\\def#{token_name(tok)}#1{"
       out << "\\fboxsep=0pt\\colorbox{#{palette_name(style[:bg])}}{" if style[:bg]
       out << '\\textbf{' if style[:bold]
       out << '\\textit{' if style[:italic]

--- a/spec/formatters/tex_spec.rb
+++ b/spec/formatters/tex_spec.rb
@@ -48,7 +48,7 @@ describe Rouge::Formatters::Tex do
     let(:expected) do
       <<-'OUT'
 \begin{RG*}%
-\RG{k}{foo} \RG{p}{\{}\newline%
+\RG{k}{foo}\hphantom{x}\RG{p}{\{}\newline%
 \hphantom{xx}\RG{no}{{\textasciitilde}100\%}\newline%
 \RG{p}{\}}%
 \end{RG*}%


### PR DESCRIPTION
In this PR we add three new escaped tokens, and also change the behavior of whitespace to use `\hphantom` for all whitespace at the beginning of a token.