### PR TITLE
Tokenise commonly used logical Unicode symbols in Coq lexer

### DIFF
--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -58,7 +58,7 @@ module Rouge
 
       def self.keyopts
         @keyopts ||= Set.new %w(
-          := => -> /\\ \\/ _ ; :> :
+          := => -> /\\ \\/ _ ; :> : ⇒ → ↔ ⇔ ≔ ≡ ∀ ∃ ∧ ∨ ¬ ⊤ ⊥ ⊢ ⊨ ∈
         )
       end
 
@@ -115,14 +115,6 @@ module Rouge
         end
         rule %r(/\\), Operator
         rule %r/\\\//, Operator
-        rule operator do |m|
-          match = m[0]
-          if self.class.keyopts.include? match
-            token Punctuation
-          else
-            token Operator
-          end
-        end
 
         rule %r/-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
         rule %r/\d[\d_]*/, Num::Integer
@@ -131,6 +123,17 @@ module Rouge
         rule %r/'/, Keyword
         rule %r/"/, Str::Double, :string
         rule %r/[~?]#{id}/, Name::Variable
+
+        rule %r/./ do |m|
+          match = m[0]
+          if self.class.keyopts.include? match
+            token Punctuation
+          elsif match =~ operator
+            token Operator
+          else
+            token Error
+          end
+        end
       end
 
       state :comment do

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -13,3 +13,15 @@ End with_T.
 Definition a_string := "hello\" world".
 
 Notation "A /\ B" := (and A B) : type_scope.
+
+Theorem progress : ∀t T,
+  empty ⊢ t ∈ T →
+  value t ∨ ∃t', t --> t'.
+
+Theorem ev_plus4 : ∀n, even n → even (4 + n).
+Proof.
+  intros n H. simpl.
+  apply ev_SS.
+  apply ev_SS.
+  apply H.
+Qed.


### PR DESCRIPTION
While the use of certain mathematical Unicode symbols in Coq is syntactically invalid, it is common to do so when writing about Coq (such as in textbooks).

This PR adds support for tokenising commonly used symbols. It fixes #1312.