### PR TITLE
Improvements to Make lexer

### DIFF
--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -47,7 +47,7 @@ module Rouge
 
         rule %r/(?:else|endif)[\t ]*(?=[#\n])/, Keyword
 
-        rule %r/(export)([\t ]+)(?=[a-zA-Z0-9_\${}()\t -]+\n)/ do
+        rule %r/(export)([\t ]+)(?=[\w\${}()\t -]+\n)/ do
           groups Keyword, Text
           push :export
         end
@@ -55,7 +55,7 @@ module Rouge
         rule %r/export[\t ]+/, Keyword
 
         # assignment
-        rule %r/([a-zA-Z0-9_${}().-]+)([\t ]*)([!?:+]?=)/m do |m|
+        rule %r/([\w${}().-]+)([\t ]*)([!?:+]?=)/m do |m|
           token Name::Variable, m[1]
           token Text, m[2]
           token Operator, m[3]

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -37,6 +37,10 @@ module Rouge
 
         rule %r/#.*?\n/, Comment
 
+        rule %r/([-s]?include)((?:[\t ]+[^\t\n #]+)+)/ do
+          groups Keyword, Literal::String::Other
+        end
+
         rule %r/(export)([\t ]+)(?=[a-zA-Z0-9_\${}()\t -]+\n)/ do
           groups Keyword, Text
           push :export

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -95,7 +95,7 @@ module Rouge
 
       state :shell_expr do
         rule(/\(/) { delegate @shell; push }
-        rule %r/\)/, Name::Variable, :pop!
+        rule %r/\)/, Name::Function, :pop!
         mixin :shell
       end
 

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -107,7 +107,7 @@ module Rouge
 
       state :shell do
         # macro interpolation
-        rule %r/\$[({][\t ]*[a-z_]\w*[\t ]*[)}]/i, Name::Variable
+        rule %r/\$[({][\t ]*[a-z_][\w:=%.]*[\t ]*[)}]/i, Name::Variable
         # function invocation
         rule %r/(\$[({])([\t ]*)(#{Make.functions.join('|')})([\t ]+)/m do
           groups Name::Function, Text, Name::Builtin, Text

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -28,15 +28,15 @@ module Rouge
 
         rule %r/#.*?\n/, Comment
 
-        rule %r/(export)(\s+)(?=[a-zA-Z0-9_\${}\t -]+\n)/ do
+        rule %r/(export)([\t ]+)(?=[a-zA-Z0-9_\${}\t -]+\n)/ do
           groups Keyword, Text
           push :export
         end
 
-        rule %r/export\s+/, Keyword
+        rule %r/export[\t ]+/, Keyword
 
         # assignment
-        rule %r/([a-zA-Z0-9_${}.-]+)(\s*)([!?:+]?=)/m do |m|
+        rule %r/([a-zA-Z0-9_${}.-]+)([\t ]*)([!?:+]?=)/m do |m|
           token Name::Variable, m[1]
           token Text, m[2]
           token Operator, m[3]
@@ -54,7 +54,7 @@ module Rouge
       state :export do
         rule %r/[\w\${}-]/, Name::Variable
         rule %r/\n/, Text, :pop!
-        rule %r/\s+/, Text
+        rule %r/[\t ]+/, Text
       end
 
       state :block_header do
@@ -80,9 +80,9 @@ module Rouge
 
       state :shell do
         # macro interpolation
-        rule %r/\$\(\s*[a-z_]\w*\s*\)/i, Name::Variable
+        rule %r/\$\([\t ]*[a-z_]\w*[\t ]*\)/i, Name::Variable
         # $(shell ...)
-        rule %r/(\$\()(\s*)(shell)(\s+)/m do
+        rule %r/(\$\()([\t ]*)(shell)([\t ]+)/m do
           groups Name::Function, Text, Name::Builtin, Text
           push :shell_expr
         end

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Makefile syntax"
       tag 'make'
       aliases 'makefile', 'mf', 'gnumake', 'bsdmake'
-      filenames '*.make', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'
+      filenames '*.make', '*.mak', '*.mk', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'
       mimetypes 'text/x-makefile'
 
       def self.functions

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Makefile syntax"
       tag 'make'
       aliases 'makefile', 'mf', 'gnumake', 'bsdmake'
-      filenames '*.make', '*.mak', '*.mk', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'
+      filenames '*.make', '*.mak', '*.mk', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile', '*,fe1'
       mimetypes 'text/x-makefile'
 
       def self.functions

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -107,7 +107,7 @@ module Rouge
 
       state :shell do
         # macro interpolation
-        rule %r/\$[({][\t ]*[a-z_][\w:=%.]*[\t ]*[)}]/i, Name::Variable
+        rule %r/\$[({][\t ]*\w[\w:=%.]*[\t ]*[)}]/i, Name::Variable
         # function invocation
         rule %r/(\$[({])([\t ]*)(#{Make.functions.join('|')})([\t ]+)/m do
           groups Name::Function, Text, Name::Builtin, Text

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -11,6 +11,15 @@ module Rouge
       filenames '*.make', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'
       mimetypes 'text/x-makefile'
 
+      def self.functions
+        @functions ||= %w(
+          abspath addprefix addsuffix and basename call dir error eval file
+          filter filter-out findstring firstword flavor foreach if join lastword
+          notdir or origin patsubst realpath shell sort strip subst suffix value
+          warning wildcard word wordlist words
+        )
+      end
+
       # TODO: Add support for special keywords
       # bsd_special = %w(
       #   include undef error warning if else elif endif for endfor
@@ -81,8 +90,8 @@ module Rouge
       state :shell do
         # macro interpolation
         rule %r/\$[({][\t ]*[a-z_]\w*[\t ]*[)}]/i, Name::Variable
-        # $(shell ...)
-        rule %r/(\$[({])([\t ]*)(shell)([\t ]+)/m do
+        # function invocation
+        rule %r/(\$[({])([\t ]*)(#{Make.functions.join('|')})([\t ]+)/m do
           groups Name::Function, Text, Name::Builtin, Text
           push :shell_expr
         end

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -41,6 +41,12 @@ module Rouge
           groups Keyword, Literal::String::Other
         end
 
+        rule %r/(ifn?def|ifn?eq)([\t ]+)([^#\n]+)/ do
+          groups Keyword, Text, Name::Variable
+        end
+
+        rule %r/(?:else|endif)[\t ]*(?=[#\n])/, Keyword
+
         rule %r/(export)([\t ]+)(?=[a-zA-Z0-9_\${}()\t -]+\n)/ do
           groups Keyword, Text
           push :export
@@ -83,6 +89,14 @@ module Rouge
       end
 
       state :block_body do
+        rule %r/(ifn?def|ifn?eq)([\t ]+)([^#\n]+)(#.*)?(\n)/ do
+          groups Keyword, Text, Name::Variable, Comment, Text
+        end
+
+        rule %r/(else|endif)([\t ]*)(#.*)?(\n)/ do
+          groups Keyword, Text, Comment, Text
+        end
+
         rule %r/(\t[\t ]*)([@-]?)/ do
           groups Text, Punctuation
           push :shell_line

--- a/spec/lexers/make_spec.rb
+++ b/spec/lexers/make_spec.rb
@@ -9,6 +9,9 @@ describe Rouge::Lexers::Make do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.make'
+      assert_guess :filename => 'bar.mak'
+      assert_guess :filename => 'baz.mk'
+      assert_guess :filename => 'Make,fe1'
       assert_guess :filename => 'Makefile'
       assert_guess :filename => 'makefile'
       assert_guess :filename => 'Makefile.in'

--- a/spec/visual/samples/make
+++ b/spec/visual/samples/make
@@ -55,3 +55,60 @@ commands_switch:	all platform
 
 frameworkaltinstallunixtools:
 	cd Mac && $(MAKE) altinstallunixtools DESTDIR="$(DESTDIR)"
+
+include SubMake.make # Insert lines from another file (which must exist)
+-include Maybe.make  # Next 2 similar, but not an error if they doon't exist
+sinclude DynamicDependencies.make
+
+# Function expansions (including $(shell)) can occur anywhere
+$(shell echo VARIABLE) := $(shell echo value)
+
+$(shell echo $(TARGET1)) $(TARGET2) target3: \
+	$(shell echo $(DEPENDENCY1)) $(DEPENDENCY2) dependency3
+	touch $(shell echo target{1..3})
+	@echo $(shell echo 1)
+	@echo $(shell echo 2 )
+	@echo ${shell echo 3}
+	@echo ${shell echo 4 }
+
+# Many other built-in functions exist
+OBJECT_GOALS = $(filter %.o,${MAKECMDGOALS})
+
+# User-defined functions can be used via $(call)
+reverse = $(2) $(1)
+foo = $(call reverse,a,b) # foo contains 'b a'
+
+# Substitution references can be used when expanding variables
+SOURCE = $(OBJECT:.o=.c)
+
+# Alternative syntax for substitution references
+foo = input1.txt
+bar = $(foo:input%.txt=output%.bin) # set to 'output1.bin'
+
+# Conditionals
+ifdef THING
+THING2 = $(THING)
+else
+THING2 = default
+endif
+
+ifeq ($(TARGET),special) # syntax variant: parentheses and separating comma
+TARGET = something_else
+else
+	ifneq '$(TARGET)' "don't" # syntax variant: either argument can be single or double quoted
+TARGET = be_silly
+	endif # and can be indented, even with tabs (so long as not in a recipe)
+endif
+
+count:
+	echo one
+	echo two
+ifndef QUIET # conditionals can happen within recipes
+	echo miss a few
+endif
+	echo one hundred
+
+# Dollars must be escaped if a literal one is required
+
+print_path:
+	echo $$PATH


### PR DESCRIPTION
This is still far from handling the full syntax of makefiles, but it handles far more of the examples I threw at it than the previous version.

If I have one main remaining observation, it's that variable expansions and function invocations (i.e. `$(thing)`) is actually valid at any point in a makefile, but they are only being fully lexed when they occur within a recipe line. For example, in the following slightly contrived example,

```makefile
NAME_OF_TARGET=TARGET
$(NAME_OF_TARGET)=$(filter %.o,$(MAKECMDGOALS))
SOURCE=$(TARGET:.o=.c)

ifneq "$(shell uname)" ''
$(shell echo $(TARGET)): $(shell echo $(SOURCE))
	cc -o $@ $(shell echo $(SOURCE))
endif
```

the only `$(shell...)` function that is differentially coloured into its component parts is the one on the penultimate line (and in fact lexing fails if you try it on the left-hand side of an assignment). By contrast, I note that GitHub's colouring above treats them all the same.

I'm not sure how consistency can be efficiently achieved.