### PR TITLE
Ensure xml lexer handles unknown DOCTYPEs

### DIFF
--- a/lib/rouge/lexers/mason.rb
+++ b/lib/rouge/lexers/mason.rb
@@ -15,11 +15,6 @@ module Rouge
         @perl = Perl.new
       end
   
-      def self.detect?(text)
-        return false if text.doctype?(/((?:ht|x)ml)/)
-        return true if text.doctype?
-      end
-
       # Note: If you add a tag in the lines below, you also need to modify "disambiguate '*.m'" in file disambiguation.rb
       TEXT_BLOCKS = %w(text doc)
       PERL_BLOCKS = %w(args flags attr init once shared perl cleanup filter)

--- a/spec/lexers/xml_spec.rb
+++ b/spec/lexers/xml_spec.rb
@@ -34,6 +34,7 @@ describe Rouge::Lexers::XML do
       assert_guess :source => '<?xml version="1.0" ?><html destdir="${reportfolderPath}" encoding="utf-8" />'
       assert_guess :source => '<!DOCTYPE xml>'
       deny_guess   :source => '<!DOCTYPE html>'
+      assert_guess :source => '<!DOCTYPE unknown>'
     end
   end
 end


### PR DESCRIPTION
Simple part of #1343, restore behavior to match pre-3.7 where the XML lexer uniquely claims responsibility for source that contains unrecognised DOCTYPE tags.  Add a test for that.