### PR TITLE
Add line_attr argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The built-in formatters are:
   table containing numbered lines, each contained in its own table-row. Options
   are:
     * `start_line: 1` - the number of the first row
-    * `line_id: 'line-%i'` - a `sprintf` template for `id` attribute with
+    * `line_attr: 'id'` - the html attribute used to get the line number
+    * `line_id: 'line-%i'` - a `sprintf` template for `line_attr` attribute with
       current line number
     * `line_class: 'lineno'` - a CSS class for each table-row
     * `table_class: 'rouge-line-table'` - a CSS class for the table

--- a/lib/rouge/formatters/html_line_table.rb
+++ b/lib/rouge/formatters/html_line_table.rb
@@ -12,7 +12,7 @@ module Rouge
       # @option opts [Integer] :start_line line number to start from. Defaults to `1`.
       # @option opts [String] :table_class Class name for the table.
       #   Defaults to `"rouge-line-table"`.
-      # @option opts [String] :line_id  a `sprintf` template for generating an `id`
+      # @option opts [String] :line_id  a `sprintf` template for generating an `line_attr`
       #   attribute for each table row corresponding to current line number.
       #   Defaults to `"line-%i"`.
       # @option opts [String] :line_class Class name for each table row.
@@ -21,6 +21,8 @@ module Rouge
       #   Defaults to `"rouge-gutter"`.
       # @option opts [String] :code_class Class name for rendered code cell.
       #   Defaults to `"rouge-code"`.
+      # @option opts [String] :line_attr HTML attribute for the line identifier.
+      #   Defaults to `"id"`.
       def initialize(formatter, opts={})
         @formatter    = formatter
         @start_line   = opts.fetch :start_line,   1
@@ -29,6 +31,7 @@ module Rouge
         @code_class   = opts.fetch :code_class,   'rouge-code'
         @line_class   = opts.fetch :line_class,   'lineno'
         @line_id      = opts.fetch :line_id,      'line-%i'
+        @line_attr    = opts.fetch :line_attr,    'id'
       end
 
       def stream(tokens, &b)
@@ -36,7 +39,7 @@ module Rouge
         buffer = [%(<table class="#@table_class"><tbody>)]
         token_lines(tokens) do |line_tokens|
           lineno += 1
-          buffer << %(<tr id="#{sprintf @line_id, lineno}" class="#@line_class">)
+          buffer << %(<tr #@line_attr="#{sprintf @line_id, lineno}" class="#@line_class">)
           buffer << %(<td class="#@gutter_class gl" )
           buffer << %(style="-moz-user-select: none;-ms-user-select: none;)
           buffer << %(-webkit-user-select: none;user-select: none;">)

--- a/lib/rouge/version.rb
+++ b/lib/rouge/version.rb
@@ -3,6 +3,6 @@
 
 module Rouge
   def self.version
-    "3.11.1"
+    "3.11.2"
   end
 end

--- a/spec/formatters/html_line_table_spec.rb
+++ b/spec/formatters/html_line_table_spec.rb
@@ -97,4 +97,39 @@ HTML
       assert { output == expected }
     end
   end
+
+  describe 'the rendered table with a data attribute' do
+    let(:options) do
+      {
+        start_line:   15,
+        table_class:  'code-table',
+        gutter_class: 'code-gutter',
+        code_class:   'fenced-code',
+        line_class:   'line-no',
+        line_id:      'L%i',
+        line_attr:    'data-line'
+      }
+    end
+    let(:input_stream) { [[Token['Name'], 'foo'], [Token['Text'], "bar\n"]] }
+
+    it 'is customizable' do
+      expected = <<-HTML
+<table class="code-table">
+  <tbody>
+    <tr data-line="L15" class="line-no">
+      <td class="code-gutter gl" style="#{cell_style}"><pre>15</pre></td>
+      <td class="fenced-code">
+        <pre><span class="n">foo</span>bar\n</pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+HTML
+      expected = expected.gsub(%r{>\s+<(?!/pre)}, '><').rstrip
+
+      refute_includes output, 'id="L1"'
+      refute_includes output, 'data-line="L1"'
+      assert { output == expected }
+    end
+  end
 end


### PR DESCRIPTION
I'm using `Rouge::Formatters::HTMLLineTable` in my project and it works very well!

The only problem I got is that the line number is stored in an `id` attribute.
I use this formatter multiple times in the same page, and it makes duplicate ids in the html.

So I added a new parameter (`line_attr`) to configure what attribute will be used (with `id` as default value). We can now use a `data-lineno` for example, to avoid ids duplication.