### PR TITLE
Kotlin: Simplify regexes and name fixes

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -24,9 +24,10 @@ module Rouge
         while yield
       )
 
-      name = %r'@?`?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}][\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*`?'
+      name_chars = %r'[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
 
-      upper = %r'[\p{Lu}]'
+      class_name = %r'`?[\p{Lu}]#{name_chars}`?'
+      name = %r'`?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}]#{name_chars}`?'
 
       state :root do
         rule %r'\b(companion)(\s+)(object)\b' do
@@ -70,12 +71,12 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
-        rule %r'(@#{upper}#{name})', Name::Decorator
-        rule %r'(#{upper}#{name})(<)' do
+        rule %r'(@#{class_name})', Name::Decorator
+        rule %r'(#{class_name})(<)' do
           groups Name::Class, Punctuation
           push :generic_parameters
         end
-        rule %r'(#{upper}#{name})', Name::Class
+        rule %r'(#{class_name})', Name::Class
         rule %r'(#{name})(?=\s*[({])', Name::Function
         rule %r'#{name}', Name
       end
@@ -85,20 +86,20 @@ module Rouge
       end
 
       state :class do
-        rule %r'#{name}', Name::Class, :pop!
+        rule %r'#{class_name}', Name::Class, :pop!
       end
 
       state :function do
         rule %r'(<)', Punctuation, :generic_parameters
         rule %r'(\s+)', Text
-        rule %r'(#{name})(\.)' do
+        rule %r'(#{class_name})(\.)' do
           groups Name::Class, Punctuation
         end
         rule %r'#{name}', Name::Function, :pop!
       end
 
       state :generic_parameters do
-        rule %r'#{name}', Name::Class
+        rule %r'#{class_name}', Name::Class
         rule %r'(<)', Punctuation, :generic_parameters
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -24,10 +24,7 @@ module Rouge
         while yield
       )
 
-      name = %r'@?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}][\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
-      name_backtick = %r'#{name}|`#{name}`'
-
-      id = %r'(#{name_backtick})'
+      name = %r'@?`?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}][\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*`?'
 
       upper = %r'[\p{Lu}]'
 
@@ -55,8 +52,8 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
-        rule %r/\bfun\b/, Keyword
-        rule %r/\b(?:#{keywords.join('|')})\b/, Keyword
+        rule %r'\bfun\b', Keyword
+        rule %r'\b(?:#{keywords.join('|')})\b', Keyword
         rule %r'^\s*\[.*?\]', Name::Attribute
         rule %r'[^\S\n]+', Text
         rule %r'\\\n', Text # line continuation
@@ -73,35 +70,35 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
-        rule %r/(@#{upper}#{name_backtick})/, Name::Decorator
-        rule %r'(#{upper}#{name_backtick})(<)' do
+        rule %r'(@#{upper}#{name})', Name::Decorator
+        rule %r'(#{upper}#{name})(<)' do
           groups Name::Class, Punctuation
           push :generic_parameters
         end
-        rule %r'(#{upper}#{name_backtick})', Name::Class
-        rule %r'(#{name_backtick})(?=\s*[({])', Name::Function
-        rule id, Name
+        rule %r'(#{upper}#{name})', Name::Class
+        rule %r'(#{name})(?=\s*[({])', Name::Function
+        rule %r'#{name}', Name
       end
 
       state :package do
-        rule %r/\S+/, Name::Namespace, :pop!
+        rule %r'\S+', Name::Namespace, :pop!
       end
 
       state :class do
-        rule id, Name::Class, :pop!
+        rule %r'#{name}', Name::Class, :pop!
       end
 
       state :function do
         rule %r'(<)', Punctuation, :generic_parameters
         rule %r'(\s+)', Text
-        rule %r'(#{name_backtick})(\.)' do
+        rule %r'(#{name})(\.)' do
           groups Name::Class, Punctuation
         end
-        rule id, Name::Function, :pop!
+        rule %r'#{name}', Name::Function, :pop!
       end
 
       state :generic_parameters do
-        rule id, Name::Class
+        rule %r'#{name}', Name::Class
         rule %r'(<)', Punctuation, :generic_parameters
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text
@@ -109,14 +106,14 @@ module Rouge
       end
 
       state :property do
-        rule id, Name::Property, :pop!
+        rule %r'#{name}', Name::Property, :pop!
       end
 
       state :destructure do
         rule %r'(,)', Punctuation
         rule %r'(\))', Punctuation, :pop!
         rule %r'(\s+)', Text
-        rule id, Name::Property
+        rule %r'#{name}', Name::Property
       end
 
       state :comment do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -76,9 +76,9 @@ module Rouge
           groups Name::Class, Punctuation
           push :generic_parameters
         end
-        rule %r'(#{class_name})', Name::Class
+        rule class_name, Name::Class
         rule %r'(#{name})(?=\s*[({])', Name::Function
-        rule %r'#{name}', Name
+        rule name, Name
       end
 
       state :package do
@@ -86,7 +86,7 @@ module Rouge
       end
 
       state :class do
-        rule %r'#{class_name}', Name::Class, :pop!
+        rule class_name, Name::Class, :pop!
       end
 
       state :function do
@@ -95,11 +95,11 @@ module Rouge
         rule %r'(#{class_name})(\.)' do
           groups Name::Class, Punctuation
         end
-        rule %r'#{name}', Name::Function, :pop!
+        rule name, Name::Function, :pop!
       end
 
       state :generic_parameters do
-        rule %r'#{class_name}', Name::Class
+        rule class_name, Name::Class
         rule %r'(<)', Punctuation, :generic_parameters
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text
@@ -107,14 +107,14 @@ module Rouge
       end
 
       state :property do
-        rule %r'#{name}', Name::Property, :pop!
+        rule name, Name::Property, :pop!
       end
 
       state :destructure do
         rule %r'(,)', Punctuation
         rule %r'(\))', Punctuation, :pop!
         rule %r'(\s+)', Text
-        rule %r'#{name}', Name::Property
+        rule name, Name::Property
       end
 
       state :comment do


### PR DESCRIPTION
Simplify the regex for matching names/identifiers in the Kotlin lexer.

Rather than having a regex for name with or without wrapped back-ticks, just have optional match for back-tick at start and end of the identifier.

Remove unnecessary id regex, when it just wrapped name into capture group.

Fix annotation matching, as it was surrounding the full name rule with @ and uppercase start. However, this meant it looked for back-ticks after the uppercase first character.

Locations that are matching for Name::Class token now look for class_name so expect capital first letter.

Remove @ from the name matcher, as there was already a separate rule to match annotations and marking them as Name::Decorator instead.

Fixes #1324

@pyrmont 