### PR TITLE
Fix division operator error

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -96,7 +96,7 @@ module Rouge
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
         rule %r/[()\[\]{}|,:;]/, Punctuation
-        rule %r/[*!@~&+%^<>=\?-]|\.{2,3}/, Operator
+        rule %r/[*\/!@~&+%^<>=\?-]|\.{2,3}/, Operator
 
         rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule %r/[.]\s*#{id}/, Name::Property

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -12,6 +12,13 @@ fn g() {
     io::println(d);
 }
 
+fn h(a: i32) -> i32 {
+  let b = (a / 4 + 1_000) * 2 - 3;
+  let c = (a | 0b0100) & 0xF;
+
+  c ^ !b
+}
+
 fn main() {
     f();
     g();


### PR DESCRIPTION
Division was missing from the list of valid rust operators.
Added some visual samples to cover operator usage.

https://github.com/rouge-ruby/rouge/pull/452 also addressed this issue, but that PR seems stale. Some of those fixes were already addressed by other PRs.