### PR TITLE
Fix json-doc lexer

### DIFF
--- a/lib/rouge/lexers/json_doc.rb
+++ b/lib/rouge/lexers/json_doc.rb
@@ -6,16 +6,17 @@ module Rouge
     load_lexer 'json.rb'
 
     class JSONDOC < JSON
-      desc "JavaScript Object Notation with extenstions for documentation"
+      desc "JavaScript Object Notation with extensions for documentation"
       tag 'json-doc'
 
-      prepend :root do
+      prepend :name do
         rule %r/([$\w]+)(\s*)(:)/ do
           groups Name::Attribute, Text, Punctuation
         end
+      end
 
+      prepend :value do
         rule %r(/[*].*?[*]/), Comment
-
         rule %r(//.*?$), Comment::Single
         rule %r/(\.\.\.)/, Comment::Single
       end


### PR DESCRIPTION
This PR fixes a regression in the json-doc lexer, introduced by a refactor of the json lexer in #1029.

Before and after:

![Before and after of the visual test](https://user-images.githubusercontent.com/990794/69007042-d683c580-0938-11ea-92c4-01bee730e7de.png)
