### PR TITLE
scheme: do comments in multiple steps

### DIFF
--- a/lib/rouge/lexers/scheme.rb
+++ b/lib/rouge/lexers/scheme.rb
@@ -59,9 +59,14 @@ module Rouge
 
       id = /[a-z0-9!$\%&*+,\/:<=>?@^_~|-]+/i
 
+      state :comment do
+        rule /[^\n]+/, Comment::Single
+        rule /\n/, Text, :pop!
+      end
+
       state :root do
         # comments
-        rule %r/;.*$/, Comment::Single
+        rule %r/;/, Comment::Single, :comment
         rule %r/\s+/m, Text
         rule %r/-?\d+\.\d+/, Num::Float
         rule %r/-?\d+/, Num::Integer


### PR DESCRIPTION
This allows for breaking out for escapes or subclassed behavior within a comment. Previously, comments were handled with a single regular expression, so when used with the `Escape` lexer, the escape tokens would inadvertently end the comment.