### PR TITLE
Add 'lisp' alias to Common Lisp lexer

### DIFF
--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Common Lisp"
       desc "The Common Lisp variant of Lisp (common-lisp.net)"
       tag 'common_lisp'
-      aliases 'cl', 'common-lisp', 'elisp', 'emacs-lisp'
+      aliases 'cl', 'common-lisp', 'elisp', 'emacs-lisp', 'lisp'
 
       filenames '*.cl', '*.lisp', '*.asd', '*.el' # used for Elisp too
       mimetypes 'text/x-common-lisp'


### PR DESCRIPTION
Although Common Lisp is a Lisp dialect, assigning the alias 'lisp' to the Common Lisp lexer is consistent with the approach of Pygments.

This commit replicates #848 which was reverted after an erroneous merge.