### PR TITLE
Updates for Swift 5.1

### DIFF
--- a/lib/rouge/demos/swift
+++ b/lib/rouge/demos/swift
@@ -3,22 +3,3 @@ func sayHello(personName: String) -> String {
     let greeting = "Hello, " + personName + "!"
     return greeting
 }
-
-func newView() -> some View {
-	ViewRegistry.find(\.MyView.name)
-}
-
-@frozen
-public enum Types {
-	case a, b, c
-	case d
-}
-
-func test(t: Types?) -> Bool {
-	switch t {
-	case .a?: return true
-	case .b?: return true
-	case .c: return true
-	default: return false
-	}
-}

--- a/lib/rouge/demos/swift
+++ b/lib/rouge/demos/swift
@@ -3,3 +3,22 @@ func sayHello(personName: String) -> String {
     let greeting = "Hello, " + personName + "!"
     return greeting
 }
+
+func newView() -> some View {
+	ViewRegistry.find(\.MyView.name)
+}
+
+@frozen
+public enum Types {
+	case a, b, c
+	case d
+}
+
+func test(t: Types?) -> Bool {
+	switch t {
+	case .a?: return true
+	case .b?: return true
+	case .c: return true
+	default: return false
+	}
+}

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -67,7 +67,9 @@ module Rouge
 
       state :root do
         mixin :whitespace
+        
         rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
+        rule %r/\\\.(#{id})/, Keyword::Type
 
         rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r([-/=+*%<>!&|^.~]+), Operator
@@ -109,8 +111,6 @@ module Rouge
         rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable
         end
-
-        rule %r/\\\.(#{id})/, Keyword::Type
 
         rule %r/(let|var)\b(\s*)([(])/ do
           groups Keyword, Text, Punctuation

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -109,7 +109,7 @@ module Rouge
         rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable
         end
-        
+
         rule %r/\\\.(#{id})/, Keyword::Type
 
         rule %r/(let|var)\b(\s*)([(])/ do

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -69,7 +69,6 @@ module Rouge
         mixin :whitespace
         
         rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
-        rule %r/\\\.(#{id})/, Keyword::Type
 
         rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r([-/=+*%<>!&|^.~]+), Operator

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -25,7 +25,7 @@ module Rouge
       )
 
       declarations = Set.new %w(
-        class deinit enum convenience extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate
+        class deinit enum convenience extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some
       )
 
       constants = Set.new %w(
@@ -109,6 +109,8 @@ module Rouge
         rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable
         end
+        
+        rule %r/\\\.(#{id})/, Keyword::Type
 
         rule %r/(let|var)\b(\s*)([(])/ do
           groups Keyword, Text, Punctuation

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -416,6 +416,7 @@ var `var` = 3
 
 // keypath
 let keypath = \Person.firstName
+var keyPath: KeyPath<String, Bool> = \.isEmpty
 
 // tuple destructuring
 let (t1, t2) = (1, 2)

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -432,4 +432,23 @@ funcWithLambdaArg { x in x + 5 }
 funcWithLambdaArg { $0 + 5 }
 funcWithLambdaArg({ x in x + 5 })
 
+func newView() -> some View {
+	ViewRegistry.find(\.MyView.name)
+}
+
+@frozen
+public enum Types {
+	case a, b, c
+	case d
+}
+
+func test(t: Types?) -> Bool {
+	switch t {
+	case .a?: return true
+	case .b?: return true
+	case .c: return true
+	default: return false
+	}
+}
+
 foo() // end-of-file comment


### PR DESCRIPTION
This adds three things:

- Support for the `some` keyword from Swift 5.1.
- Coloring for KeyPath syntax such as `\.TypeName.propertyName`.
- A few more items in the Swift demo document, to provide better coverage of new features.

The demo document shows that in `case .value?:` the `.value` isn't actually captured as a variable name, unlike the plain `case .value:` variant. It looks like the rule on line 120 should capture this, but my regex-fu is somewhat rusty and I've not actually delved into the rouge API enough to get a deep understanding of exactly what I'm seeing here. Any suggestions to solve that particular issue would be greatly appreciated.