### PR TITLE
Support '"' to identify heredoc delimiters in Shell lexer

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -64,7 +64,7 @@ module Rouge
         # here-string
         rule %r/<<</, Operator
 
-        rule %r/(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
+        rule %r/(<<-?)(\s*)(['"]?)(\\?)(\w+)(\3)/ do |m|
           groups Operator, Text, Str::Heredoc, Str::Heredoc, Name::Constant, Str::Heredoc
           @heredocstr = Regexp.escape(m[5])
           push :heredoc

--- a/spec/visual/samples/shell
+++ b/spec/visual/samples/shell
@@ -1034,7 +1034,7 @@ compiler."
       fi
 
       # Append the name of the PIC object to the libtool object file.
-      test -z "$run" && cat >> ${libobj}T <<EOF
+      test -z "$run" && cat >> ${libobj}T <<"EOF"
 pic_object='$objdir/$objname'
 
 EOF
@@ -1046,7 +1046,7 @@ EOF
     else
       # No PIC object so indicate it doesn't exist in the libtool
       # object file.
-      test -z "$run" && cat >> ${libobj}T <<EOF
+      test -z "$run" && cat >> ${libobj}T <<'EOF'
 pic_object=none
 
 EOF


### PR DESCRIPTION
Heredoc delimiters in the Shell lexer can be identified by the use of `'`. This PR adds support for the use of `"`.

This fixes #1409.