### PR TITLE
Fix NameError on @ + UPPERCASE token in Objective-C

### DIFF
--- a/lib/rouge/lexers/objective_c/common.rb
+++ b/lib/rouge/lexers/objective_c/common.rb
@@ -44,7 +44,7 @@ module Rouge
             elsif base.at_builtins.include? m[1]
               token base::Name::Builtin
             else
-              token Error
+              token base::Error
             end
           end
 

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -173,3 +173,6 @@ ViewController *controller = [[ViewController alloc] initWithDocument:document c
     builder.thumbnailBarMode = ThumbnailBarModeScrollable;
     builder.pageLabelEnabled = NO;
 }]];
+
+// Invalid Objective-C keyword
+@FOO


### PR DESCRIPTION
I got an error when highlighting `@FOO` as Objective-C.
This pull request will fix the problem.



```bash
$ ruby -Ilib -rrouge -e 'p Rouge.highlight("@FOO", "objective_c", "html")'
Traceback (most recent call last):
        18: from -e:1:in `<main>'
        17: from /path/to/rouge/lib/rouge.rb:32:in `highlight'
        16: from /path/to/rouge/lib/rouge/formatter.rb:46:in `format'
        15: from /path/to/rouge/lib/rouge/formatter.rb:74:in `format'
        14: from /path/to/rouge/lib/rouge/formatters/html.rb:12:in `stream'
        13: from /path/to/rouge/lib/rouge/formatters/html.rb:12:in `each'
        12: from /path/to/rouge/lib/rouge/formatter.rb:58:in `filter_escapes'
        11: from /path/to/rouge/lib/rouge/formatter.rb:58:in `each'
        10: from /path/to/rouge/lib/rouge/lexer.rb:451:in `lex'
         9: from /path/to/rouge/lib/rouge/lexer.rb:461:in `continue_lex'
         8: from /path/to/rouge/lib/rouge/regex_lexer.rb:272:in `stream_tokens'
         7: from /path/to/rouge/lib/rouge/regex_lexer.rb:291:in `step'
         6: from /path/to/rouge/lib/rouge/regex_lexer.rb:291:in `each'
         5: from /path/to/rouge/lib/rouge/regex_lexer.rb:294:in `block in step'
         4: from /path/to/rouge/lib/rouge/regex_lexer.rb:291:in `step'
         3: from /path/to/rouge/lib/rouge/regex_lexer.rb:291:in `each'
         2: from /path/to/rouge/lib/rouge/regex_lexer.rb:309:in `block in step'
         1: from /path/to/rouge/lib/rouge/regex_lexer.rb:309:in `instance_exec'
/path/to/rouge/lib/rouge/lexers/objective_c/common.rb:47:in `block (2 levels) in extended': uninitialized constant Rouge::Lexers::ObjectiveCCommon::Error (NameError)
Did you mean?  IOError
               Errno
```


I guess this error is related to #1378. Because this PR introduced the `base` variable.



By the way, I'm not sure I should write test code for this fix.
I guess we can add it to `spec/visual/samples/objective_c`, but I don't know Objective-C syntax.
And it is highlighted as "Error", so I'm wondering if the visual test should contain it.

Please tell me how to write a test if it's necessary :bowing_man: 