### PR TITLE
Fix overeager q<> quoting in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -127,7 +127,7 @@ module Rouge
         rule %r/(q|qq|qw|qr|qx)\(/, Str::Other, :rb_string
         rule %r/(q|qq|qw|qr|qx)\[/, Str::Other, :sb_string
         rule %r/(q|qq|qw|qr|qx)</, Str::Other, :lt_string
-        rule %r/(q|qq|qw|qr|qx)([^a-zA-Z0-9])(.|\n)*?\2/, Str::Other
+        rule %r/(q|qq|qw|qr|qx)(\W)(.|\n)*?\2/, Str::Other
 
         rule %r/package\s+/, Keyword, :modulename
         rule %r/sub\s+/, Keyword, :funcname

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -72,6 +72,10 @@ my $str2 = "This is a $string with plain interpolation."
 my $cmd2 = `So is @this one.`
 my $str3 = 'A boring $string.'
 
+my @w = ( q!str4!, qw< str5 str6 >, qq(str7 $str1), qx`false`, qr/foo/ );
+$a = qr/bar/i;
+my %x = ( q_ThisString => "doesnt_overrun as if it were q-quoted" );
+
 # from http://gist.github.com/485595
 use strict;
 use warnings;


### PR DESCRIPTION
Underscore is part of word characters, meaning a hash key like `q_data` should not begin a quote.

At least that's the case that annoyed me at work today.