### PR TITLE
Handle Guesser::Ambiguous during markdown processing

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -49,6 +49,9 @@ module Rouge
       #
       #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
       #
+      #   If the code matches more than one lexer then Guesser::Ambiguous
+      #   is raised.
+      #
       # This is used in the Redcarpet plugin as well as Rouge's own
       # markdown lexer for highlighting internal code blocks.
       #

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -34,7 +34,13 @@ module Rouge
 
         rule %r/^([ \t]*)(```|~~~)([^\n]*\n)((.*?)(\2))?/m do |m|
           name = m[3].strip
-          sublexer = Lexer.find_fancy(name.empty? ? "guess" : name, m[5], @options)
+          sublexer =
+            begin
+              Lexer.find_fancy(name.empty? ? "guess" : name, m[5], @options)
+            rescue Guesser::Ambiguous => e
+              e.alternatives.first.new(@options)
+            end
+
           sublexer ||= PlainText.new(@options.merge(:token => Str::Backtick))
           sublexer.reset!
 

--- a/lib/rouge/plugins/redcarpet.rb
+++ b/lib/rouge/plugins/redcarpet.rb
@@ -9,7 +9,13 @@ module Rouge
   module Plugins
     module Redcarpet
       def block_code(code, language)
-        lexer = Lexer.find_fancy(language, code) || Lexers::PlainText
+        lexer =
+          begin
+            Lexer.find_fancy(language, code)
+          rescue Guesser::Ambiguous => e
+            e.alternatives.first
+          end
+        lexer ||= Lexers::PlainText
 
         # XXX HACK: Redcarpet strips hard tabs out of code blocks,
         # so we assume you're not using leading spaces that aren't tabs,

--- a/spec/lexers/markdown_spec.rb
+++ b/spec/lexers/markdown_spec.rb
@@ -39,6 +39,14 @@ describe Rouge::Lexers::Markdown do
       assert_has_token("Comment.Single","```\n#!/usr/bin/env ruby\n```\n")
     end
 
+    it 'picks a sub-lexer when the code-block-content is ambiguous' do
+      source = "Index: ): Awaitable<\n"
+      assert_raises Rouge::Guesser::Ambiguous do
+        Rouge::Lexer.find_fancy(nil, source)
+      end
+      assert_no_errors "```\n#{source}```\n"
+    end
+
     it 'recognizes backticks instead of code block if inside string' do
       assert_has_token("Literal.String.Backtick","\nx```ruby\nfoo\n```\n")
       deny_has_token("Name.Label","\nx```ruby\nfoo\n```\n")

--- a/spec/plugins/redcarpet_spec.rb
+++ b/spec/plugins/redcarpet_spec.rb
@@ -42,6 +42,16 @@ puts "hello, world"
     assert { result.include?(%(<pre class="highlight ruby"><code>)) }
   end
 
+  it 'chooses when a guess is ambiguous' do
+    result = markdown.render <<-mkd
+``` guess
+Index: ): Awaitable<
+```
+    mkd
+
+    assert { result.include?(%(<pre class="highlight)) }
+  end
+
   it 'passes options' do
     result = markdown.render <<-mkd
 ``` shell?k=v


### PR DESCRIPTION
Second part of #1343, handle the 'ambiguous lexer' case and pick an arbitrary one when Rouge is (a) running its markdown lexer and (b) invoked by redcarpet in the same kind of context.

I wasn't sure whether you'd prefer the repeated code factored into a `Lexer.find_fancy_safe` or something.

