### PR TITLE
Add support for HTTP/2 to HTTP lexer

### DIFF
--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -26,8 +26,8 @@ module Rouge
         # request
         rule %r(
           (#{HTTP.http_methods.join('|')})([ ]+) # method
-          ([^ ]+)([ ]+)                     # path
-          (HTTPS?)(/)(1[.][01])(\r?\n|$)  # http version
+          ([^ ]+)([ ]+)                          # path
+          (HTTPS?)(/)(\d(?:\.\d)?)(\r?\n|$)      # http version
         )ox do
           groups(
             Name::Function, Text,
@@ -40,9 +40,9 @@ module Rouge
 
         # response
         rule %r(
-          (HTTPS?)(/)(1[.][01])([ ]+) # http version
-          (\d{3})([ ]+)               # status
-          ([^\r\n]+)(\r?\n|$)       # status message
+          (HTTPS?)(/)(\d(?:\.\d))([ ]+)  # http version
+          (\d{3})([ ]+)?                 # status
+          ([^\r\n]+)?(\r?\n|$)           # status message
         )x do
           groups(
             Keyword, Operator, Num, Text,

--- a/spec/lexers/http_spec.rb
+++ b/spec/lexers/http_spec.rb
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::HTTP do
+  let(:subject) { Rouge::Lexers::HTTP.new }
+  include Support::Lexing
+
+  it 'lexes HTTP/2' do
+    request = "GET / HTTP/2"
+    assert_tokens_equal request, ["Name.Function", "GET"],
+                                 ["Text", " "],
+                                 ["Name.Namespace", "/"],
+                                 ["Text", " "],
+                                 ["Keyword", "HTTP"],
+                                 ["Operator", "/"],
+                                 ["Literal.Number", "2"]
+  end
+  
+  it 'lexes HTTP/1.1' do
+    request = "GET / HTTP/1.1"
+    assert_tokens_equal request, ["Name.Function", "GET"],
+                                 ["Text", " "],
+                                 ["Name.Namespace", "/"],
+                                 ["Text", " "],
+                                 ["Keyword", "HTTP"],
+                                 ["Operator", "/"],
+                                 ["Literal.Number", "1.1"]
+  end
+end


### PR DESCRIPTION
The HTTP lexer only supports requests where the HTTP version is either 1.0 or 1.1. This means that HTTP/0.9 and HTTP/2 cause errors to be generated.

It is a non-goal of lexers to check for semantic correctness and so the simplest solution is to match against version numbers generally.

This fixes #1295.