### PR TITLE
CI: Drop unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: trusty
 language: ruby
 rvm:


### PR DESCRIPTION
- See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details