### PR TITLE
Guess format of RISC OS conventional version header files

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -126,6 +126,18 @@ module Rouge
 
         next PlainText
       end
+
+      disambiguate 'VersionNum' do
+        next C if matches?(/^#define/)
+
+        next PlainText
+      end
+
+      disambiguate 'VersionASM' do
+        next ArmAsm if matches?(/^ +GBLS +/)
+
+        next PlainText
+      end
     end
   end
 end

--- a/lib/rouge/lexers/armasm.rb
+++ b/lib/rouge/lexers/armasm.rb
@@ -7,7 +7,7 @@ module Rouge
       title "ArmAsm"
       desc "Arm assembly syntax"
       tag 'armasm'
-      filenames '*.s'
+      filenames '*.s', 'VersionASM'
 
       def self.preproc_keyword
         @preproc_keyword ||= %w(

--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -5,7 +5,7 @@ module Rouge
   module Lexers
     class C < RegexLexer
       tag 'c'
-      filenames '*.c', '*.h', '*.idc'
+      filenames '*.c', '*.h', '*.idc', 'VersionNum'
       mimetypes 'text/x-chdr', 'text/x-csrc'
 
       title "C"

--- a/lib/rouge/lexers/plain_text.rb
+++ b/lib/rouge/lexers/plain_text.rb
@@ -9,7 +9,7 @@ module Rouge
 
       tag 'plaintext'
       aliases 'text'
-      filenames '*.txt', 'Messages'
+      filenames '*.txt', 'Messages', 'VersionASM', 'VersionNum'
       mimetypes 'text/plain'
 
       attr_reader :token

--- a/spec/lexers/armasm_spec.rb
+++ b/spec/lexers/armasm_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::ArmAsm do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.s'
+      assert_guess :filename => 'VersionASM', :source => ' GBLS Version'
     end
   end
 end

--- a/spec/lexers/c_spec.rb
+++ b/spec/lexers/c_spec.rb
@@ -11,6 +11,7 @@ describe Rouge::Lexers::C do
       assert_guess :filename => 'foo.c'
       assert_guess :filename => 'FOO.C'
       assert_guess :filename => 'foo.h', :source => 'foo'
+      assert_guess :filename => 'VersionNum', :source => '#define Version 1'
     end
 
     it 'guesses by mimetype' do

--- a/spec/lexers/plain_text_spec.rb
+++ b/spec/lexers/plain_text_spec.rb
@@ -11,6 +11,8 @@ describe Rouge::Lexers::PlainText do
       assert_guess :filename => 'foo'
       assert_guess :filename => 'foo.txt'
       assert_guess :filename => 'Messages', :source => 'foo'
+      assert_guess :filename => 'VersionASM', :source => 'foo'
+      assert_guess :filename => 'VersionNum', :source => 'foo'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
(I realize this this one might be a little more contentious than some of my other pull requests, but I thought it was worth a punt!)

Projects that primarily target the operating system RISC OS by convention contains C and assembly header files defining the project version number, date etc using standardised filenames. However, these filenames do not include any filename extensions by which the file format can be guessed. Guess instead by matching the filename and a key string within each file.
