### PR TITLE
magritte theme: color Generic::Output royal

### DIFF
--- a/lib/rouge/themes/magritte.rb
+++ b/lib/rouge/themes/magritte.rb
@@ -67,8 +67,8 @@ module Rouge
             Literal::String::Interpol,    :fg => :purple, :bold => true
       style Name::Builtin,                :bold => true
       style Name::Entity,                 :fg => :darkgray, :bold => true
-      style Text::Whitespace,
-            Generic::Output,              :fg => :lightgray
+      style Text::Whitespace,             :fg => :lightgray
+      style Generic::Output,              :fg => :royal
       style Name::Function,
             Name::Property,
             Name::Attribute,              :fg => :candy


### PR DESCRIPTION
A slight tweak to the Magritte theme, so that `Generic::Output` is more readable.