### PR TITLE
Fix pattern for values incorporating backslashes in JSON lexer

### DIFF
--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -34,7 +34,7 @@ module Rouge
       end
 
       state :name do
-        rule %r/("(?:\\.|[^"\n])*?")(\s*)(:)/ do
+        rule %r/("(?:\\.|[^"\\\n])*?")(\s*)(:)/ do
           groups Name::Label, Text::Whitespace, Punctuation
         end
       end

--- a/spec/visual/samples/json
+++ b/spec/visual/samples/json
@@ -140,3 +140,5 @@ null
                (SELECT max(\"ci_builds\".id) FROM \"ci_builds\" WHERE
                \"ci_builds\".\"commit_id\" = $2 GROUP BY
                \"ci_builds\".\"name\", \"ci_builds\".\"commit_id\")" }
+
+{"message":"\\\"retry_count\\\":0}\"}"}


### PR DESCRIPTION
It is possible for a JSON value that incorporates backslashes and colons to incorrectly match a pattern in the `:name` state. In certain situations, this can cause the lexing of a JSON file to hang indefinitely.

This commit adds `\\` to the excluded character class in the `:name` state. This causes such strings to instead be matched in the `:value` state.

This fixes #1330.