### PR TITLE
Fix tokenisation in ARM Assembly lexer

### DIFF
--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -60,7 +60,9 @@ module Rouge
 
       state :root do
         rule %r/\n/, Text
-        rule %r/^[ \t]*#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})(?:[ \t].*)?)?\n/, Comment::Preproc
+        rule %r/^([ \t]*)(#[ \t]*(?:(?:#{ArmAsm.preproc_keyword.join('|')})(?:[ \t].*)?)?)(\n)/ do
+          groups Text, Comment::Preproc, Text
+        end
         rule %r/[ \t]+/, Text, :command
         rule %r/;.*/, Comment
         rule %r/\$[a-z_]\w*\.?/i, Name::Namespace # variable substitution or macro argument


### PR DESCRIPTION
The ARM assembly lexer contains a rule for preprocessor comments that tokenises the entire string with the `Comment::Preproc` token. Whitespace should be tokenised with the `Text` token. This PR fixes that. It resulted from discussion in #1282.