### PR TITLE
Combine import and package rules in Java lexer

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -50,10 +50,9 @@ module Rouge
         rule %r/@#{id}/, Name::Decorator
         rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
         rule %r/(?:#{types.join('|')})\b/, Keyword::Type
-        rule %r/package\b/, Keyword::Namespace
         rule %r/(?:true|false|null)\b/, Keyword::Constant
         rule %r/(?:class|interface)\b/, Keyword::Declaration, :class
-        rule %r/import\b/, Keyword::Namespace, :import
+        rule %r/(?:import|package)\b/, Keyword::Namespace, :import
         rule %r/"(\\\\|\\"|[^"])*"/, Str
         rule %r/'(?:\\.|[^\\]|\\u[0-9a-f]{4})'/, Str::Char
         rule %r/(\.)(#{id})/ do


### PR DESCRIPTION
The lexing that is performed for packages imported using the `import` keyword should be the same for the `package` keyword. This is consistent with the current behaviour in [the Pygments lexer](https://github.com/pygments/pygments/blob/5d47e334ed0112040336482a0da77d3842ddf96b/pygments/lexers/jvm.py#L60).

This fixes #1388.