### PR TITLE
Improve escaping and interpolating in string and charlist literals in Elixir lexer

### DIFF
--- a/spec/visual/samples/elixir
+++ b/spec/visual/samples/elixir
@@ -20,6 +20,20 @@
 # maps
 %{key: 1}
 
+# strings
+"Hello world"
+"Hello \" world"
+"Hello \n world"
+"Hello #{"world"}"
+"Hello #world"
+
+# charlists
+'Hello world'
+'Hello \' world'
+'Hello \n world'
+'Hello #{'world'}'
+'Hello #world'
+
 # regexes
 ~r()gif
 ~r[]gfi


### PR DESCRIPTION
The Elixir lexer does not properly handle escaping and interpolating in string (`"foo"`) and charlist (`'foo'`) literals.

This PR adds general escaping rules for use in strings as well as adding support for escaping and interpolating to charlist literals. It also rationalises the states used for string literals. Examples to confirm correct behaviour have been added to the visual sample.

This fixes #1306.