### PR TITLE
Remove note about GitHub Pages' version of Rouge

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,6 @@ Rouge::Theme.find('base16.light').render(scope: '.highlight')
 
 ### Jekyll
 
-**NOTE**: If you're using GitHub Pages, you're stuck with [version
-2.2.1][ghp-versions] of Rouge. Although GitHub Pages uses an up to date version
-of Jekyll, it locks the version of Rouge. There is [an open issue][ghp-issue] to
-upgrade this to a more current release.
-
-[ghp-versions]: https://pages.github.com/versions/
-"Version of the dependencies used by GitHub Pages"
-
-[ghp-issue]: https://github.com/github/pages-gem/issues/601
-"pages-gem Issue #601"
-
 Rouge is Jekyll's default syntax highlighter. Out of the box, Rouge will be
 used to highlight text wrapped in the `{% highlight %}` template tags. The
 `{% highlight %}` tag provides minimal options: you can specify the language to


### PR DESCRIPTION
GitHub has updated their version of Rouge to 3.11.0; see https://pages.github.com/versions/.