### PR TITLE
Allow empty reason responses in HTTP lexer

### DIFF
--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -42,7 +42,7 @@ module Rouge
         rule %r(
           (HTTPS?)(/)(\d(?:\.\d))([ ]+)  # http version
           (\d{3})([ ]+)?                 # status
-          ([^\r\n]+)?(\r?\n|$)           # status message
+          ([^\r\n]*)?(\r?\n|$)           # status message
         )x do
           groups(
             Keyword, Operator, Num, Text,

--- a/spec/lexers/http_spec.rb
+++ b/spec/lexers/http_spec.rb
@@ -5,7 +5,7 @@ describe Rouge::Lexers::HTTP do
   let(:subject) { Rouge::Lexers::HTTP.new }
   include Support::Lexing
 
-  it 'lexes HTTP/2' do
+  it 'lexes a HTTP/2 request' do
     request = "GET / HTTP/2"
     assert_tokens_equal request, ["Name.Function", "GET"],
                                  ["Text", " "],
@@ -16,7 +16,7 @@ describe Rouge::Lexers::HTTP do
                                  ["Literal.Number", "2"]
   end
   
-  it 'lexes HTTP/1.1' do
+  it 'lexes a HTTP/1.1 request' do
     request = "GET / HTTP/1.1"
     assert_tokens_equal request, ["Name.Function", "GET"],
                                  ["Text", " "],
@@ -25,5 +25,15 @@ describe Rouge::Lexers::HTTP do
                                  ["Keyword", "HTTP"],
                                  ["Operator", "/"],
                                  ["Literal.Number", "1.1"]
+  end
+
+  it 'lexes an empty HTTP/1.1 response' do
+    response = "HTTP/1.1 200 "
+    assert_tokens_equal response, ["Keyword", "HTTP"],
+                                  ["Operator", "/"], 
+                                  ["Literal.Number", "1.1"],
+                                  ["Text", " "],
+                                  ["Literal.Number", "200"],
+                                  ["Text", " "]
   end
 end


### PR DESCRIPTION
The HTTP 1.1 spec permits empty reason-phrase elements in HTTP responses. The HTTP lexer requires a reason-phrase to be given. This commit corrects that.

This fixes #977.