### PR TITLE
Fix Liquid's pattern for matching include tag's filename argument

### DIFF
--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -266,7 +266,7 @@ module Rouge
         end
 
         rule %r/(with|for)\b/, Name::Tag
-        rule %r/[^\s\.]+(\.[^\s\.]+)+\b/, Name::Other
+        rule %r/[\/\w-]+(\.[\w-]+)+\b/, Text
 
         mixin :variable_tag_markup
       end

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -57,8 +57,8 @@ Some other {{ output }}!
 {% else %}
 {% endcase %}
 
-{% include file.html param = 'value' param2 = object %}
-{% include 'snippet', param: 'value', param2: object %}
+{% include dir/file.html param = 'example.com' param2 = object %}
+{% include 'snippet', param: 'example.com', param2: object %}
 {% include product_page with products[0] %}
 {% include {{product_page | split: "." | first}} for products %}
 


### PR DESCRIPTION
In the Liquid lexer, [this line](https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/liquid.rb#L269) in the `:include` state is specific to [Jekyll's implementation of the `include` tag](https://jekyllrb.com/docs/includes/), which allows specifying an unquoted file path as the initial argument, much like its own `include_relative` tag. This changes the rule to only allow a specific set of characters (including slash, because the tag searches subdirectories) which fixes a code sample in [this section](https://jekyllrb.com/docs/includes/#passing-parameters-to-includes), and marks the argument as plain `Text` to match how `include_relative` is handled.