### PR TITLE
Fix parsing of 'false' as Boolean option value

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -318,7 +318,7 @@ module Rouge
 
     def as_bool(val)
       case val
-      when nil, false, 0, '0', 'off'
+      when nil, false, 0, '0', 'false', 'off'
         false
       when Array
         val.empty? ? true : as_bool(val.last)

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -185,4 +185,23 @@ describe Rouge::Lexer do
     refute { NonDetectableLexer.methods(false).include?(:detect?) }
     refute { NonDetectableLexer.detectable? }
   end
+
+  it 'handles boolean options' do
+    option_lexer = Class.new(Rouge::RegexLexer) do
+      option :bool_opt, 'An example boolean option'
+
+      def initialize(*)
+        super
+        @bool_opt = bool_option(:bool_opt) { nil }
+      end
+    end
+
+    assert_equal true, option_lexer.new({bool_opt: 'true'}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: nil}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: false}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: 0}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: '0'}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: 'false'}).instance_variable_get(:@bool_opt)
+    assert_equal false, option_lexer.new({bool_opt: 'off'}).instance_variable_get(:@bool_opt)
+  end
 end


### PR DESCRIPTION
Rouge allows for options to be passed to a lexer's constructor method. The options are parsed from strings. As noted in #1379, the string `'false'` was not being converted to the value `false`. This PR fixes that. It also adds a rudimentary series of tests to ensure that values are being properly parsed.

This fixes #1380.