### PR TITLE
Fix escape quoting in JSON lexer

### DIFF
--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -34,7 +34,7 @@ module Rouge
       end
 
       state :name do
-        rule %r/("(?:\"|[^"\n])*?")(\s*)(:)/ do
+        rule %r/("(?:\\.|[^"\n])*?")(\s*)(:)/ do
           groups Name::Label, Text::Whitespace, Punctuation
         end
       end


### PR DESCRIPTION
There is a bug in the JSON lexer where the rule from the `:name` state matches `\"` when it should be `\\"`. This PR fixes that bug.

No change to the visual sample is required. The error was actually visible but had just not been noticed.