### PR TITLE
Support optional props in TypeScript lexer

### DIFF
--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -20,8 +20,8 @@ module Rouge
       mimetypes 'text/typescript'
 
       prepend :statement do
-        rule %r/(#{Javascript.id_regex}\??)(\s*)(:)/ do
-          groups Name::Label, Text, Punctuation
+        rule %r/(#{Javascript.id_regex})(\??)(\s*)(:)/ do
+          groups Name::Label, Punctuation, Text, Punctuation
           push :expr_start
         end
       end

--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -18,6 +18,13 @@ module Rouge
       filenames '*.ts', '*.d.ts'
 
       mimetypes 'text/typescript'
+
+      prepend :statement do
+        rule %r/(#{Javascript.id_regex}\??)(\s*)(:)/ do
+          groups Name::Label, Text, Punctuation
+          push :expr_start
+        end
+      end
     end
   end
 end

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -167,7 +167,7 @@ declare module "foo" {
     export interface IFoo {
         theObject: any;
         aWord: string;
-        aNumber: number;
+        aNumber?: number;
     }
 }
 


### PR DESCRIPTION
TypeScript allows a user to mark a property as an optional when defining an interface by appending a question mark to the property name. Rouge's TypeScript lexer doesn't currently support this because the lexer merely uses the states defined in the JavaScript lexer.

This PR prepends a rule to the `statement` state that will match a property name ending with a `?`. This will allow matches outside of the interface definition but as syntax checking is a non-goal of Rouge this is not considered to be a problem.

The TypeScript visual sample is updated to include an example.

This fixes #1391.