### PR TITLE
Remove link to online dingus

### DIFF
--- a/.github/ISSUE_TEMPLATE/lexer-bug.md
+++ b/.github/ISSUE_TEMPLATE/lexer-bug.md
@@ -10,9 +10,6 @@ assignees: ''
 **Name of the lexer**
 The name of the lexer with the bug.
 
-**Online example**
-A link to an example on <http://rouge.jneen.net/>
-
 **Code sample**
 A sample of the code that produces the bug.
 


### PR DESCRIPTION
The online dingus at rouge.jneen.net no longer allows a user to save a code sample. Suggesting a link be provided in the bug template is confusing at best and disuades bugs being filed at worst. Having a link to a sample is helpful so this change should be reverted once that's fixed.