### PR TITLE
Magik: Add missing keyword _finally

### DIFF
--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -22,7 +22,7 @@ module Rouge
            _throw
            _lock _endlock
            _if _then _elif _else _endif
-           _for _over _while _loop _endloop _loopbody _continue _leave
+           _for _over _while _loop _finally _endloop _loopbody _continue _leave
            _return
            _class
            _local _constant _recursive _global _dynamic _import


### PR DESCRIPTION
It turns out I forgot the keyword ```_finally``` for the magik language. This pull request adds it.