### PR TITLE
Remove sprintf format parsing for Rust lexer

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -185,16 +185,7 @@ module Rouge
       state :string do
         rule %r/"/, Str, :pop!
         rule escapes, Str::Escape
-        rule %r/%%/, Str::Interpol
-        rule %r(
-          %
-          ( [0-9]+ [$] )?  # Parameter
-          [0#+-]*          # Flag
-          ( [0-9]+ [$]? )? # Width
-          ( [.] [0-9]+ )?  # Precision
-          [bcdfiostuxX?]   # Type
-        )x, Str::Interpol
-        rule %r/[^%"\\]+/m, Str
+        rule %r/[^"\\]+/m, Str
       end
     end
   end

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -31,13 +31,6 @@ println!("a\n");
 println!("a\"b");
 println!("a\'");
 
-debug!("test %?", a.b);
-debug!("test %u", a.c);
-debug!("test %i", a.d);
-debug!("test %c", a.e);
-debug!("test %f", a.f);
-debug!("test %b", a.g);
-
 trait iterable<A> {
     fn iterate(blk: fn(x: &A) -> bool);
 }


### PR DESCRIPTION
Rust doesn't use sprintf parsing for its string formatting, using Python-style formatting instead.

For instance, `print!("test %?", a.b)` would be written as `print!("test {:?}", a.b)` in Rust today. The old syntax was removed before 1.0, as such there is no real reason to support it.