### PR TITLE
some updates to the PHP lexer

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -44,9 +44,6 @@ module Rouge
         end
       end
 
-      LNUM = '\d+(?:_\d+)*'
-      DNUM = '(?:(?:#{LNUM}?\.#{LNUM})|(?:#{LNUM}\.#{LNUM}?))'
-      WHITESPACE = '[ \n\r\t]+'
       # source: http://php.net/manual/en/language.variables.basics.php
       # the given regex is invalid utf8, so... we're using the unicode
       # "Letter" property instead.
@@ -143,11 +140,10 @@ module Rouge
         end
 
         rule %r/(true|false|null)\b/, Keyword::Constant
-        rule /(?:void|\??(?:int|float|bool|string|iterable))\b/i, Keyword::Type
-        rule /\??(?:self|callable)\b/i, Keyword::Type
+        rule %r/(?:void|\??(?:int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable
         rule %r/\$+#{id}/i, Name::Variable
-        rule /(yield)(#{WHITESPACE})(from)/io do
+        rule %r/(yield)([ \n\r\t]+)(from)/i do
           groups Keyword, Text, Keyword
         end
 
@@ -164,19 +160,19 @@ module Rouge
           end
         end
 
-        rule %r/(?:(?:#{LNUM}|#{DNUM})[eE][+-]?#{LNUM})/o, Num::Float
-        rule %r/#{DNUM}/o, Num::Float
+        rule %r/(?:(?:(?:\d+(?:_\d+)*)|(?:(?:(?:\d+(?:_\d+)*)?\.(?:\d+(?:_\d+)*))|(?:(?:\d+(?:_\d+)*)\.(?:\d+(?:_\d+)*)?)))e[+-]?(?:\d+(?:_\d+)*))/i, Num::Float
+        rule %r/(?:(?:\d+(?:_\d+)*)?\.(?:\d+(?:_\d+)*))|(?:(?:\d+(?:_\d+)*)\.(?:\d+(?:_\d+)*)?)/, Num::Float
         rule %r/0[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule %r/0[bB][01]+(?:_[01]+)*/, Num::Bin
+        rule %r/0b[01]+(?:_[01]+)*/i, Num::Bin
         rule %r/0x[a-f0-9]+(?:_[a-f0-9]+)*/i, Num::Hex
-        rule %r/#{LNUM}/o, Num::Integer
+        rule %r/\d+(?:_\d+)*/, Num::Integer
         rule %r/'([^'\\]*(?:\\.[^'\\]*)*)'/, Str::Single
         rule %r/`([^`\\]*(?:\\.[^`\\]*)*)`/, Str::Backtick
         rule %r/"/, Str::Double, :string
       end
       
       state :use do
-        rule %r/(\s+)(as)(\s+)(#{id})/ do
+        rule %r/(\s+)(as)(\s+)(#{id})/i do
           groups Text, Keyword, Text, Name
           :pop!
         end
@@ -188,7 +184,7 @@ module Rouge
         rule %r/\s+/, Text
         rule %r/,/, Operator
         rule %r/\}/, Operator, :pop!
-        rule %r/(as)(\s+)(#{id})/ do
+        rule %r/(as)(\s+)(#{id})/i do
           groups Keyword, Text, Name
         end
         rule %r/#{id}/, Name::Namespace
@@ -201,8 +197,8 @@ module Rouge
       state :string do
         rule %r/"/, Str::Double, :pop!
         rule %r/[^\\{$"]+/, Str::Double
-        rule /\\u\{[0-9a-fA-F]+\}/, Str::Escape
-        rule %r/\\([efrntv\"$\\]|[0-7]{1,3}|x[0-9A-Fa-f]{1,2})/,
+        rule %r/\\u\{[0-9a-fA-F]+\}/, Str::Escape
+        rule %r/\\([efrntv\"$\\]|[0-7]{1,3}|[xX][0-9a-fA-F]{1,2})/,
           Str::Escape
         rule %r/\$#{id}(\[\S+\]|->#{id})?/, Name::Variable
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -117,23 +117,23 @@ module Rouge
 
         rule %r/[~!%^&*+=\|:.<>\/?@-]+/, Operator
         rule %r/[\[\]{}();,]/, Punctuation
-        rule %r/(class|interface|trait)(\s+)(#{nsid})/ do
+        rule %r/(class|interface|trait)(\s+)(#{nsid})/i do
           groups Keyword::Declaration, Text, Name::Class
         end
-        rule %r/(use)(\s+)(function|const|)(\s*)(#{nsid})/ do
+        rule %r/(use)(\s+)(function|const|)(\s*)(#{nsid})/i do
           groups Keyword::Namespace, Text, Keyword::Namespace, Text, Name::Namespace
           push :use
         end
-        rule %r/(namespace)(\s+)(#{nsid})/ do
+        rule %r/(namespace)(\s+)(#{nsid})/i do
           groups Keyword::Namespace, Text, Name::Namespace
         end
         # anonymous functions
-        rule %r/(function)(\s*)(?=\()/ do
+        rule %r/(function)(\s*)(?=\()/i do
           groups Keyword, Text
         end
 
         # named functions
-        rule %r/(function)(\s+)(&?)(\s*)/ do
+        rule %r/(function)(\s+)(&?)(\s*)/i do
           groups Keyword, Text, Operator, Text
           push :funcname
         end

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -67,6 +67,7 @@ module Rouge
         # - isset, unset and empty are actually keywords (directly handled by PHP's lexer but let's pretend these are functions, you use them like so)
         # - self and parent are kind of keywords, they are not handled by PHP's lexer
         # - use, const, namespace and function are handled by specific rules to highlight what's next to the keyword
+        # - class is also listed here, in addition to the rule below, to handle anonymous classes
         @keywords ||= Set.new %w(
           old_function cfunction
           __class__ __dir__ __file__ __function__ __halt_compiler
@@ -144,8 +145,8 @@ module Rouge
 
         rule %r/stdClass\b/i, Name::Class
         rule %r/(true|false|null)\b/i, Keyword::Constant
-        rule %r/(?:E|PHP)(?:_[[:upper:]]+)+\b/, Keyword::Constant
-        rule %r/(?:void|\??(?:int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
+        rule %r/(E|PHP)(_[[:upper:]]+)+\b/, Keyword::Constant
+        rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable
         rule %r/\$+#{id}/i, Name::Variable
         rule %r/(yield)([ \n\r\t]+)(from)/i do
@@ -165,12 +166,11 @@ module Rouge
           end
         end
 
-        rule %r/(?:(?:(?:\d+(?:_\d+)*)|(?:(?:(?:\d+(?:_\d+)*)?\.(?:\d+(?:_\d+)*))|(?:(?:\d+(?:_\d+)*)\.(?:\d+(?:_\d+)*)?)))e[+-]?(?:\d+(?:_\d+)*))/i, Num::Float
-        rule %r/(?:(?:\d+(?:_\d+)*)?\.(?:\d+(?:_\d+)*))|(?:(?:\d+(?:_\d+)*)\.(?:\d+(?:_\d+)*)?)/, Num::Float
-        rule %r/0[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule %r/0b[01]+(?:_[01]+)*/i, Num::Bin
-        rule %r/0x[a-f0-9]+(?:_[a-f0-9]+)*/i, Num::Hex
-        rule %r/\d+(?:_\d+)*/, Num::Integer
+        rule %r/(\d[_\d]*)?\.(\d[_\d]*)?(e[+-]?\d[_\d]*)?/i, Num::Float
+        rule %r/0[0-7][0-7_]*/, Num::Oct
+        rule %r/0b[01][01_]*/i, Num::Bin
+        rule %r/0x[a-f0-9][a-f0-9_]*/i, Num::Hex
+        rule %r/\d[_\d]*/, Num::Integer
         rule %r/'([^'\\]*(?:\\.[^'\\]*)*)'/, Str::Single
         rule %r/`([^`\\]*(?:\\.[^`\\]*)*)`/, Str::Backtick
         rule %r/"/, Str::Double, :string

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -104,7 +104,7 @@ module Rouge
       state :php do
         rule %r/\?>/, Comment::Preproc, :pop!
         # heredocs
-        rule %r/<<<('?)(#{id})\1\n.*?\n\s*\2;?/im, Str::Heredoc
+        rule %r/<<<(["']?)(#{id})\1\n.*?\n\s*\2;?/im, Str::Heredoc
         rule %r/\s+/, Text
         rule %r/#.*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -144,6 +144,7 @@ module Rouge
 
         rule %r/stdClass\b/i, Name::Class
         rule %r/(true|false|null)\b/i, Keyword::Constant
+        rule %r/(?:E|PHP)(?:_[[:upper:]]+)+\b/, Keyword::Constant
         rule %r/(?:void|\??(?:int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable
         rule %r/\$+#{id}/i, Name::Variable

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -67,7 +67,7 @@ module Rouge
           and E_PARSE old_function E_ERROR or as E_WARNING parent eval
           PHP_OS break exit case extends PHP_VERSION cfunction
           print for require continue foreach require_once declare return
-          default static do switch die stdclass echo else elseif
+          default static do switch die echo else elseif
           var empty if xor enddeclare include virtual endfor include_once
           while endforeach global __file__ endif list __line__ endswitch
           new __sleep endwhile not array __wakeup E_ALL final
@@ -139,6 +139,7 @@ module Rouge
           groups Keyword, Text, Name::Constant
         end
 
+        rule %r/stdClass\b/i, Name::Class
         rule %r/(true|false|null)\b/i, Keyword::Constant
         rule %r/(?:void|\??(?:int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -68,12 +68,12 @@ module Rouge
       def self.keywords
         @keywords ||= Set.new %w(
           and E_PARSE old_function E_ERROR or as E_WARNING parent eval
-          PHP_OS break exit case extends PHP_VERSION cfunction FALSE
+          PHP_OS break exit case extends PHP_VERSION cfunction false
           print for require continue foreach require_once declare return
-          default static do switch die stdClass echo else TRUE elseif
+          default static do switch die stdclass echo else true elseif
           var empty if xor enddeclare include virtual endfor include_once
           while endforeach global __file__ endif list __line__ endswitch
-          new __sleep endwhile not array __wakeup E_ALL NULL final
+          new __sleep endwhile not array __wakeup E_ALL null final
           php_user_filter interface implements public private protected
           abstract clone try catch finally throw this use namespace yield
           fn callable insteadof trait __trait__ goto __namespace__ __dir__

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -65,12 +65,12 @@ module Rouge
       def self.keywords
         @keywords ||= Set.new %w(
           and E_PARSE old_function E_ERROR or as E_WARNING parent eval
-          PHP_OS break exit case extends PHP_VERSION cfunction false
+          PHP_OS break exit case extends PHP_VERSION cfunction
           print for require continue foreach require_once declare return
-          default static do switch die stdclass echo else true elseif
+          default static do switch die stdclass echo else elseif
           var empty if xor enddeclare include virtual endfor include_once
           while endforeach global __file__ endif list __line__ endswitch
-          new __sleep endwhile not array __wakeup E_ALL null final
+          new __sleep endwhile not array __wakeup E_ALL final
           php_user_filter interface implements public private protected
           abstract clone try catch finally throw this use namespace yield
           fn callable insteadof trait __trait__ goto __namespace__ __dir__
@@ -139,7 +139,7 @@ module Rouge
           groups Keyword, Text, Name::Constant
         end
 
-        rule %r/(true|false|null)\b/, Keyword::Constant
+        rule %r/(true|false|null)\b/i, Keyword::Constant
         rule %r/(?:void|\??(?:int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable
         rule %r/\$+#{id}/i, Name::Variable

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -116,6 +116,7 @@ module Rouge
           groups Operator, Text, Name::Attribute
         end
 
+        rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/[~!%^&*+=\|:.<>\/?@-]+/, Operator
         rule %r/[\[\]{}();,]/, Punctuation
         rule %r/(class|interface|trait)(\s+)(#{nsid})/i do
@@ -146,7 +147,6 @@ module Rouge
         rule %r/stdClass\b/i, Name::Class
         rule %r/(true|false|null)\b/i, Keyword::Constant
         rule %r/(E|PHP)(_[[:upper:]]+)+\b/, Keyword::Constant
-        rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/\$\{\$+#{id}\}/i, Name::Variable
         rule %r/\$+#{id}/i, Name::Variable
         rule %r/(yield)([ \n\r\t]+)(from)/i do

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -63,19 +63,22 @@ module Rouge
       end
 
       def self.keywords
+        # (echo parent ; echo self ; sed -nE 's/<ST_IN_SCRIPTING>"((__)?[[:alpha:]_]+(__)?)".*/\1/p' zend_language_scanner.l | tr '[A-Z]' '[a-z]') | sort -u | grep -Fwv -e isset -e unset -e empty -e const -e use -e function -e namespace
+        # - isset, unset and empty are actually keywords (directly handled by PHP's lexer but let's pretend these are functions, you use them like so)
+        # - self and parent are kind of keywords, they are not handled by PHP's lexer
+        # - use, const, namespace and function are handled by specific rules to highlight what's next to the keyword
         @keywords ||= Set.new %w(
-          and E_PARSE old_function E_ERROR or as E_WARNING parent eval
-          PHP_OS break exit case extends PHP_VERSION cfunction
-          print for require continue foreach require_once declare return
-          default static do switch die echo else elseif
-          var empty if xor enddeclare include virtual endfor include_once
-          while endforeach global __file__ endif list __line__ endswitch
-          new __sleep endwhile not array __wakeup E_ALL final
-          php_user_filter interface implements public private protected
-          abstract clone try catch finally throw this use namespace yield
-          fn callable insteadof trait __trait__ goto __namespace__ __dir__
-          instanceof __class__ __function__ __method__ __halt_compiler
-          class self
+          old_function cfunction
+          __class__ __dir__ __file__ __function__ __halt_compiler
+          __line__ __method__ __namespace__ __trait__ abstract and
+          array as break callable case catch class clone continue
+          declare default die do echo else elseif enddeclare
+          endfor endforeach endif endswitch endwhile eval exit
+          extends final finally fn for foreach global goto if
+          implements include include_once instanceof insteadof
+          interface list new or parent print private protected
+          public require require_once return self static switch
+          throw trait try var while xor yield
         )
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -78,7 +78,7 @@ module Rouge
           abstract clone try catch finally throw this use namespace yield
           fn callable insteadof trait __trait__ goto __namespace__ __dir__
           instanceof __class__ __function__ __method__ __halt_compiler
-          self
+          class self
         )
       end
 

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -54,11 +54,14 @@ describe Rouge::Lexers::PHP do
     end
 
     it 'recognizes case insensitively keywords' do
-      assert_tokens_equal 'wHiLe', ["Keyword", "wHiLe"]
+      assert_tokens_equal 'While', ["Keyword", "While"]
+      # class for anonymous classes is recognized as a regular keyword
+      assert_tokens_equal 'Class {', ["Keyword", "Class"], ["Text", " "], ["Punctuation", "{"]
       assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]
       assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]
       assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]
       assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]
+      # function for anonymous functions is also recognized as a regular keyword
       assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]
       assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name.Function", "foo"]
     end

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -55,6 +55,12 @@ describe Rouge::Lexers::PHP do
 
     it 'recognizes case insensitively keywords' do
       assert_tokens_equal 'wHiLe', ["Keyword", "wHiLe"]
+      assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]
+      assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]
+      assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]
+      assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]
+      assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]
+      assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name.Function", "foo"]
     end
 
     it 'recognizes case sensitively E_* and PHP_* as constants' do

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -52,5 +52,18 @@ describe Rouge::Lexers::PHP do
     it 'recognizes trait definition' do
       assert_tokens_equal 'trait A {}', ["Keyword.Declaration", "trait"], ["Text", " "], ["Name.Class", "A"], ["Text", " "], ["Punctuation", "{}"]
     end
+
+    it 'recognizes case insensitively keywords' do
+      assert_tokens_equal 'wHiLe', ["Keyword", "wHiLe"]
+    end
+
+    it 'recognizes case sensitively E_* and PHP_* as constants' do
+      assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]
+      assert_tokens_equal 'PHP_EOL_1', ["Name.Other", "PHP_EOL_1"]
+
+      assert_tokens_equal 'E_user_DEPRECATED', ["Name.Other", "E_user_DEPRECATED"]
+      assert_tokens_equal 'E_USER_deprecated', ["Name.Other", "E_USER_deprecated"]
+      assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]
+    end
   end
 end

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -1,5 +1,6 @@
 <p>It's html outside php!</p>
 <?php
+file_put_contents("log.txt", "\u{FEFF}===== Début du fichier =====\n");
 
 $test = function($a) { $lambda = 1; }
 
@@ -519,7 +520,7 @@ class Zip extends Archive {
                              $header);
 
       // Valid header?
-      if($header_info['header'] != 33639248)
+      if($header_info['header'] != 33_639_248)
         return false;
 
       // New position
@@ -577,7 +578,7 @@ class Zip extends Archive {
                              $header);
 
       // Valid header?
-      if($header_info['header'] != 67324752)
+      if($header_info['header'] != 67_324_752)
         return false;
 
       // Get content start position


### PR DESCRIPTION
Hi,

I would like to submit some updates and improvements to the PHP lexer:

* fix case insensitivity of (accordingly to the language they are case insensitive but currently are not):
  + `<?php`
  + `as` in `use` list
  + keywords (when checked in `@keywords`)
  + function/method names (when checked in `@builtins`)
* fix heredoc: the syntax with `"` around the starting label was not recognized as is
* updates from the language:
  + support `_` in (binary, decimal, hexadecimal, ...) numbers (7.4.0)
  + support for binary numbers (`0b...`) (5.4.0)
  + Unicode codepoints escape syntax (`\u{...}`) (7.0.0)
  + add some missing keywords:
    * 7.4.0: `fn`
    * type declarations (PHP 7, including `void` and nullable types from PHP 7.1)
    * 7.0.0: `class` (anonymous classes), `yield from`
    * 5.4.0: `callable`, `insteadof`, `trait`, `__TRAIT__`
    * 5.3.0: `goto`, `__NAMESPACE__`, `__DIR__`
    * others: `instanceof`, `__CLASS__`, `__FUNCTION__`, `__METHOD__`, `__halt_compiler`
    * `self` even if it's not really a reserved word

I haven't deleted them but I am in favor of the removal of the current builtin/predefined constants (E_\* and PHP_\*) and class `stdClass` from `@keywords`:

* they are not keywords
* these constants are case sensitive (which is not the case of the keywords in PHP as said above)

Let me know if you agree and if I missed or forgot something.

Also, is there a reason for `TRUE`/`FALSE`/`NULL` to be in `@keywords`? I mean shouldn't `rule %r/(true|false|null)\b/, Keyword::Constant` be made case insensitive instead?


Thanks.