### PR TITLE
Support Unicode identifiers in Java lexer

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -23,9 +23,9 @@ module Rouge
 
       types = %w(boolean byte char double float int long short var void)
 
-      id = /[a-zA-Z_][a-zA-Z0-9_]*/
-      const_name = /[A-Z][A-Z0-9_]*\b/
-      class_name = /[A-Z][a-zA-Z0-9]*\b/
+      id = /[[:alpha:]_][[:word:]]*/
+      const_name = /[[:upper:]][[:upper:][:digit:]_]*\b/
+      class_name = /[[:upper:]][[:alnum:]]*\b/
 
       state :root do
         rule %r/[^\S\n]+/, Text

--- a/spec/visual/samples/java
+++ b/spec/visual/samples/java
@@ -682,4 +682,5 @@ public class PlatformManagerImpl implements PlatformManager
 }
 
 // Permit Unicode characters in identifiers
+getHauptadresse().setPLZ("91126");
 getHauptadresse().setStraßePostfach("Am Hundsacker 6");

--- a/spec/visual/samples/java
+++ b/spec/visual/samples/java
@@ -680,3 +680,6 @@ public class PlatformManagerImpl implements PlatformManager
     {
     }
 }
+
+// Permit Unicode characters in identifiers
+getHauptadresse().setStraßePostfach("Am Hundsacker 6");


### PR DESCRIPTION
Identifiers used in Java can include Unicode characters; however, the Java lexer only matches against ASCII identifiers. This PR adds support for Unicode characters using Ruby's broader character classes.

This fixes #831.