### PR TITLE
Liquid: several fixes and additions

### DIFF
--- a/lib/rouge/demos/liquid
+++ b/lib/rouge/demos/liquid
@@ -5,7 +5,6 @@
       Only {{ product.price | format_as_money }}
 
       <p>{{ product.description | prettyprint | truncate: 200  }}</p>
-
     </li>
   {% endfor %}
 </ul>

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -36,7 +36,7 @@ module Rouge
         end
 
         # other builtin blocks
-        rule %r/(capture)(\s+)([^\s%]+)(\s*)(-?%\})/ do
+        rule %r/(capture|(?:in|de)crement)(\s+)([^\s%]+)(\s*)(-?%\})/ do
           groups Name::Tag, Text::Whitespace, Name::Variable, Text::Whitespace, Punctuation
           pop!
         end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -218,7 +218,7 @@ module Rouge
       end
 
       state :variable do
-        rule %r/(empty|blank)\b/, Name::Builtin
+        rule %r/(empty|blank|forloop\.[^\s%}\|:]+)\b/, Name::Builtin
         rule %r/\.(?=\w)/, Punctuation
         rule %r/[a-zA-Z_][\w-]*\??/, Name::Variable
       end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -197,7 +197,7 @@ module Rouge
 
       # states for different values types
       state :keyword do
-        rule %r/(false|true)\b/, Keyword::Constant
+        rule %r/(false|true|nil)\b/, Keyword::Constant
       end
 
       state :variable do

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -204,6 +204,7 @@ module Rouge
       state :variable do
         rule %r/(empty|blank|forloop\.[^\s%}\|:]+)\b/, Name::Builtin
         rule %r/\.(?=\w)|\[|\]/, Punctuation
+        rule %r/(first|last|size)\b/, Name::Function
         rule %r/[a-zA-Z_][\w-]*\??/, Name::Variable
       end
 

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -41,7 +41,7 @@ module Rouge
 
         # other builtin blocks
         rule %r/(capture)(\s+)([^\s%]+)(\s*)(%\})/ do
-          groups Name::Tag, Text::Whitespace, Name::Attribute, Text::Whitespace, Punctuation
+          groups Name::Tag, Text::Whitespace, Name::Variable, Text::Whitespace, Punctuation
           pop!
         end
 

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -243,6 +243,7 @@ module Rouge
       end
 
       state :number do
+        rule %r/-/, Operator
         rule %r/\d+\.\d+/, Num::Float
         rule %r/\d+/, Num::Integer
       end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -217,7 +217,7 @@ module Rouge
 
       state :variable do
         rule %r/\.(?=\w)/, Punctuation
-        rule %r/[a-zA-Z_]\w*\??/, Name::Variable
+        rule %r/[a-zA-Z_][\w-]*\??/, Name::Variable
       end
 
       state :string do

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -98,7 +98,7 @@ module Rouge
           )(\s*)
         /x do |m|
           groups Name::Tag, Text::Whitespace, Name::Variable, Text::Whitespace,
-                 Keyword::Reserved, Text::Whitespace
+                 Name::Tag, Text::Whitespace
 
           token_class = case m[7]
                         when %r/'[^']*'/ then Str::Single
@@ -287,6 +287,7 @@ module Rouge
       state :include do
         mixin :whitespace
 
+        rule %r/(with|for)\b/, Name::Tag
         rule %r/[^\s\.]+(\.[^\s\.]+)+\b/, Name::Other
 
         mixin :variable_tag_markup

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -287,9 +287,7 @@ module Rouge
       state :include do
         mixin :whitespace
 
-        rule %r/([^\.]+)(\.)(html|liquid)/ do
-          groups Name::Attribute, Punctuation, Name::Attribute
-        end
+        rule %r/[^\s\.]+(\.[^\s\.]+)+\b/, Name::Other
 
         mixin :variable_tag_markup
       end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -73,7 +73,7 @@ module Rouge
                         else
                           Name::Attribute
                         end
-          
+
           groups Name::Tag, Text::Whitespace, token_class,
                  Text::Whitespace, Punctuation, Text::Whitespace
 
@@ -277,7 +277,7 @@ module Rouge
         end
 
         rule %r/-?\}\}/, Punctuation, :pop!
-        
+
         mixin :variable_param_markup
       end
     end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -218,6 +218,7 @@ module Rouge
       end
 
       state :variable do
+        rule %r/(empty|blank)\b/, Name::Builtin
         rule %r/\.(?=\w)/, Punctuation
         rule %r/[a-zA-Z_][\w-]*\??/, Name::Variable
       end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -149,13 +149,8 @@ module Rouge
         mixin :end_of_block
         mixin :whitespace
 
-        rule %r/([=!><]=?)/, Operator
-
-        rule %r/\b(?:(!)|(not\b))/ do
-          groups Operator, Operator::Word
-        end
-
-        rule %r/(contains)/, Operator::Word
+        rule %r/([=!]=|[<>]=?)/, Operator
+        rule %r/(and|or|contains)\b/, Operator::Word
 
         mixin :generic
         mixin :whitespace
@@ -165,18 +160,6 @@ module Rouge
         mixin :end_of_block
         mixin :whitespace
         mixin :generic
-      end
-
-      state :operator do
-        rule %r/(\s*)((?:=|!|>|<)=?)(\s*)/ do
-          groups Text::Whitespace, Operator, Text::Whitespace
-          pop!
-        end
-
-        rule %r/(\s*)(\bcontains\b)(\s*)/ do
-          groups Text::Whitespace, Operator::Word, Text::Whitespace
-          pop!
-        end
       end
 
       state :end_of_tag do

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -164,10 +164,6 @@ module Rouge
           groups Name::Attribute, Text::Whitespace, Operator
         end
 
-        rule %r/(\{\{-?)(\s*)([^\s\}])(\s*)(-?\}\})/ do
-          groups Punctuation, Text::Whitespace, Text, Text::Whitespace, Punctuation
-        end
-
         rule %r/,|:/, Punctuation
       end
 
@@ -266,10 +262,25 @@ module Rouge
       end
 
       state :include do
+        rule %r/(\{\{-?)(\s*)/ do
+          groups Punctuation, Text::Whitespace
+          push :output_embed
+        end
+
         rule %r/(with|for)\b/, Name::Tag
         rule %r/[^\s\.]+(\.[^\s\.]+)+\b/, Name::Other
 
         mixin :variable_tag_markup
+      end
+
+      state :output_embed do
+        rule %r/(\|)(\s*)([a-zA-Z_][^\s}\|:]*)/ do
+          groups Punctuation, Text::Whitespace, Name::Function
+        end
+
+        rule %r/-?\}\}/, Punctuation, :pop!
+        
+        mixin :variable_param_markup
       end
     end
   end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -12,12 +12,12 @@ module Rouge
       state :root do
         rule %r/[^\{]+/, Text
 
-        rule %r/(\{%)(\s*)/ do
+        rule %r/(\{%-?)(\s*)/ do
           groups Punctuation, Text::Whitespace
           push :tag_or_block
         end
 
-        rule %r/(\{\{)(\s*)/ do
+        rule %r/(\{\{-?)(\s*)/ do
           groups Punctuation, Text::Whitespace
           push :output
         end
@@ -30,34 +30,34 @@ module Rouge
         rule %r/(if|elsif|unless|case)\b/, Keyword::Reserved, :condition
         rule %r/(when)\b/, Keyword::Reserved, :when
 
-        rule %r/(else)(\s*)(%\})/ do
+        rule %r/(else)(\s*)(-?%\})/ do
           groups Keyword::Reserved, Text::Whitespace, Punctuation
           pop!
         end
 
         # other builtin blocks
-        rule %r/(capture)(\s+)([^\s%]+)(\s*)(%\})/ do
+        rule %r/(capture)(\s+)([^\s%]+)(\s*)(-?%\})/ do
           groups Name::Tag, Text::Whitespace, Name::Variable, Text::Whitespace, Punctuation
           pop!
         end
 
-        rule %r/(comment)(\s*)(%\})/ do
+        rule %r/(comment)(\s*)(-?%\})/ do
           groups Name::Tag, Text::Whitespace, Punctuation
           push :comment
         end
 
-        rule %r/(raw)(\s*)(%\})/ do
+        rule %r/(raw)(\s*)(-?%\})/ do
           groups Name::Tag, Text::Whitespace, Punctuation
           push :raw
         end
 
         # end of block
-        rule %r/(end(?:if|unless|case))(\s*)(%\})/ do
+        rule %r/(end(?:if|unless|case))(\s*)(-?%\})/ do
           groups Keyword::Reserved, Text::Whitespace, Punctuation
           pop!
         end
 
-        rule %r/(end(?:[^\s%]+))(\s*)(%\})/ do
+        rule %r/(end(?:[^\s%]+))(\s*)(-?%\})/ do
           groups Name::Tag, Text::Whitespace, Punctuation
           pop!
         end
@@ -145,11 +145,11 @@ module Rouge
       end
 
       state :end_of_tag do
-        rule(/\}\}/) { token Punctuation; reset_stack }
+        rule(/-?\}\}/) { token Punctuation; reset_stack }
       end
 
       state :end_of_block do
-        rule(/%\}/) { token Punctuation; reset_stack }
+        rule(/-?%\}/) { token Punctuation; reset_stack }
       end
 
       # states for unknown markup
@@ -163,7 +163,7 @@ module Rouge
           groups Name::Attribute, Text::Whitespace, Operator
         end
 
-        rule %r/(\{\{)(\s*)([^\s\}])(\s*)(\}\})/ do
+        rule %r/(\{\{-?)(\s*)([^\s\}])(\s*)(-?\}\})/ do
           groups Punctuation, Text::Whitespace, Text, Text::Whitespace, Punctuation
         end
 
@@ -232,7 +232,7 @@ module Rouge
       state :comment do
         rule %r/[^\{]+/, Comment
 
-        rule %r/(\{%)(\s*)(endcomment)(\s*)(%\})/ do
+        rule %r/(\{%-?)(\s*)(endcomment)(\s*)(-?%\})/ do
           groups Punctuation, Text::Whitespace, Name::Tag, Text::Whitespace, Punctuation
           reset_stack
         end
@@ -243,7 +243,7 @@ module Rouge
       state :raw do
         rule %r/[^\{]+/, Text
 
-        rule %r/(\{%)(\s*)(endraw)(\s*)(%\})/ do
+        rule %r/(\{%-?)(\s*)(endraw)(\s*)(-?%\})/ do
           groups Punctuation, Text::Whitespace, Name::Tag, Text::Whitespace, Punctuation
           reset_stack
         end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -201,6 +201,8 @@ module Rouge
       end
 
       state :tag_markup do
+        rule %r/(reversed)\b/, Name::Attribute
+
         mixin :end_of_block
         mixin :default_param_markup
       end

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -63,8 +63,8 @@ module Rouge
         end
 
         # builtin tags
-        rule %r/assign\b/, Name::Tag, :assign
-        rule %r/include\b/, Name::Tag, :include
+        rule %r/(assign|echo)\b/, Name::Tag, :assign
+        rule %r/(include|render)\b/, Name::Tag, :include
 
         rule %r/(cycle)(\s+)(?:([^\s:]*)(\s*)(:))?(\s*)/ do |m|
           groups Name::Tag, Text::Whitespace

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -90,7 +90,7 @@ module Rouge
 
         # iteration
         rule %r/
-          (for)(\s+)
+          (for|tablerow)(\s+)
           ([\w-]+)(\s+)
           (in)(\s+)
           (

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -162,7 +162,7 @@ module Rouge
           groups Name::Attribute, Text::Whitespace, Operator
         end
 
-        rule %r/,|:/, Punctuation
+        rule %r/[,:]/, Punctuation
       end
 
       state :default_param_markup do

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -67,18 +67,16 @@ module Rouge
         rule %r/(include|render)\b/, Name::Tag, :include
 
         rule %r/(cycle)(\s+)(?:([^\s:]*)(\s*)(:))?(\s*)/ do |m|
-          groups Name::Tag, Text::Whitespace
-
           token_class = case m[3]
                         when %r/'[^']*'/ then Str::Single
                         when %r/"[^"]*"/ then Str::Double
                         else
                           Name::Attribute
                         end
-          token token_class, m[3]
-          token Text::Whitespace, m[4]
-          token Punctuation, m[5]
-          token Text::Whitespace, m[6]
+          
+          groups Name::Tag, Text::Whitespace, token_class,
+                 Text::Whitespace, Punctuation, Text::Whitespace
+
           push :variable_tag_markup
         end
 

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -113,22 +113,23 @@ module Rouge
       end
 
       state :output do
-        rule %r/\|/, Punctuation, :filters
+        rule %r/(\|)(\s*)([a-zA-Z_][^\s}\|:]*)/ do
+          groups Punctuation, Text::Whitespace, Name::Function
+          push :filters
+        end
 
         mixin :end_of_tag
         mixin :generic
       end
 
       state :filters do
-        rule %r/\|/, Punctuation
-
-        rule %r/([a-zA-Z_][^\s\|:]*)(:?)(\s*)/ do
-          groups Name::Function, Punctuation, Text::Whitespace
+        rule %r/(\|)(\s*)([a-zA-Z_][^\s%}\|:]*)/ do
+          groups Punctuation, Text::Whitespace, Name::Function
         end
 
         mixin :end_of_tag
         mixin :end_of_block
-        mixin :default_param_markup
+        mixin :variable_param_markup
       end
 
       state :condition do
@@ -167,7 +168,7 @@ module Rouge
           groups Punctuation, Text::Whitespace, Text, Text::Whitespace, Punctuation
         end
 
-        rule %r/,/, Punctuation
+        rule %r/,|:/, Punctuation
       end
 
       state :default_param_markup do
@@ -253,7 +254,11 @@ module Rouge
 
       state :assign do
         rule %r/=/, Operator
-        rule %r/\|/, Punctuation, :filters
+
+        rule %r/(\|)(\s*)([a-zA-Z_][^\s%\|:]*)/ do
+          groups Punctuation, Text::Whitespace, Name::Function
+          push :filters
+        end
 
         mixin :end_of_block
         mixin :generic

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -10,7 +10,7 @@ Just regular text - what happens?
 
 {% comment %}
   My lovely {{comment}} that is split
-  accross multiple lines {% comment %}
+  across multiple lines {% comment %}
 {% endcomment %}
 
 {% custom_tag params: true %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -13,7 +13,7 @@ Just regular text - what happens?
   across multiple lines {% comment %}
 {% endcomment %}
 
-{% custom_tag params: true %}
+{% custom_tag param1: true param2 : nil %}
 {% custom_block my="abc" c = false %}
   Just usual {{liquid}}.
 {% endcustom_block %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -99,7 +99,7 @@ Some other {{ output }}!
 {% endfor %}
 
 {% for item in array reversed limit:2 %}
-  {{ item }}
+  Item {{ forloop.index }}: {{ item.name }}
 {% endfor %}
 
 {% for item in array offset:2 %}
@@ -116,7 +116,7 @@ Some other {{ output }}!
 
 {% assign num- = 4 %}
 {% for i in (1..num-) %}
-  {{ i }}
+  {%-if forloop.last-%}{{ i }}{%-endif-%}
 {% endfor %}
 
 {% for char in 'The Quick Brown Fox' %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -111,7 +111,7 @@ Some other {{ output }}!
 {% endfor %}
 
 {% for i in (3..5) %}
-  {{ i }}
+  {% render "snippet", number: i %}
 {% endfor %}
 
 {% assign num- = 4 %}
@@ -124,5 +124,5 @@ Some other {{ output }}!
 {% endfor %}
 
 {% for char in "Hello World" reversed %}
-  {{ char | upcase }}
+  {% echo char | upcase %}
 {% endfor %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -67,7 +67,7 @@ Some other {{ output }}!
 {% if link.object.content contains img_tag %}
   {% assign src = link.object.content | split: 'src="' %}
   {% assign src = src[1] | split: '"' | first %}
-    {% if src %}
+    {% if src.size %}
       {% assign page_has_image = true %}
       {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' |
                                   replace: '_large', '' | replace: '_grande', '' %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -39,12 +39,12 @@ Just regular text - what happens?
 
 {% if a == 'B' %}
 Testing {{ some }} stuff.
-{% elsif a == 'C%}' %}
-{% elsif c %}
+{% elsif a != 'C%}' %}
+{% elsif c and d or e %}
 {% else %}
 {% endif %}
 
-{% unless not a %}
+{% unless a %}
 Some {{ output }} right here.
 {% else %}
 {% endunless %}
@@ -89,7 +89,7 @@ Some other {{ output }}!
 {% endtablerow %}
 
 {% for i in (1..5) %}
-  {% if i == 4 %}
+  {% if i > 4 %}
     {% break %}
   {% else %}
     {% continue %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -28,10 +28,10 @@ Just regular text - what happens?
 {{ variable-nil? }}
 
 {% capture name %}
-{{ title | downcase | slice: -3, 2 }}
+{{- title | downcase | slice: -3, 2 -}}
 {% endcapture %}
 
-{% assign life = 'infinite' | upcase %}
+{%- assign life = 'infinite' | upcase -%}
 
 {% cycle '1', 2, var %}
 {% cycle 'group1': '1', var, 2 %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -58,7 +58,9 @@ Some other {{ output }}!
 {% endcase %}
 
 {% include file.html param = 'value' param2 = object %}
-{% include 'snippet' param = 'value' param2 = object %}
+{% include 'snippet', param: 'value', param2: object %}
+{% include 'product' with products[0] %}
+{% include 'product' for products %}
 
 {% assign page_has_image = false %}
 {% assign img_tag = '<' | append: 'img' %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -59,8 +59,8 @@ Some other {{ output }}!
 
 {% include file.html param = 'value' param2 = object %}
 {% include 'snippet', param: 'value', param2: object %}
-{% include 'product' with products[0] %}
-{% include 'product' for products %}
+{% include product_page with products[0] %}
+{% include {{product_page | split: "." | first}} for products %}
 
 {% assign page_has_image = false %}
 {% assign img_tag = '<' | append: 'img' %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -96,7 +96,7 @@ Some other {{ output }}!
   {% endif %}
 {% endfor %}
 
-{% for item in array limit:2 reversed %}
+{% for item in array reversed limit:2 %}
   {{ item }}
 {% endfor %}
 
@@ -121,6 +121,6 @@ Some other {{ output }}!
   {{ char | upcase }}
 {% endfor %}
 
-{% for char in "Hello World" %}
+{% for char in "Hello World" reversed %}
   {{ char | upcase }}
 {% endfor %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -103,11 +103,11 @@ Some other {{ output }}!
 {% endfor %}
 
 {% for item in array offset:2 %}
-  {{ item }}
+  {% increment var %}
 {% endfor %}
 
 {% for item in array reversed %}
-  {{ item }}
+  {% decrement var %}
 {% endfor %}
 
 {% for i in (3..5) %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -40,7 +40,7 @@ Just regular text - what happens?
 {% if a == 'B' %}
 Testing {{ some }} stuff.
 {% elsif a != 'C%}' %}
-{% elsif c and d or e %}
+{% elsif c and d or e == empty %}
 {% else %}
 {% endif %}
 

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -25,7 +25,7 @@ Just regular text - what happens?
 {{ var.field.property | textilize | markdownify }}
 {{ -3.14 | abs }}
 {{ 'string' | truncate: 100 param='df"g' }}
-{{ variable.nil? }}
+{{ variable-nil? }}
 
 {% capture name %}
 {{ title | downcase | slice: -3, 2 }}
@@ -112,8 +112,8 @@ Some other {{ output }}!
   {{ i }}
 {% endfor %}
 
-{% assign num = 4 %}
-{% for i in (1..num) %}
+{% assign num- = 4 %}
+{% for i in (1..num-) %}
   {{ i }}
 {% endfor %}
 

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -23,11 +23,12 @@ Just regular text - what happens?
 {{ variable | upcase }}
 {{ var.field | textilize | markdownify }}
 {{ var.field.property | textilize | markdownify }}
+{{ -3.14 | abs }}
 {{ 'string' | truncate: 100 param='df"g' }}
 {{ variable.nil? }}
 
 {% capture name %}
-{{ title | downcase }}
+{{ title | downcase | slice: -3, 2 }}
 {% endcapture %}
 
 {% assign life = 'infinite' | upcase %}

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -82,11 +82,11 @@ Some other {{ output }}!
   </a>
 {% endif %}
 
-{% for page in site.pages %}
+{% tablerow page in site.pages %}
   {% if page.layout == 'home' %}
     {{ page.excerpt }}
   {% endif %}
-{% endfor %}
+{% endtablerow %}
 
 {% for i in (1..5) %}
   {% if i == 4 %}


### PR DESCRIPTION
I set out to fix this page's [highlighting error](https://shopify.github.io/liquid/filters/abs/), and it snowballed from there.

Support has been added for several Liquid features that probably weren't present when this lexer was first written, plus a few expected in the next release. I also refactored for simplicity and accuracy. Left for a future PR is support for the upcoming [{% liquid %} tag](https://github.com/Shopify/liquid/pull/1086).

I've left each change as separate commits so you can see what I did, and can squash if needed.