### PR TITLE
Add support Phoenix Live View (Live EEx)

### DIFF
--- a/lib/rouge/lexers/eex.rb
+++ b/lib/rouge/lexers/eex.rb
@@ -7,8 +7,9 @@ module Rouge
       desc "Embedded Elixir"
 
       tag 'eex'
+      aliases 'leex'
 
-      filenames '*.eex'
+      filenames '*.eex', '*.leex'
 
       def initialize(opts={})
         @elixir_lexer = Elixir.new(opts)

--- a/spec/lexers/eex_spec.rb
+++ b/spec/lexers/eex_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::EEX do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.eex'
       assert_guess :filename => 'foo.html.eex'
+      assert_guess :filename => 'foo.html.leex'
     end
   end
 end


### PR DESCRIPTION
Since [Phoenix Live View](https://github.com/phoenixframework/phoenix_live_view) become more a more popular, 
I would like to see highlight source code in GitLab/GitHub for **[*.leex](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Engine.html)** extensions. 

Basically it alias for ***.eex**, that a reason why it was added in existing lexers.
