### PR TITLE
Add regex support to Lua lexer

### DIFF
--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -71,8 +71,11 @@ module Rouge
         rule %r((function)\b), Keyword, :function_name
 
         rule %r([A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?) do |m|
-          name = m[0]
-          if self.builtins.include?(name)
+          name = m[0].downcase
+          if name == "gsub"
+            token Name::Builtin
+            push :gsub
+          elsif self.builtins.include?(name)
             token Name::Builtin
           elsif name =~ /\./
             a, b = name.split('.', 2)
@@ -96,6 +99,41 @@ module Rouge
         end
         # inline function
         rule %r(\(), Punctuation, :pop!
+      end
+
+      state :gsub do
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/[(,]/, Punctuation
+        rule %r/\s+/, Text
+        rule %r/"/, Str::Regex, :regex
+      end
+
+      state :regex do
+        rule %r(") do
+          token Str::Regex
+          goto :regex_end
+        end
+
+        rule %r/\[\^?/, Str::Escape, :regex_group
+        rule %r/\\./, Str::Escape
+        rule %r{[(][?][:=<!]}, Str::Escape
+        rule %r/[{][\d,]+[}]/, Str::Escape
+        rule %r/[()?]/, Str::Escape
+        rule %r/./, Str::Regex
+      end
+
+			state :regex_end do
+        rule %r/[$]+/, Str::Regex, :pop!
+        rule(//) { pop! }
+      end
+
+      state :regex_group do
+        rule %r(/), Str::Escape
+        rule %r/\]/, Str::Escape, :pop!
+        rule %r/(\\)(.)/ do |m|
+          groups Str::Escape, Str::Regex
+        end
+        rule %r/./, Str::Regex
       end
 
       state :escape_sqs do

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -71,7 +71,7 @@ module Rouge
         rule %r((function)\b), Keyword, :function_name
 
         rule %r([A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?) do |m|
-          name = m[0].downcase
+          name = m[0]
           if name == "gsub"
             token Name::Builtin
             push :gsub
@@ -122,7 +122,7 @@ module Rouge
         rule %r/./, Str::Regex
       end
 
-			state :regex_end do
+      state :regex_end do
         rule %r/[$]+/, Str::Regex, :pop!
         rule(//) { pop! }
       end

--- a/spec/visual/samples/lua
+++ b/spec/visual/samples/lua
@@ -258,3 +258,6 @@ end
 acc = Account.create(1000)
 acc:withdraw(100)
 
+if
+   url = url:gsub("^['\"]", ""):gsub("['\"]$", "")
+end


### PR DESCRIPTION
The Lua lexer does not currently provide any support for tokenising regular expressions. This PR adds support for regular expressions.

It fixes #1401.