### PR TITLE
Add a lexer for MessageTrans messages files

### DIFF
--- a/lib/rouge/demos/msgtrans
+++ b/lib/rouge/demos/msgtrans
@@ -1,0 +1,4 @@
+# Example MessageTrans file
+Token
+Token0x??:Replacement localised %0 text
+Color/Colour:Colour

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -122,7 +122,7 @@ module Rouge
       end
 
       disambiguate 'Messages' do
-        next MsgTrans if matches?(/^(?:#|[^\s:]+:[^\s:]+)/)
+        next MsgTrans if matches?(/^[^\s:]+:[^\s:]+/)
 
         next PlainText
       end

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -120,6 +120,12 @@ module Rouge
 
         next Python
       end
+
+      disambiguate 'Messages' do
+        next MsgTrans if matches?(/^\w+:\w+/)
+
+        next PlainText
+      end
     end
   end
 end

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -122,7 +122,7 @@ module Rouge
       end
 
       disambiguate 'Messages' do
-        next MsgTrans if matches?(/^\w+:\w+/)
+        next MsgTrans if matches?(/^(?:#|[^\s:]+:[^\s:]+)/)
 
         next PlainText
       end

--- a/lib/rouge/lexers/msgtrans.rb
+++ b/lib/rouge/lexers/msgtrans.rb
@@ -19,7 +19,7 @@ module Rouge
       state :value do
         rule %r/\n/, Text, :pop!
         rule %r/%[0-3%]/, Operator
-        rule %r/./, Literal::String
+        rule %r/[^\n%]/, Literal::String
       end
     end
   end

--- a/lib/rouge/lexers/msgtrans.rb
+++ b/lib/rouge/lexers/msgtrans.rb
@@ -11,7 +11,7 @@ module Rouge
 
       state :root do
         rule %r/^#[^\n]*/, Comment
-        rule %r/[^\n ,):?\/]+/, Name::Variable
+        rule %r/[^\t\n\r ,):?\/]+/, Name::Variable
         rule %r/[\n\/?]/, Operator
         rule %r/:/, Operator, :value
       end

--- a/lib/rouge/lexers/msgtrans.rb
+++ b/lib/rouge/lexers/msgtrans.rb
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class MsgTrans < RegexLexer
+      title "MessageTrans"
+      desc "RISC OS message translator messages file"
+      tag 'msgtrans'
+      filenames 'Messages*'
+
+      state :root do
+        rule %r/^#[^\n]*/, Comment
+        rule %r/[^\n ,):?\/]+/, Name::Variable
+        rule %r/[\n\/?]/, Operator
+        rule %r/:/, Operator, :value
+      end
+
+      state :value do
+        rule %r/\n/, Text, :pop!
+        rule %r/%[0-3%]/, Operator
+        rule %r/./, Literal::String
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/msgtrans.rb
+++ b/lib/rouge/lexers/msgtrans.rb
@@ -7,7 +7,7 @@ module Rouge
       title "MessageTrans"
       desc "RISC OS message translator messages file"
       tag 'msgtrans'
-      filenames 'Messages*'
+      filenames 'Messages', 'Message[0-9]', 'Message[1-9][0-9]', 'Message[1-9][0-9][0-9]'
 
       state :root do
         rule %r/^#[^\n]*/, Comment

--- a/lib/rouge/lexers/plain_text.rb
+++ b/lib/rouge/lexers/plain_text.rb
@@ -9,7 +9,7 @@ module Rouge
 
       tag 'plaintext'
       aliases 'text'
-      filenames '*.txt'
+      filenames '*.txt', 'Messages'
       mimetypes 'text/plain'
 
       attr_reader :token

--- a/spec/lexers/msgtrans_spec.rb
+++ b/spec/lexers/msgtrans_spec.rb
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::MsgTrans do
+  let(:subject) { Rouge::Lexers::MsgTrans.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'Messages*'
+    end
+  end
+end

--- a/spec/lexers/msgtrans_spec.rb
+++ b/spec/lexers/msgtrans_spec.rb
@@ -8,7 +8,7 @@ describe Rouge::Lexers::MsgTrans do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'Messages'
+      assert_guess :filename => 'Messages', :source => 'Token:Token'
       assert_guess :filename => 'Message0'
       assert_guess :filename => 'Message12'
       assert_guess :filename => 'Message123'

--- a/spec/lexers/msgtrans_spec.rb
+++ b/spec/lexers/msgtrans_spec.rb
@@ -8,7 +8,10 @@ describe Rouge::Lexers::MsgTrans do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'Messages*'
+      assert_guess :filename => 'Messages'
+      assert_guess :filename => 'Message0'
+      assert_guess :filename => 'Message12'
+      assert_guess :filename => 'Message123'
     end
   end
 end

--- a/spec/lexers/plain_text_spec.rb
+++ b/spec/lexers/plain_text_spec.rb
@@ -10,6 +10,7 @@ describe Rouge::Lexers::PlainText do
     it 'guesses by filename' do
       assert_guess :filename => 'foo'
       assert_guess :filename => 'foo.txt'
+      assert_guess :filename => 'Messages', :source => 'foo'
     end
 
     it 'guesses by mimetype' do

--- a/spec/visual/samples/msgtrans
+++ b/spec/visual/samples/msgtrans
@@ -1,0 +1,104 @@
+_TaskName:ChangeFSI
+_Version:Substituted at build time
+# Picture menu
+Pimg:Image info
+Psrc:Source info
+Prange:Range info
+Pzoom:Zoom
+Psave:Save image
+# Iconbar menu
+Iinfo:Info
+Iscale:Scaling
+Iproc:Processing
+Ijpg:JPEG output
+Ispr:Sprite output
+Ifast:Fast
+Ichoice:Save choices
+Iquit:Quit
+# Common menus
+PIredo:Reprocess
+# General messages
+ScaleFill:Scale to fill %0 by %1
+NoRange:Range not used
+OverW:Overwrite source file?
+ButErr:Ignore,Quit
+ButCon:Cancel,Discard
+BadJQ:Invalid JPEG quality in JPEG output dialogue box
+BadMode:Invalid mode number in sprite output dialogue box
+Proc:processed in %0 seconds
+Unsaved:Image created from '%0' not saved
+# Interactive help
+Hinfo?/Hinfo??:This \w displays information about ChangeFSI.
+Hpic?/Hpic??:\Toutput image from ChangeFSI.
+Hsave0:Drag this icon to the directory in which you want to save the file, or drag it to the program into which you want to transfer the data.
+Hsave1:This shows the filename for this data. If it is not a full pathname, drag the icon into a directory display.
+Hsave2:\Ssave the data with the current filename. If it is not a full pathname, you must drag the icon to a directory first.
+Hsave?/Hsave??:This \w allows you to save data in a file, or transfer it to another application.
+Hsprite?/Hsprite??:This \w displays information on the output image produced.
+Hjpeg1:\Screate colour JPEGs.
+Hjpeg2:\Screate greyscale JPEGs.
+Hjpeg5:Enter a quality directly in this box.|MValues in the range 0-100 are accepted and trade off file size with image quality.|MA value of 100 means 'do not compress'.|M
+Hjpeg3:\Sdecrease the quality (smaller output file).
+Hjpeg4:\Sincrease the quality (larger output file).
+Hjpeg?/Hjpeg??:This \w sets the output JPEG type.
+Hzoom?/Hzoom??:Either fill in the numerator and denominator, or click \s on the arrows, to use the given zoom factor.
+Hrange?/Hrange??:This \w displays the range of pixel intensities used.
+Hsrc?/Hsrc??:This \w displays information on the source image that was processed.
+Hscale0:\Sdisable automatic pixel size correction for source pixels only.
+Hscale18:\Sdisable all automatic pixel size correction.
+Hscale19:\Sattempt to scale the image as requested but overall retain the picture aspect ratio. 
+Hscale1:\Sscale to fill the current screen size.
+Hscale2:\Sperform no scaling.
+Hscale3:\Shalve the height.
+Hscale4:\Shalve the width.
+Hscale5:\Shalve both the width and height.
+Hscale9:\Suse a custom scaling factor.
+Hscale10/Hscale12:The numerator is an initial scaling up of the source image.
+Hscale11/Hscale13:The denominator is a subsequent scaling down of the source image.
+Hscale6:\Senable rotation.
+Hscale16:\Srotate clockwise 90 degrees.
+Hscale17:\Srotate anti-clockwise 90 degrees.
+Hscale7:\Sflip the image about its vertical edge.
+Hscale8:\Sflip the image about its horizontal edge.
+Hscale?/Hscale??:This \w sets up geometrical operations to perform on the source image.
+Hproc0:\Sanalyse the source image and attempt to maximise the dynamic range used in the output.
+Hproc1:\Sanalyse the source image and attempt to spread the intensities evenly in the output.
+Hproc2:\Sturn off the error diffusion patterns used to trick the eye when not enough colours are available.
+Hproc3:\Smake a negative.
+Hproc4:\Sslightly lighten the output image.
+Hproc5:\Sattempt to correct for black inked spots bigger than the given size.
+Hproc6:\Sapply gamma correction for the display.
+Hproc7:\Sdigitally sharpen the source image.
+Hproc12:\Sdigitally soften the source image.
+Hproc8:Enter a number in the range 0-128.|M0 means no correction, 128 is severe correction.
+Hproc9:Enter a number for gamma.|MMonitors typically use a gamma factor of 2.2.
+Hproc10:Enter a number in the range 8-31.|M8 means most sharp, 31 is slight sharpening.
+Hproc11:Enter a number in the range 1 to 23.|M1 means most soft, 23 is slight softening.
+Hproc?/Hproc??:This \w sets up special effects to perform on the source image.
+Hout16:\Screate colour sprites.
+Hout17:\Screate greyscale sprites.
+Hout18:\Screate a sprite for the current desktop mode.
+Hout24:\Screate a sprite for the a numbered mode.
+Hout33:Enter a numbered Archimedes screen mode.
+Hout3/Hout4/Hout5/Hout6/Hout7/Hout8:\Screate a sprite with the given number of colours, and square pixels.
+Hout9/Hout10/Hout11/Hout12/Hout13/Hout14:\Screate a sprite with the given number of colours, and rectangular pixels.
+Hout20:This is the equivalent mode number based on the current selection.
+Hout15:\Screate a sprite using one of ChangeFSI's special colour matching options.
+Hout19:Choose from one of four colour matching options, depending on the output colours selected.|Mc: 2 or 4 colours|Md: 2, 16 or 256 colours|Mt: 2, 16 or 256 colours|Mr: 4, 16 or 256 colours
+Hout?/Hout??:This \w sets the output sprite type.
+Himnu0:\Rsee information about ChangeFSI.
+Himnu1:\Rset the scaling factors.
+Himnu2:\Rset extra image processing steps.
+Himnu3:\Schoose sprite output.|M\Rset the output sprite type.
+Himnu4:\Schoose JPEG output.|M\Rset the output JPEG type.
+Himnu5/Hpmnu5:\Sredo this image with the selected options.
+Himnu5g:\Gno image has been processed yet.
+Himnu6:\Sswitch to a low video mode while calculating.
+Himnu6g:\Gthe computer is already configured to be fast.
+Himnu7:\Ssave the current setup as the default.
+Himnu8:\Squit ChangeFSI.
+Hpmnu0:\Rsee information about the output image.
+Hpmnu1:\Rsee information about the input image.
+Hpmnu2:\Rsee information about the range used.
+Hpmnu3:\Rset the zoom factors.
+Hpmnu4:\Rsave this image to disc.

--- a/spec/visual/samples/msgtrans
+++ b/spec/visual/samples/msgtrans
@@ -1,104 +1,15 @@
-_TaskName:ChangeFSI
-_Version:Substituted at build time
-# Picture menu
-Pimg:Image info
-Psrc:Source info
-Prange:Range info
-Pzoom:Zoom
-Psave:Save image
-# Iconbar menu
-Iinfo:Info
-Iscale:Scaling
-Iproc:Processing
-Ijpg:JPEG output
-Ispr:Sprite output
-Ifast:Fast
-Ichoice:Save choices
-Iquit:Quit
-# Common menus
-PIredo:Reprocess
-# General messages
+# Comments require hash in column 0
+Token:Value # this is still part of the value
+# All sorts of nonsense is permitted in token names
+Token!"#$%&'(*+-.;<=>@[\]^_`{|}~:Other value
+# Parameter substitution uses %
 ScaleFill:Scale to fill %0 by %1
-NoRange:Range not used
+# Literal % characters are represented by %%
+FullSize:Scale to 100%%
+# Multiple tokens can match the same result and be separated by '/' or newline
+Hout3/Hout4/Hout5
+Hout6/Hout7/Hout8:Create a sprite with the given number of colours.
+# '?' is a wildcard in token names
+Hinfo?/Hinfo??:This window displays information about ChangeFSI.
+# But not in values
 OverW:Overwrite source file?
-ButErr:Ignore,Quit
-ButCon:Cancel,Discard
-BadJQ:Invalid JPEG quality in JPEG output dialogue box
-BadMode:Invalid mode number in sprite output dialogue box
-Proc:processed in %0 seconds
-Unsaved:Image created from '%0' not saved
-# Interactive help
-Hinfo?/Hinfo??:This \w displays information about ChangeFSI.
-Hpic?/Hpic??:\Toutput image from ChangeFSI.
-Hsave0:Drag this icon to the directory in which you want to save the file, or drag it to the program into which you want to transfer the data.
-Hsave1:This shows the filename for this data. If it is not a full pathname, drag the icon into a directory display.
-Hsave2:\Ssave the data with the current filename. If it is not a full pathname, you must drag the icon to a directory first.
-Hsave?/Hsave??:This \w allows you to save data in a file, or transfer it to another application.
-Hsprite?/Hsprite??:This \w displays information on the output image produced.
-Hjpeg1:\Screate colour JPEGs.
-Hjpeg2:\Screate greyscale JPEGs.
-Hjpeg5:Enter a quality directly in this box.|MValues in the range 0-100 are accepted and trade off file size with image quality.|MA value of 100 means 'do not compress'.|M
-Hjpeg3:\Sdecrease the quality (smaller output file).
-Hjpeg4:\Sincrease the quality (larger output file).
-Hjpeg?/Hjpeg??:This \w sets the output JPEG type.
-Hzoom?/Hzoom??:Either fill in the numerator and denominator, or click \s on the arrows, to use the given zoom factor.
-Hrange?/Hrange??:This \w displays the range of pixel intensities used.
-Hsrc?/Hsrc??:This \w displays information on the source image that was processed.
-Hscale0:\Sdisable automatic pixel size correction for source pixels only.
-Hscale18:\Sdisable all automatic pixel size correction.
-Hscale19:\Sattempt to scale the image as requested but overall retain the picture aspect ratio. 
-Hscale1:\Sscale to fill the current screen size.
-Hscale2:\Sperform no scaling.
-Hscale3:\Shalve the height.
-Hscale4:\Shalve the width.
-Hscale5:\Shalve both the width and height.
-Hscale9:\Suse a custom scaling factor.
-Hscale10/Hscale12:The numerator is an initial scaling up of the source image.
-Hscale11/Hscale13:The denominator is a subsequent scaling down of the source image.
-Hscale6:\Senable rotation.
-Hscale16:\Srotate clockwise 90 degrees.
-Hscale17:\Srotate anti-clockwise 90 degrees.
-Hscale7:\Sflip the image about its vertical edge.
-Hscale8:\Sflip the image about its horizontal edge.
-Hscale?/Hscale??:This \w sets up geometrical operations to perform on the source image.
-Hproc0:\Sanalyse the source image and attempt to maximise the dynamic range used in the output.
-Hproc1:\Sanalyse the source image and attempt to spread the intensities evenly in the output.
-Hproc2:\Sturn off the error diffusion patterns used to trick the eye when not enough colours are available.
-Hproc3:\Smake a negative.
-Hproc4:\Sslightly lighten the output image.
-Hproc5:\Sattempt to correct for black inked spots bigger than the given size.
-Hproc6:\Sapply gamma correction for the display.
-Hproc7:\Sdigitally sharpen the source image.
-Hproc12:\Sdigitally soften the source image.
-Hproc8:Enter a number in the range 0-128.|M0 means no correction, 128 is severe correction.
-Hproc9:Enter a number for gamma.|MMonitors typically use a gamma factor of 2.2.
-Hproc10:Enter a number in the range 8-31.|M8 means most sharp, 31 is slight sharpening.
-Hproc11:Enter a number in the range 1 to 23.|M1 means most soft, 23 is slight softening.
-Hproc?/Hproc??:This \w sets up special effects to perform on the source image.
-Hout16:\Screate colour sprites.
-Hout17:\Screate greyscale sprites.
-Hout18:\Screate a sprite for the current desktop mode.
-Hout24:\Screate a sprite for the a numbered mode.
-Hout33:Enter a numbered Archimedes screen mode.
-Hout3/Hout4/Hout5/Hout6/Hout7/Hout8:\Screate a sprite with the given number of colours, and square pixels.
-Hout9/Hout10/Hout11/Hout12/Hout13/Hout14:\Screate a sprite with the given number of colours, and rectangular pixels.
-Hout20:This is the equivalent mode number based on the current selection.
-Hout15:\Screate a sprite using one of ChangeFSI's special colour matching options.
-Hout19:Choose from one of four colour matching options, depending on the output colours selected.|Mc: 2 or 4 colours|Md: 2, 16 or 256 colours|Mt: 2, 16 or 256 colours|Mr: 4, 16 or 256 colours
-Hout?/Hout??:This \w sets the output sprite type.
-Himnu0:\Rsee information about ChangeFSI.
-Himnu1:\Rset the scaling factors.
-Himnu2:\Rset extra image processing steps.
-Himnu3:\Schoose sprite output.|M\Rset the output sprite type.
-Himnu4:\Schoose JPEG output.|M\Rset the output JPEG type.
-Himnu5/Hpmnu5:\Sredo this image with the selected options.
-Himnu5g:\Gno image has been processed yet.
-Himnu6:\Sswitch to a low video mode while calculating.
-Himnu6g:\Gthe computer is already configured to be fast.
-Himnu7:\Ssave the current setup as the default.
-Himnu8:\Squit ChangeFSI.
-Hpmnu0:\Rsee information about the output image.
-Hpmnu1:\Rsee information about the input image.
-Hpmnu2:\Rsee information about the range used.
-Hpmnu3:\Rset the zoom factors.
-Hpmnu4:\Rsave this image to disc.


### PR DESCRIPTION
These are commonly used for key-value string lookup (with basic parameter
substitution facilities) on RISC OS. Typically, each application will be
distributed with one such file for each locale that it has been translated
into.