### PR TITLE
Kotlin: Fix highlighting plugin names for build.gradle.kts files

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -24,7 +24,7 @@ module Rouge
         while yield
       )
 
-      name_chars = %r'[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
+      name_chars = %r'[-_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
 
       class_name = %r'`?[\p{Lu}]#{name_chars}`?'
       name = %r'`?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}]#{name_chars}`?'

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -59,6 +59,8 @@ fun next(field: Field): Field {
     }
 }
 
+`maven-publish-plugin`
+
 /** A few colony examples here */
 fun main(args: Array<String>) {
     // Simplistic demo


### PR DESCRIPTION
When using Gradle Kotlin DSL, the contents are Kotlin code. However, in this situation you may have an identifier that contains a dash, due to it referring to the name of a Gradle plugin.

Without this change it doesn't match at all and if the plugin name is wrapped in back-ticks it marks those as errors.

E.g.
```
plugins {
  `maven-publish-plugin`
}
```

Fixes #927
Fixes #1325 

@pyrmont 