### PR TITLE
Support raw strings in Rust lexer

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -159,6 +159,7 @@ module Rouge
         )x, Str::Char
 
         rule %r/"/, Str, :string
+        rule %r/r(#*)".*?"\1/m, Str
 
         # numbers
         dot = /[.][0-9_]+/

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -30,6 +30,14 @@ println!("a\\");
 println!("a\n");
 println!("a\"b");
 println!("a\'");
+println!(r"");
+println!(r"\n\");
+println!(r#"a"b\"#);
+println!(r##"r#""#"##);
+println!(r###"r##"r#""#"##"###);
+println!(r#"
+  "New line in a raw string"
+"#);
 
 debug!("test %?", a.b);
 debug!("test %u", a.c);


### PR DESCRIPTION
Fixes #1398

GitHub syntax highlights them correctly if that helps. There is no special behavior for `\`, those are raw strings.

```rust
println!(r"\n\");
println!(r#"a"b\"#);
println!(r##"r#""#"##);
println!(r###"r##"r#""#"##"###);
```