### PR TITLE
Add a lexer for CMHG files

### DIFF
--- a/lib/rouge/demos/cmhg
+++ b/lib/rouge/demos/cmhg
@@ -1,0 +1,8 @@
+; Header comments
+
+#include "definitions.h"
+
+command-keyword-table:  command_handler
+                        foo(min-args:0, max-args:0,; comment
+                            international:,
+                            invalid-syntax: "syntaxtoken" help-text: "helptoken")

--- a/lib/rouge/lexers/cmhg.rb
+++ b/lib/rouge/lexers/cmhg.rb
@@ -17,7 +17,7 @@ module Rouge
 
       state :root do
         rule %r/;[^\n]*/, Comment
-        rule %r/^[ \t]*#[ \t]*(?:(?:#{CMHG.preproc_keyword.join('|')})[ \t].*)?/, Comment::Preproc
+        rule %r/^[ \t]*#[ \t]*(?:(?:#{CMHG.preproc_keyword.join('|')})(?:[ \t].*)?)?(?=\n)/, Comment::Preproc
         rule %r/[-a-z]+:/, Keyword::Declaration
         rule %r/[a-z_]\w+/i, Name::Entity
         rule %r/"[^"]*"/, Literal::String

--- a/lib/rouge/lexers/cmhg.rb
+++ b/lib/rouge/lexers/cmhg.rb
@@ -24,7 +24,7 @@ module Rouge
         rule %r/(?:&|0x)\h+/, Literal::Number::Hex
         rule %r/\d+/, Literal::Number
         rule %r/[,\/()]/, Punctuation
-        rule %r/[ \t\n]+/, Text
+        rule %r/\s+/, Text
       end
     end
   end

--- a/lib/rouge/lexers/cmhg.rb
+++ b/lib/rouge/lexers/cmhg.rb
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class CMHG < RegexLexer
+      title "CMHG"
+      desc "RISC OS C module header generator source file"
+      tag 'cmhg'
+      filenames '*.cmhg'
+
+      def self.preproc_keyword
+        @preproc_keyword ||= %w(
+          define elif else endif error if ifdef ifndef include line pragma undef warning
+        )
+      end
+
+      state :root do
+        rule %r/;[^\n]*/, Comment
+        rule %r/^[ \t]*#[ \t]*(?:(?:#{CMHG.preproc_keyword.join('|')})[ \t].*)?/, Comment::Preproc
+        rule %r/[-a-z]+:/, Keyword::Declaration
+        rule %r/[a-z_]\w+/i, Name::Entity
+        rule %r/"[^"]*"/, Literal::String
+        rule %r/(?:&|0x)\h+/, Literal::Number::Hex
+        rule %r/\d+/, Literal::Number
+        rule %r/[,\/()]/, Punctuation
+        rule %r/[ \t\n]+/, Text
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/cmhg.rb
+++ b/lib/rouge/lexers/cmhg.rb
@@ -17,7 +17,9 @@ module Rouge
 
       state :root do
         rule %r/;[^\n]*/, Comment
-        rule %r/^[ \t]*#[ \t]*(?:(?:#{CMHG.preproc_keyword.join('|')})(?:[ \t].*)?)?(?=\n)/, Comment::Preproc
+        rule %r/^([ \t]*)(#[ \t]*(?:(?:#{CMHG.preproc_keyword.join('|')})(?:[ \t].*)?)?)(?=\n)/ do
+          groups Text, Comment::Preproc
+        end
         rule %r/[-a-z]+:/, Keyword::Declaration
         rule %r/[a-z_]\w+/i, Name::Entity
         rule %r/"[^"]*"/, Literal::String

--- a/lib/rouge/lexers/cmhg.rb
+++ b/lib/rouge/lexers/cmhg.rb
@@ -24,7 +24,8 @@ module Rouge
         rule %r/(?:&|0x)\h+/, Literal::Number::Hex
         rule %r/\d+/, Literal::Number
         rule %r/[,\/()]/, Punctuation
-        rule %r/\s+/, Text
+        rule %r/[ \t]+/, Text
+        rule %r/\n+/, Text
       end
     end
   end

--- a/spec/lexers/cmhg_spec.rb
+++ b/spec/lexers/cmhg_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::CMHG do
+  let(:subject) { Rouge::Lexers::CMHG.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.cmhg'
+    end
+  end
+end

--- a/spec/visual/samples/cmhg
+++ b/spec/visual/samples/cmhg
@@ -1,0 +1,58 @@
+;
+; CDDL HEADER START
+;
+; The contents of this file are subject to the terms of the
+; Common Development and Distribution License (the "Licence").
+; You may not use this file except in compliance with the Licence.
+;
+; You can obtain a copy of the licence at
+; cddl/RiscOS/Sources/HWSupport/SD/SDIODriver/LICENCE.
+; See the Licence for the specific language governing permissions
+; and limitations under the Licence.
+;
+; When distributing Covered Code, include this CDDL HEADER in each
+; file and include the Licence file. If applicable, add the
+; following below this CDDL HEADER, with the fields enclosed by
+; brackets "[]" replaced with your own identifying information:
+; Portions Copyright [yyyy] [name of copyright owner]
+;
+; CDDL HEADER END
+;
+; Copyright 2012 Ben Avison.  All rights reserved.
+; Portions Copyright 2013 Jeffrey Lee.
+; Use is subject to license terms.
+;
+
+#include "Global/Services.h"
+#include "VersionNum"
+
+initialisation-code:	module_initialise
+
+finalisation-code:	module_finalise
+
+; Service_Hardware
+service-call-handler:	module_service Service_Hardware,
+				       Service_ModulePostInit
+
+title-string:		SDIODriver
+
+help-string:		SDIODriver Module_MajorVersion_CMHG Module_MinorVersion_CMHG
+
+command-keyword-table:	module_command
+			SDIODevices(min-args:0, max-args:0, international:, invalid-syntax:"SSDIDEV", help-text:"HSDIDEV"),
+			SDIOSlots(min-args:0, max-args:0, international:, invalid-syntax:"SSDISLT", help-text:"HSDISLT")
+
+swi-chunk-base-number:	0x59000
+
+swi-handler-code:	module_swi
+
+swi-decoding-table:	SDIO, Initialise, Control, Enumerate, ControllerFeatures, ReadRegister, Op, ClaimDeviceVector, ReleaseDeviceVector
+
+international-help-file:"Resources:$.Resources.SDIODriver.Messages"
+
+date-string:		Module_Date_CMHG
+
+generic-veneers:	module_irq_veneer/module_irq_handler,
+			module_card_insertion_veneer/module_card_insertion_handler
+
+vector-handlers:	module_tickerv_veneer/module_tickerv_handler

--- a/spec/visual/samples/cmhg
+++ b/spec/visual/samples/cmhg
@@ -24,7 +24,9 @@
 ;
 
 #include "Global/Services.h"
-#include "VersionNum"
+#ifndef Module_Date_CMHG
+	#include "VersionNum"
+#endif
 
 initialisation-code:	module_initialise
 

--- a/spec/visual/samples/cmhg
+++ b/spec/visual/samples/cmhg
@@ -39,8 +39,8 @@ title-string:		SDIODriver
 help-string:		SDIODriver Module_MajorVersion_CMHG Module_MinorVersion_CMHG
 
 command-keyword-table:	module_command
-			SDIODevices(min-args:0, max-args:0, international:, invalid-syntax:"SSDIDEV", help-text:"HSDIDEV"),
-			SDIOSlots(min-args:0, max-args:0, international:, invalid-syntax:"SSDISLT", help-text:"HSDISLT")
+			SDIODevices(min-args:0, max-args:1, international:, invalid-syntax:"SSDIDEV", help-text:"HSDIDEV"),
+			SDIOSlots(min-args:0, max-args:255, international:, invalid-syntax:"SSDISLT", help-text:"HSDISLT")
 
 swi-chunk-base-number:	0x59000
 


### PR DESCRIPTION
This file format is parsed by the `cmhg` or `cmunge` tools to generate the
binary object header for privileged code modules on RISC OS - the initialism
stands for 'C Module Header Generator'.