### PR TITLE
Fix: q lexer - escaped quote within strings not being recognised

### DIFF
--- a/lib/rouge/demos/q
+++ b/lib/rouge/demos/q
@@ -1,8 +1,6 @@
 / comment
 x: til 10
 
-y: "string with quote \" inside";
-
 tab:([]a:1 2 3;b:`a `b `c);
 
 function:{[table]

--- a/lib/rouge/demos/q
+++ b/lib/rouge/demos/q
@@ -1,2 +1,10 @@
 / comment
 x: til 10
+
+y: "string with quote \" inside";
+
+tab:([]a:1 2 3;b:`a `b `c);
+
+function:{[table]
+	select from table where b=`c
+	};

--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -110,8 +110,9 @@ module Rouge
       end
 
       state :string do
-        rule(/"/, Str, :pop!)
-        rule %r/\\([\\nr]|[01][0-7]{2})/, Str::Escape
+	rule %r/\\"/, Str
+        rule %r/"/, Str, :pop!
+	rule %r/\\([\\nr]|[01][0-7]{2})/, Str::Escape
         rule %r/[^\\"\n]+/, Str
         rule %r/\\/, Str # stray backslash
       end

--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -110,9 +110,9 @@ module Rouge
       end
 
       state :string do
-	rule %r/\\"/, Str
+        rule %r/\\"/, Str
         rule %r/"/, Str, :pop!
-	rule %r/\\([\\nr]|[01][0-7]{2})/, Str::Escape
+        rule %r/\\([\\nr]|[01][0-7]{2})/, Str::Escape
         rule %r/[^\\"\n]+/, Str
         rule %r/\\/, Str # stray backslash
       end

--- a/spec/visual/samples/q
+++ b/spec/visual/samples/q
@@ -39,6 +39,7 @@ iasc|idesc|inv|keys|load|log|lsq|ltime|ltrim|maxs|md5|meta|mins|next|parse|plist
 
 / Strings
 ("";"x\n";"\007")
+y: "string with quote \" inside";
 
 a:1 2 3   / comment with leading whitespaces
 b:3 4 5 5 / to bring in line with this comment


### PR DESCRIPTION
The current lexer would recognise the escaped quote within  `"\""` as the end of the string

This caused files with any escaped quotes to be treated as a string from there onward and have no further syntax highlighting.

New rule on line 113 ahead of the pop checks that the quote is not escaped before terminating the string.

See updated example below.

Old:
![image](https://user-images.githubusercontent.com/16032432/68219106-588cf980-ffdd-11e9-86d6-fb3fb0d4ce92.png)


New:
![image](https://user-images.githubusercontent.com/16032432/68218851-e74d4680-ffdc-11e9-8570-3bfba76f419c.png)
