### PR TITLE
Add support for inline tables to TOML lexer

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -17,6 +17,12 @@ module Rouge
         rule %r/\s+/, Text
         rule %r/#.*?$/, Comment
         rule %r/(true|false)/, Keyword::Constant
+
+        rule %r/(\S+)(\s*)(=)(\s*)(\{)/ do |m|
+          groups Name::Namespace, Text, Operator, Text, Punctuation
+          push :inline
+        end
+
         rule %r/(?<!=)\s*\[[\S]+\]/, Name::Namespace
 
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
@@ -33,7 +39,6 @@ module Rouge
           groups Name::Property, Text, Punctuation
           push :value
         end
-
       end
 
       state :value do
@@ -62,6 +67,16 @@ module Rouge
       state :array do
         mixin :content
         rule %r/\]/, Punctuation, :pop!
+      end
+
+      state :inline do
+        mixin :content
+
+        rule %r/(#{identifier})(\s*)(=)/ do
+          groups Name::Property, Text, Punctuation
+        end
+
+        rule %r/\}/, Punctuation, :pop!
       end
     end
   end

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -62,3 +62,6 @@ test_string = "You'll hate me after this - #"          # " Annoying, isn't it?
             ]
 
 東京都 = 123
+
+name = { first = "Tom", last = "Preston-Werner" }
+point = { x = 1, y = 2 }


### PR DESCRIPTION
The current TOML lexer does not support inline tables. This PR fixes that by adding a new `:inline` state.

This fixes #826.