### PR TITLE
Add lexer for Cython support

### DIFF
--- a/lib/rouge/demos/cython
+++ b/lib/rouge/demos/cython
@@ -1,0 +1,18 @@
+cpdef fib(int n):    # Cython version
+    """Print a Fibonacci series up to n."""
+    cdef int a = 0
+    cdef int b
+
+    b = 1
+
+    while a < n:
+        print(a)
+        a, b = b, a+b
+
+# Python function
+def fib(n):    # Python version
+    """Print a Fibonacci series up to n."""
+    a, b = 0, 1
+    while a < n:
+        print a,
+        a, b = b, a+b

--- a/lib/rouge/demos/cython
+++ b/lib/rouge/demos/cython
@@ -1,3 +1,17 @@
+import numpy
+from numpy cimport abs
+
+cdef extern from 'foo.h':
+    int foo_int
+    struct foo_struct:
+        pass
+
+ctypedef int word
+
+cdef struct Foo:
+    pass
+
+
 cpdef fib(int n):    # Cython version
     """Print a Fibonacci series up to n."""
     cdef int a = 0

--- a/lib/rouge/demos/cython
+++ b/lib/rouge/demos/cython
@@ -1,32 +1,6 @@
-import numpy
-from numpy cimport abs
-
 cdef extern from 'foo.h':
     int foo_int
     struct foo_struct:
         pass
 
 ctypedef int word
-
-cdef struct Foo:
-    pass
-
-
-cpdef fib(int n):    # Cython version
-    """Print a Fibonacci series up to n."""
-    cdef int a = 0
-    cdef int b
-
-    b = 1
-
-    while a < n:
-        print(a)
-        a, b = b, a+b
-
-# Python function
-def fib(n):    # Python version
-    """Print a Fibonacci series up to n."""
-    a, b = 0, 1
-    while a < n:
-        print a,
-        a, b = b, a+b

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -20,7 +20,7 @@ module Rouge
 
       def self.keywords
         @keywords ||= super + %w(
-          by except? fused gil nogil 
+          by except? fused gil nogil
         )
       end
 
@@ -32,7 +32,7 @@ module Rouge
 
       identifier = /[a-z_]\w*/i
       dotted_identifier = /[a-z_.][\w.]*/i
-      
+
       prepend :root do
         rule %r/cp?def|ctypedef/ do
           token Keyword
@@ -75,11 +75,11 @@ module Rouge
       state :func_call_fix do
         rule %r/#{identifier}(?=\()/ do |m|
           if self.class.keywords.include? m[0]
-            token Keyword 
+            token Keyword
           elsif self.class.exceptions.include? m[0]
-            token Name::Builtin 
+            token Name::Builtin
           elsif self.class.builtins.include? m[0]
-            token Name::Builtin 
+            token Name::Builtin
           elsif self.class.builtins_pseudo.include? m[0]
             token Name::Builtin::Pseudo
           else
@@ -98,7 +98,7 @@ module Rouge
 
       state :c_start do
         rule %r/[^\S\n]+/, Text
-        
+
         rule %r/cp?def|ctypedef/, Keyword
 
         rule %r/(?:un)?signed/, Keyword::Type
@@ -122,7 +122,7 @@ module Rouge
             pop!
           end
         end
-        
+
         rule(//) { pop! }
       end
 
@@ -143,7 +143,7 @@ module Rouge
             pop! 2 # Pop :c_start and :c_definitions
           end
         end
-        
+
         rule(//) { @indentation = nil; reset_stack }
       end
     end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -63,6 +63,7 @@ module Rouge
 
         rule %r/:/, Punctuation, :pop!
         rule %r/(?=["\'])/, Text, :pop!
+        rule %r/\n/, Text, :pop!
         rule %r/[a-zA-Z_]\w*/, Keyword::Type
         rule %r/./m, Text
       end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -64,8 +64,7 @@ module Rouge
         rule %r/:/, Punctuation, :pop!
         rule %r/(?=["\'])/, Text, :pop!
         rule %r/[a-zA-Z_]\w*/, Keyword::Type
-        rule %r/\n+/m, Text
-        rule %r/./, Text
+        rule %r/./m, Text
       end
 
     end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -14,11 +14,12 @@ module Rouge
       mimetypes 'text/x-cython', 'application/x-cython'
 
       def self.keywords
-        @keywords ||= super + Set.new(%w(
+        @keywords ||= super + Array.new(%w(
           by ctypedef except? fused gil nogil 
         ))
       end
 
+      dotted_identifier = /[a-z_.][a-z0-9_.]*/i
       prepend :root do
         rule %r/(cimport)(\s+)(#{dotted_identifier})/ do
           groups Keyword::Namespace, Text, Name::Namespace
@@ -32,9 +33,13 @@ module Rouge
                  Keyword::Namespace
         end
 
-        rule %r/(cp?def)((?:\s|\\\s)+)/ do
+        rule %r/(cp?def)(\s+)/ do
           groups Keyword, Text
           push :cdef
+        end
+
+        rule %r/(cdef)(:)/ do
+          groups Keyword, Punctuation
         end
 
         rule %r/(struct)((?:\s|\\\s)+)/ do
@@ -55,10 +60,7 @@ module Rouge
         end
         rule %r/from\b/, Keyword, :pop!
         rule %r/as\b/, Keyword
-        rule %r/:/, Punctuation, :pop!
-        rule %r/(?=["\'])/, Text, :pop!
-        rule %r/[a-zA-Z_]\w*/, Keyword::Type
-        rule %r/./, Text
+        mixin :root
       end
 
     end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -15,27 +15,29 @@ module Rouge
 
       def initialize(opts = {})
         super opts
-        @indentation = []
+        @indentation = nil
       end
 
       def self.keywords
         @keywords ||= super + %w(
-          by cdef cpdef ctypedef except? fused gil nogil 
+          by except? fused gil nogil 
         )
       end
 
-      def self.ckeywords
+      def self.c_keywords
         @ckeywords ||= %w(
-          public readonly extern api inline struct enum union class
+          public readonly extern api inline enum union
         )
       end
 
       identifier = /[a-z_]\w*/i
-      dotted_identifier = /[a-z_.][a-z0-9_.]*/i
+      dotted_identifier = /[a-z_.][\w.]*/i
       
       prepend :root do
-        rule %r/(cimport)(\s+)(#{dotted_identifier})/ do
-          groups Keyword::Namespace, Text, Name::Namespace
+        rule %r/cp?def|ctypedef/ do
+          token Keyword
+          push :c_definitions
+          push :c_start
         end
 
         rule %r/(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(cimport)/ do
@@ -46,76 +48,100 @@ module Rouge
                  Keyword::Namespace
         end
 
-        rule %r/cp?def|ctypedef/, Keyword, :ctype
+        rule %r/(cimport)(\s+)(#{dotted_identifier})/ do
+          groups Keyword::Namespace, Text, Name::Namespace
+        end
 
         rule %r/(struct)((?:\\\s|\s)+)/ do
           groups Keyword, Text
           push :classname
         end
-        
-        rule %r/(#{identifier})(\()/ do |m|
-          if self.class.keywords.include? m[1]
-            groups Keyword, Punctuation
-          elsif self.class.exceptions.include? m[1]
-            groups Name::Builtin, Punctuation
-          elsif self.class.builtins.include? m[1]
-            groups Name::Builtin, Punctuation
-          elsif self.class.builtins_pseudo.include? m[1]
-            groups Name::Builtin::Pseudo, Punctuation
+
+        mixin :func_call_fix
+
+        rule %r/[(,]/, Punctuation, :c_start
+      end
+
+      prepend :classname do
+        rule %r/(?:\\\s|\s)+/, Text
+      end
+
+      prepend :funcname do
+        rule %r/(?:\\\s|\s)+/, Text
+      end
+      # This is a fix for the way that function calls are lexed in the Python
+      # lexer. This should be moved to the Python lexer once confirmed that it
+      # does not cause any regressions.
+      state :func_call_fix do
+        rule %r/#{identifier}(?=\()/ do |m|
+          if self.class.keywords.include? m[0]
+            token Keyword 
+          elsif self.class.exceptions.include? m[0]
+            token Name::Builtin 
+          elsif self.class.builtins.include? m[0]
+            token Name::Builtin 
+          elsif self.class.builtins_pseudo.include? m[0]
+            token Name::Builtin::Pseudo
           else
-            groups Name::Function, Punctuation
+            token Name::Function
           end
-          goto :ctype
         end
       end
 
-      state :ctype do
+      # The Cython lexer adds three states to those already in the Python lexer.
+      # Calls to `cdef`, `cpdef` and `ctypedef` move the lexer into the :c_start
+      # state. The primary purpose of this state is to highlight datatypes. Once
+      # this has been done, the lexer moves to the :c_definitions state where
+      # the majority of text in a definition is lexed. Finally, newlines cause
+      # the lexer to move to :c_indent. This state is used to check whether we
+      # have moved out of a C block.
+
+      state :c_start do
         rule %r/[^\S\n]+/, Text
         
-        rule %r/cp?def|ctypedef/ do |m|
-          token Keyword
-        end
-        
+        rule %r/cp?def|ctypedef/, Keyword
+
+        rule %r/(?:un)?signed/, Keyword::Type
+
+        # This rule matches identifiers that could be type declarations. The
+        # lookahead matches (1) pointers, (2) arrays and (3) variable names.
         rule %r/#{identifier}(?=(?:\*+)|(?:[ \t]*\[)|(?:[ \t]+\w))/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
-          elsif self.class.ckeywords.include? m[0]
+            pop!
+          elsif %w(def).include? m[0]
+            token Keyword
+            goto :funcname
+          elsif %w(struct class).include? m[0]
+            token Keyword::Reserved
+            goto :classname
+          elsif self.class.c_keywords.include? m[0]
             token Keyword::Reserved
           else
             token Keyword::Type
+            pop!
           end
-          goto :cdef
         end
         
-        rule(//) { goto :cdef }
+        rule(//) { pop! }
       end
 
-      state :cdef do
-        rule %r/\n/, Text, :cindent
-        
-        rule %r/cp?def|ctypedef/ do |m|
-          token Keyword
-          goto :ctype
-        end
-
-        rule %r/(public|readonly|extern|api|inline)\b/, Keyword::Reserved
-        rule %r/(struct|enum|union|class)\b/, Keyword
-
+      state :c_definitions do
+        rule %r/\n/, Text, :c_indent
         mixin :root
       end
 
-      state :cindent do
+      state :c_indent do
         rule %r/[ \t]+/ do |m|
           token Text
+          goto :c_start
 
           if @indentation.nil?
             @indentation = m[0]
           elsif @indentation.length > m[0].length
             @indentation = nil
-            pop!
+            pop! 2 # Pop :c_start and :c_definitions
           end
-
-          goto :ctype
         end
         
         rule(//) { @indentation = nil; reset_stack }

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    load_lexer 'python.rb'
+
+    class Cython < Python
+      title "Cython"
+      desc "Cython and Pyrex source code (cython.org)"
+      tag 'cython'
+      aliases 'pyx', 'pyrex'
+      filenames '*.pyx', '*.pxd', '*.pxi'
+      mimetypes 'text/x-cython', 'application/x-cython'
+
+      def self.keywords
+        @keywords ||= super + Set.new(%w(
+          by ctypedef except? fused gil nogil 
+        ))
+      end
+
+      prepend :root do
+        rule %r/(cimport)(\s+)(#{dotted_identifier})/ do
+          groups Keyword::Namespace, Text, Name::Namespace
+        end
+
+        rule %r/(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(cimport)/ do
+          groups Keyword::Namespace,
+                 Text,
+                 Name::Namespace,
+                 Text,
+                 Keyword::Namespace
+        end
+
+        rule %r/(cp?def)((?:\s|\\\s)+)/ do
+          groups Keyword, Text
+          push :cdef
+        end
+
+        rule %r/(struct)((?:\s|\\\s)+)/ do
+          groups Keyword, Text
+          push :classname
+        end
+      end
+
+      state :cdef do
+        rule %r/(public|readonly|extern|api|inline)\b/, Keyword::Reserved
+        rule %r/(struct|enum|union|class)\b/, Keyword
+        rule %r/([a-zA-Z_]\w*)(\s*)(?=[(:#=]|$)/ do 
+          groups Name::Function, Text
+          :pop!
+        end
+        rule %r/([a-zA-Z_]\w*)(\s*)(,)/ do
+          groups Name::Function, Text, Punctuation
+        end
+        rule %r/from\b/, Keyword, :pop!
+        rule %r/as\b/, Keyword
+        rule %r/:/, Punctuation, :pop!
+        rule %r/(?=["\'])/, Text, :pop!
+        rule %r/[a-zA-Z_]\w*/, Keyword::Type
+        rule %r/./, Text
+      end
+
+    end
+  end
+end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -14,9 +14,9 @@ module Rouge
       mimetypes 'text/x-cython', 'application/x-cython'
 
       def self.keywords
-        @keywords ||= super + Array.new(%w(
+        @keywords ||= super + %w(
           by ctypedef except? fused gil nogil 
-        ))
+        )
       end
 
       dotted_identifier = /[a-z_.][a-z0-9_.]*/i
@@ -42,7 +42,7 @@ module Rouge
           groups Keyword, Punctuation
         end
 
-        rule %r/(struct)((?:\s|\\\s)+)/ do
+        rule %r/(struct)((?:\\\s|\s)+)/ do
           groups Keyword, Text
           push :classname
         end
@@ -60,7 +60,12 @@ module Rouge
         end
         rule %r/from\b/, Keyword, :pop!
         rule %r/as\b/, Keyword
-        mixin :root
+
+        rule %r/:/, Punctuation, :pop!
+        rule %r/(?=["\'])/, Text, :pop!
+        rule %r/[a-zA-Z_]\w*/, Keyword::Type
+        rule %r/\n+/m, Text
+        rule %r/./, Text
       end
 
     end

--- a/spec/lexers/cython_spec.rb
+++ b/spec/lexers/cython_spec.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Cython do
+  let(:subject) { Rouge::Lexers::Cython.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.pyx'
+      assert_guess :filename => 'foo.pxd'
+      assert_guess :filename => 'foo.pxi'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-cython'
+      assert_guess :mimetype => 'application/x-cython'
+    end
+  end
+end
+

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -1,0 +1,144 @@
+def lex(code, lexer):
+    """
+    Lex ``code`` with ``lexer`` and return an iterable of tokens.
+    """
+    try:
+        return lexer.get_tokens(code)
+    except TypeError, err:
+        if isinstance(err.args[0], str) and \
+           'unbound method get_tokens' in err.args[0]:
+            raise TypeError('lex() argument must be a lexer instance, '
+                            'not a class')
+        raise
+
+# quotes in strings
+def foo():
+    "it's working"
+
+def foo():
+    'he said "hi"'
+
+def foo():
+    """it's working"""
+    """he said "hi" """
+
+def foo():
+    '''he said "hi"'''
+    '''it's working'''
+
+# unicode docstrings
+def foo():
+    ur"""unicode-raw"""
+
+def bar():
+    u"""unicode"""
+
+def baz():
+    r'raw'
+
+def zap():
+    """docstring"""
+
+# escaped characters in string literals
+def baz():
+    '\a\b\f\n\r\t\v\"\''
+    '\N{DEGREE SIGN}'
+    '\uaF09'
+    '\UaaaaAF09'
+    '\xaf\xAF\x09'
+    '\007'
+
+# escaped characters in raw strings
+def baz():
+    r'\a\b\f\n\r\t\v\"\''
+    r'\N{DEGREE SIGN}'
+    r'\uaF09'
+    r'\UaaaaAF09'
+    r'\xaf\xAF\x09'
+    r'\007'
+
+# line continuations
+apple.filter(x, y)
+apple.\
+    filter(x, y)
+
+1 \
+    . \
+    __str__
+
+from os import path
+from \
+        os \
+        import \
+        path
+
+import os.path as something
+
+import \
+        os.path \
+        as \
+        something
+
+class \
+ Spam:
+    pass
+
+class Spam: pass
+
+class Spam(object):
+    pass
+
+class \
+ Spam \
+  (
+   object
+ ) \
+ :
+ pass
+
+
+def \
+ spam \
+  ( \
+  ) \
+  : \
+  pass
+
+def the_word_strand():
+    a = b.strip()
+    a = strand
+    b = band
+    c = strand
+    b = error
+    c = stror
+    c = string
+
+py2_long = -123L
+
+# Python 3
+
+def test():
+    raise Exception from foo
+
+def exceptions():
+    try:
+        print("Hello")
+    except Exception as e:
+        print("Exception")
+
+# PEP 515
+integer_literals = [
+    123, -1_2_0, 0, 00, 0_0_00, 0b1, 0B1_0, 0b_1, 0b00_0,
+    0o1, 0O1_2, 0O_1, 0o00_0, 0x1, 0X1_2, 0x_1, 0x00_0
+]
+float_literals = [
+    0., 1., 00., 0_00., 1_0_0., 0_1., .0,
+    .1_2, 3.4_5, 1_2.3_4, 00_0.0_0_0, 0_0.1_2,
+    0_1_2j, 0_00J, 1.2J, 0.1j, 1_0.J,
+    0_00E+2_34_5, 0.e+1, 00_1.E-0_2, -100.e+20, 1e01,
+    0_00E+2_34_5j, 0.e+1J, 00_1.E-0_2j, -100.e+20J 1e01j
+]
+
+# PEP 465
+a = b @ c
+x @= y

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -1,5 +1,37 @@
 # File from https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html
 
+import numpy
+from numpy cimport abs
+
+cdef extern from 'foo.h':
+    int foo_int
+    struct foo_struct:
+        pass
+
+ctypedef int word
+
+cdef struct Foo:
+    pass
+
+cpdef fib(int n):    # Cython version
+    """Print a Fibonacci series up to n."""
+    cdef int a = 0
+    cdef int b
+
+    b = 1
+
+    while a < n:
+        print(a)
+        a, b = b, a+b
+
+# Python function
+def fib(n):    # Python version
+    """Print a Fibonacci series up to n."""
+    a, b = 0, 1
+    while a < n:
+        print a,
+        a, b = b, a+b
+
 from cython.view cimport array as cvarray
 import numpy as np
 
@@ -47,3 +79,9 @@ cpdef int sum3d(int[:, :, :] arr) nogil:
             for k in range(K):
                 total += arr[i, j, k]
     return total
+            
+for i in range(i]:
+    total = total + 1
+
+# Back out of the block
+1 + 1 = 2

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -37,6 +37,8 @@ print("NumPy sum of NumPy array after assignments: %s" % narr.sum())
 cpdef int sum3d(int[:, :, :] arr) nogil:
     cdef size_t i, j, k, I, J, K
     cdef int total = 0
+    cdef:
+        int I, J, K
     I = arr.shape[0]
     J = arr.shape[1]
     K = arr.shape[2]

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -66,7 +66,7 @@ cpdef int sum3d(int[:, :, :] arr) nogil:
             for k in range(K):
                 total += arr[i, j, k]
     return total
-            
+
 # Inline C function
 cdef inline int something_fast(int a, int b):
     return a*a + b

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -1,21 +1,45 @@
-# File from https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html
+# -------------
+# Cython Syntax
+# -------------
 
+# Import statements
 import numpy
 from numpy cimport abs
 
+# Import statements with selection
+import numpy as np
+from cython.view cimport array as cvarray
+
+# Extern values
 cdef extern from 'foo.h':
     int foo_int
     struct foo_struct:
         pass
 
+# Type definitions
 ctypedef int word
 
+# C structs
 cdef struct Foo:
     pass
 
+# C classes
+cdef class MyType(ParentType):
+    cdef int field
+    cpdef foo(self, x=*, int k=*)
+
+# C class with classmethod
+cdef class Blah:
+    def some_method(self):
+        print self
+        some_method = classmethod(some_method)
+        a = 2*3
+        print "hi", a
+
+# C function
 cpdef fib(int n):    # Cython version
     """Print a Fibonacci series up to n."""
-    cdef int a = 0
+    cdef unsigned int a = 0
     cdef int b
 
     b = 1
@@ -25,47 +49,14 @@ cpdef fib(int n):    # Cython version
         a, b = b, a+b
 
 # Python function
-def fib(n):    # Python version
-    """Print a Fibonacci series up to n."""
-    a, b = 0, 1
-    while a < n:
-        print a,
-        a, b = b, a+b
+def foo(int n)
+    return n + 1
 
-from cython.view cimport array as cvarray
-import numpy as np
+# C function with return type
+cpdef unsigned int foo():
+    return 1 + 2
 
-# Memoryview on a NumPy array
-narr = np.arange(27, dtype=np.dtype("i")).reshape((3, 3, 3))
-cdef int [:, :, :] narr_view = narr
-
-# Memoryview on a C array
-cdef:
-    int carr[3][3][3]
-    int [:, :, :] carr_view = carr
-
-# Memoryview on a Cython array
-cyarr = cvarray(shape=(3, 3, 3), itemsize=sizeof(int), format="i")
-cdef int [:, :, :] cyarr_view = cyarr
-
-# Show the sum of all the arrays before altering it
-print("NumPy sum of the NumPy array before assignments: %s" % narr.sum())
-
-# We can copy the values from one memoryview into another using a single
-# statement, by either indexing with ... or (NumPy-style) with a colon.
-carr_view[...] = narr_view
-cyarr_view[:] = narr_view
-# NumPy-style syntax for assigning a single value to all elements.
-narr_view[:, :, :] = 3
-
-# Just to distinguish the arrays
-carr_view[0, 0, 0] = 100
-cyarr_view[0, 0, 0] = 1000
-
-# Assigning into the memoryview on the NumPy array alters the latter
-print("NumPy sum of NumPy array after assignments: %s" % narr.sum())
-
-# A function using a memoryview does not usually need the GIL
+# C function with no GIL
 cpdef int sum3d(int[:, :, :] arr) nogil:
     cdef size_t i, j, k, I, J, K
     cdef int total = 0
@@ -80,8 +71,49 @@ cpdef int sum3d(int[:, :, :] arr) nogil:
                 total += arr[i, j, k]
     return total
             
+# Inline C function
+cdef inline int something_fast(int a, int b):
+    return a*a + b
+
+# Assignment on declaration
+cdef int n = python_call(foo(x,y), a + b + c) - 32
+cdef int [:, :, :] narr_view = narr
+
+# Definition with C-block syntax
+cdef:
+    int carr[3][3][3]
+    int [:, :, :] carr_view = carr
+
+# Iteration with steps
+for i from 0 <= i < 10 by 2:
+    print i
+
+# -------------
+# Python syntax
+# -------------
+
+# Function call
+print("NumPy sum of the NumPy array before assignments: %s" % narr.sum())
+
+# Assignment
+narr = np.arange(27, dtype=np.dtype("i")).reshape((3, 3, 3))
+carr_view[...] = narr_view
+cyarr_view[:] = narr_view
+narr_view[:, :, :] = 3
+carr_view[0, 0, 0] = 100
+
+# Equality test
+1 + 1 == 2
+1 < 2
+
+# For loops
 for i in range(i]:
     total = total + 1
 
-# Back out of the block
-1 + 1 = 2
+# Function definition
+def fib(n):    # Python version
+    """Print a Fibonacci series up to n."""
+    a, b = 0, 1
+    while a < n:
+        print a,
+        a, b = b, a+b

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -8,8 +8,9 @@ narr = np.arange(27, dtype=np.dtype("i")).reshape((3, 3, 3))
 cdef int [:, :, :] narr_view = narr
 
 # Memoryview on a C array
-cdef int carr[3][3][3]
-cdef int [:, :, :] carr_view = carr
+cdef:
+    int carr[3][3][3]
+    int [:, :, :] carr_view = carr
 
 # Memoryview on a Cython array
 cyarr = cvarray(shape=(3, 3, 3), itemsize=sizeof(int), format="i")

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -19,11 +19,11 @@ cdef extern from 'foo.h':
 # Type definitions
 ctypedef int word
 
-# C structs
+# C struct
 cdef struct Foo:
     pass
 
-# C classes
+# C class
 cdef class MyType(ParentType):
     cdef int field
     cpdef foo(self, x=*, int k=*)
@@ -48,10 +48,6 @@ cpdef fib(int n):    # Cython version
         print(a)
         a, b = b, a+b
 
-# Python function
-def foo(int n)
-    return n + 1
-
 # C function with return type
 cpdef unsigned int foo():
     return 1 + 2
@@ -74,6 +70,10 @@ cpdef int sum3d(int[:, :, :] arr) nogil:
 # Inline C function
 cdef inline int something_fast(int a, int b):
     return a*a + b
+
+# Python function with typed parameters
+def foo(int n)
+    return n + 1
 
 # Assignment on declaration
 cdef int n = python_call(foo(x,y), a + b + c) - 32

--- a/spec/visual/samples/cython
+++ b/spec/visual/samples/cython
@@ -1,144 +1,46 @@
-def lex(code, lexer):
-    """
-    Lex ``code`` with ``lexer`` and return an iterable of tokens.
-    """
-    try:
-        return lexer.get_tokens(code)
-    except TypeError, err:
-        if isinstance(err.args[0], str) and \
-           'unbound method get_tokens' in err.args[0]:
-            raise TypeError('lex() argument must be a lexer instance, '
-                            'not a class')
-        raise
+# File from https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html
 
-# quotes in strings
-def foo():
-    "it's working"
+from cython.view cimport array as cvarray
+import numpy as np
 
-def foo():
-    'he said "hi"'
+# Memoryview on a NumPy array
+narr = np.arange(27, dtype=np.dtype("i")).reshape((3, 3, 3))
+cdef int [:, :, :] narr_view = narr
 
-def foo():
-    """it's working"""
-    """he said "hi" """
+# Memoryview on a C array
+cdef int carr[3][3][3]
+cdef int [:, :, :] carr_view = carr
 
-def foo():
-    '''he said "hi"'''
-    '''it's working'''
+# Memoryview on a Cython array
+cyarr = cvarray(shape=(3, 3, 3), itemsize=sizeof(int), format="i")
+cdef int [:, :, :] cyarr_view = cyarr
 
-# unicode docstrings
-def foo():
-    ur"""unicode-raw"""
+# Show the sum of all the arrays before altering it
+print("NumPy sum of the NumPy array before assignments: %s" % narr.sum())
 
-def bar():
-    u"""unicode"""
+# We can copy the values from one memoryview into another using a single
+# statement, by either indexing with ... or (NumPy-style) with a colon.
+carr_view[...] = narr_view
+cyarr_view[:] = narr_view
+# NumPy-style syntax for assigning a single value to all elements.
+narr_view[:, :, :] = 3
 
-def baz():
-    r'raw'
+# Just to distinguish the arrays
+carr_view[0, 0, 0] = 100
+cyarr_view[0, 0, 0] = 1000
 
-def zap():
-    """docstring"""
+# Assigning into the memoryview on the NumPy array alters the latter
+print("NumPy sum of NumPy array after assignments: %s" % narr.sum())
 
-# escaped characters in string literals
-def baz():
-    '\a\b\f\n\r\t\v\"\''
-    '\N{DEGREE SIGN}'
-    '\uaF09'
-    '\UaaaaAF09'
-    '\xaf\xAF\x09'
-    '\007'
-
-# escaped characters in raw strings
-def baz():
-    r'\a\b\f\n\r\t\v\"\''
-    r'\N{DEGREE SIGN}'
-    r'\uaF09'
-    r'\UaaaaAF09'
-    r'\xaf\xAF\x09'
-    r'\007'
-
-# line continuations
-apple.filter(x, y)
-apple.\
-    filter(x, y)
-
-1 \
-    . \
-    __str__
-
-from os import path
-from \
-        os \
-        import \
-        path
-
-import os.path as something
-
-import \
-        os.path \
-        as \
-        something
-
-class \
- Spam:
-    pass
-
-class Spam: pass
-
-class Spam(object):
-    pass
-
-class \
- Spam \
-  (
-   object
- ) \
- :
- pass
-
-
-def \
- spam \
-  ( \
-  ) \
-  : \
-  pass
-
-def the_word_strand():
-    a = b.strip()
-    a = strand
-    b = band
-    c = strand
-    b = error
-    c = stror
-    c = string
-
-py2_long = -123L
-
-# Python 3
-
-def test():
-    raise Exception from foo
-
-def exceptions():
-    try:
-        print("Hello")
-    except Exception as e:
-        print("Exception")
-
-# PEP 515
-integer_literals = [
-    123, -1_2_0, 0, 00, 0_0_00, 0b1, 0B1_0, 0b_1, 0b00_0,
-    0o1, 0O1_2, 0O_1, 0o00_0, 0x1, 0X1_2, 0x_1, 0x00_0
-]
-float_literals = [
-    0., 1., 00., 0_00., 1_0_0., 0_1., .0,
-    .1_2, 3.4_5, 1_2.3_4, 00_0.0_0_0, 0_0.1_2,
-    0_1_2j, 0_00J, 1.2J, 0.1j, 1_0.J,
-    0_00E+2_34_5, 0.e+1, 00_1.E-0_2, -100.e+20, 1e01,
-    0_00E+2_34_5j, 0.e+1J, 00_1.E-0_2j, -100.e+20J 1e01j
-]
-
-# PEP 465
-a = b @ c
-x @= y
+# A function using a memoryview does not usually need the GIL
+cpdef int sum3d(int[:, :, :] arr) nogil:
+    cdef size_t i, j, k, I, J, K
+    cdef int total = 0
+    I = arr.shape[0]
+    J = arr.shape[1]
+    K = arr.shape[2]
+    for i in range(I):
+        for j in range(J):
+            for k in range(K):
+                total += arr[i, j, k]
+    return total


### PR DESCRIPTION
Since Gitlab uses this lexer, I wanted to implement cython support. However, this is pretty much the first code I've written in Ruby.

I lent heavily on the Pygments implementation (https://bitbucket.org/birkenfeld/pygments-main/src/0bcf355df9fbe55d3753256c01260f48fa01e794/pygments/lexers/python.py?at=default&fileviewer=file-view-default#python.py-570) as suggested in the issue https://github.com/rouge-ruby/rouge/issues/1101

From what I can tell it passes tests, and a look at the rackup output seems to produce the right results for highlighting on the test file I used.

Let me know if this works and what needs to change.


