### PR TITLE
Allow spaces after Jinja filter pipes

### DIFF
--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -57,7 +57,7 @@ module Rouge
 
       state :filter do
         # Filters are called like variable|foo(arg1, ...)
-        rule %r/(\|)(\w+)/ do
+        rule %r/(\|\s*)(\w+)/ do
           groups Operator, Name::Function
         end
       end

--- a/spec/visual/samples/jinja
+++ b/spec/visual/samples/jinja
@@ -12,7 +12,9 @@
 
 {# A comment #}
 
-Hello {{ user.name|capitalize }} !
+Hello {{ user.name|capitalize | upper }} !
+
+Cool list filter {{ listx | join(', ') }}
 
 {% if user.admin is true %}
   <span>You're an admin !</span>


### PR DESCRIPTION
This PR allows for spaces to exist after the pipe `|` for Jinja filters

_Before_
![image](https://user-images.githubusercontent.com/3383063/71935872-8ae9dd00-316d-11ea-834a-3ad41d3a8d08.png)

_After_
![image](https://user-images.githubusercontent.com/3383063/71935892-963d0880-316d-11ea-8c7d-309118f1b3ce.png)
