### PR TITLE
fix crash in terminal256 formatter with escaped tokens

### DIFF
--- a/spec/lexers/escape_spec.rb
+++ b/spec/lexers/escape_spec.rb
@@ -1,0 +1,26 @@
+describe Rouge::Lexers::Escape do
+  let(:lexer) { Rouge::Lexers::Escape.new(lang: 'json') }
+  let(:text) { '{ "foo": <!<bar>!> }' }
+  let(:result) {
+    Rouge::Formatter.with_escape do
+      formatter.format(lexer.lex(text))
+    end
+  }
+
+  describe 'html' do
+    let(:formatter) { Rouge::Formatters::HTML.new }
+
+    it 'unescapes' do
+      assert { result =~ /<bar>/ }
+    end
+  end
+
+  describe 'terminal256' do
+    let(:formatter) { Rouge::Formatters::Terminal256.new }
+    let(:text) { %({ "foo": <!\e123!> }) }
+
+    it 'unescapes' do
+      assert { result =~ /\e123/ }
+    end
+  end
+end


### PR DESCRIPTION
Also added specs - apparently this feature didn't have any!