### PR TITLE
Fix unmatched characters in Puppet lexer

### DIFF
--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -59,7 +59,7 @@ module Rouge
         rule cap_id, Name::Class
 
         rule %r/[+=|~-]>|<[|~-]/, Punctuation
-        rule %r/[:}();\[\]]/, Punctuation
+        rule %r/[|:}();\[\]]/, Punctuation
 
         # HACK for case statements and selectors
         rule %r/{/, Punctuation, :regex_allowed
@@ -68,7 +68,7 @@ module Rouge
         rule %r/(in|and|or)\b/, Operator::Word
         rule %r/[=!<>]=/, Operator
         rule %r/[=!]~/, Operator, :regex_allowed
-        rule %r([.|=<>!+*/-]), Operator
+        rule %r([.=<>!+*/-]), Operator
 
         rule %r/(class|include)(\s*)(#{qualname})/ do
           groups Keyword, Text, Name::Class

--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -68,7 +68,7 @@ module Rouge
         rule %r/(in|and|or)\b/, Operator::Word
         rule %r/[=!<>]=/, Operator
         rule %r/[=!]~/, Operator, :regex_allowed
-        rule %r([=<>!+*/-]), Operator
+        rule %r([.|=<>!+*/-]), Operator
 
         rule %r/(class|include)(\s*)(#{qualname})/ do
           groups Keyword, Text, Name::Class

--- a/spec/visual/samples/puppet
+++ b/spec/visual/samples/puppet
@@ -1,3 +1,5 @@
+# Some example code
+
 node /www\.example\.com/ {
   include foo::bar
 
@@ -18,4 +20,15 @@ class foo::bar (
     'bar',
     'baz',
   ]
+}
+
+lookup('classes', {merge => unique}).include
+
+$resources = $acls.map |$index, $acl| {
+   $parts = $acl.split('\s+')
+   unless $parts =~ Array[Data, 4] {
+     fail("${func_name}: acl line $index does not have enough parts")
+   }
+
+   $resource
 }

--- a/spec/visual/samples/puppet
+++ b/spec/visual/samples/puppet
@@ -25,10 +25,10 @@ class foo::bar (
 lookup('classes', {merge => unique}).include
 
 $resources = $acls.map |$index, $acl| {
-   $parts = $acl.split('\s+')
-   unless $parts =~ Array[Data, 4] {
-     fail("${func_name}: acl line $index does not have enough parts")
-   }
+  $parts = $acl.split('\s+')
+  unless $parts =~ Array[Data, 4] {
+    fail("${func_name}: acl line $index does not have enough parts")
+  }
 
-   $resource
+  $resource
 }


### PR DESCRIPTION
The Puppet lexer does not match `.` or `|`, two valid characters. This PR fixes this bug.