### PR TITLE
Stash base dir paths in module constants

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -38,59 +38,60 @@ module Rouge
   end
 end
 
-def rouge_relative(path)
-  File.join(Rouge::LIB_DIR, "rouge/#{path}.rb")
+# mimic Kernel#require_relative API
+def load_relative(path)
+  load File.join(Rouge::LIB_DIR, "#{path}.rb")
 end
 
 def lexer_dir(path = '')
   File.join(Rouge::LIB_DIR, 'rouge/lexers', path)
 end
 
-load rouge_relative 'version'
-load rouge_relative 'util'
-load rouge_relative 'text_analyzer'
-load rouge_relative 'token'
+load_relative 'rouge/version'
+load_relative 'rouge/util'
+load_relative 'rouge/text_analyzer'
+load_relative 'rouge/token'
 
-load rouge_relative 'lexer'
-load rouge_relative 'regex_lexer'
-load rouge_relative 'template_lexer'
+load_relative 'rouge/lexer'
+load_relative 'rouge/regex_lexer'
+load_relative 'rouge/template_lexer'
 
 Dir.glob(lexer_dir('*rb')).each { |f| Rouge::Lexers.load_lexer(f.sub(lexer_dir, '')) }
 
-load rouge_relative 'guesser'
-load rouge_relative 'guessers/util'
-load rouge_relative 'guessers/glob_mapping'
-load rouge_relative 'guessers/modeline'
-load rouge_relative 'guessers/filename'
-load rouge_relative 'guessers/mimetype'
-load rouge_relative 'guessers/source'
-load rouge_relative 'guessers/disambiguation'
+load_relative 'rouge/guesser'
+load_relative 'rouge/guessers/util'
+load_relative 'rouge/guessers/glob_mapping'
+load_relative 'rouge/guessers/modeline'
+load_relative 'rouge/guessers/filename'
+load_relative 'rouge/guessers/mimetype'
+load_relative 'rouge/guessers/source'
+load_relative 'rouge/guessers/disambiguation'
 
-load rouge_relative 'formatter'
-load rouge_relative 'formatters/html'
-load rouge_relative 'formatters/html_table'
-load rouge_relative 'formatters/html_pygments'
-load rouge_relative 'formatters/html_legacy'
-load rouge_relative 'formatters/html_linewise'
-load rouge_relative 'formatters/html_line_table'
-load rouge_relative 'formatters/html_inline'
-load rouge_relative 'formatters/terminal256'
-load rouge_relative 'formatters/terminal_truecolor'
-load rouge_relative 'formatters/tex'
-load rouge_relative 'formatters/null'
+load_relative 'rouge/formatter'
+load_relative 'rouge/formatters/html'
+load_relative 'rouge/formatters/html_table'
+load_relative 'rouge/formatters/html_pygments'
+load_relative 'rouge/formatters/html_legacy'
+load_relative 'rouge/formatters/html_linewise'
+load_relative 'rouge/formatters/html_line_table'
+load_relative 'rouge/formatters/html_inline'
+load_relative 'rouge/formatters/terminal256'
+load_relative 'rouge/formatters/terminal_truecolor'
+load_relative 'rouge/formatters/tex'
+load_relative 'rouge/formatters/null'
 
-load rouge_relative 'theme'
-load rouge_relative 'tex_theme_renderer'
-load rouge_relative 'themes/thankful_eyes'
-load rouge_relative 'themes/colorful'
-load rouge_relative 'themes/base16'
-load rouge_relative 'themes/github'
-load rouge_relative 'themes/igor_pro'
-load rouge_relative 'themes/monokai'
-load rouge_relative 'themes/molokai'
-load rouge_relative 'themes/monokai_sublime'
-load rouge_relative 'themes/gruvbox'
-load rouge_relative 'themes/tulip'
-load rouge_relative 'themes/pastie'
-load rouge_relative 'themes/bw'
-load rouge_relative 'themes/magritte'
+load_relative 'rouge/theme'
+load_relative 'rouge/tex_theme_renderer'
+load_relative 'rouge/themes/thankful_eyes'
+load_relative 'rouge/themes/colorful'
+load_relative 'rouge/themes/base16'
+load_relative 'rouge/themes/github'
+load_relative 'rouge/themes/igor_pro'
+load_relative 'rouge/themes/monokai'
+load_relative 'rouge/themes/molokai'
+load_relative 'rouge/themes/monokai_sublime'
+load_relative 'rouge/themes/gruvbox'
+load_relative 'rouge/themes/tulip'
+load_relative 'rouge/themes/pastie'
+load_relative 'rouge/themes/bw'
+load_relative 'rouge/themes/magritte'

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -6,6 +6,10 @@ require 'pathname'
 
 # The containing module for Rouge
 module Rouge
+  # cache value in a constant since `__dir__` allocates a new string
+  # on every call.
+  LIB_DIR = __dir__.freeze
+
   class << self
     def reload!
       Object.send :remove_const, :Rouge
@@ -34,60 +38,59 @@ module Rouge
   end
 end
 
-# mimic Kernel#require_relative API
-def load_relative(path)
-  load File.join(__dir__, "#{path}.rb")
+def rouge_relative(path)
+  File.join(Rouge::LIB_DIR, "rouge/#{path}.rb")
 end
 
 def lexer_dir(path = '')
-  File.join(__dir__, 'rouge', 'lexers', path)
+  File.join(Rouge::LIB_DIR, 'rouge/lexers', path)
 end
 
-load_relative 'rouge/version'
-load_relative 'rouge/util'
-load_relative 'rouge/text_analyzer'
-load_relative 'rouge/token'
+load rouge_relative 'version'
+load rouge_relative 'util'
+load rouge_relative 'text_analyzer'
+load rouge_relative 'token'
 
-load_relative 'rouge/lexer'
-load_relative 'rouge/regex_lexer'
-load_relative 'rouge/template_lexer'
+load rouge_relative 'lexer'
+load rouge_relative 'regex_lexer'
+load rouge_relative 'template_lexer'
 
 Dir.glob(lexer_dir('*rb')).each { |f| Rouge::Lexers.load_lexer(f.sub(lexer_dir, '')) }
 
-load_relative 'rouge/guesser'
-load_relative 'rouge/guessers/util'
-load_relative 'rouge/guessers/glob_mapping'
-load_relative 'rouge/guessers/modeline'
-load_relative 'rouge/guessers/filename'
-load_relative 'rouge/guessers/mimetype'
-load_relative 'rouge/guessers/source'
-load_relative 'rouge/guessers/disambiguation'
+load rouge_relative 'guesser'
+load rouge_relative 'guessers/util'
+load rouge_relative 'guessers/glob_mapping'
+load rouge_relative 'guessers/modeline'
+load rouge_relative 'guessers/filename'
+load rouge_relative 'guessers/mimetype'
+load rouge_relative 'guessers/source'
+load rouge_relative 'guessers/disambiguation'
 
-load_relative 'rouge/formatter'
-load_relative 'rouge/formatters/html'
-load_relative 'rouge/formatters/html_table'
-load_relative 'rouge/formatters/html_pygments'
-load_relative 'rouge/formatters/html_legacy'
-load_relative 'rouge/formatters/html_linewise'
-load_relative 'rouge/formatters/html_line_table'
-load_relative 'rouge/formatters/html_inline'
-load_relative 'rouge/formatters/terminal256'
-load_relative 'rouge/formatters/terminal_truecolor'
-load_relative 'rouge/formatters/tex'
-load_relative 'rouge/formatters/null'
+load rouge_relative 'formatter'
+load rouge_relative 'formatters/html'
+load rouge_relative 'formatters/html_table'
+load rouge_relative 'formatters/html_pygments'
+load rouge_relative 'formatters/html_legacy'
+load rouge_relative 'formatters/html_linewise'
+load rouge_relative 'formatters/html_line_table'
+load rouge_relative 'formatters/html_inline'
+load rouge_relative 'formatters/terminal256'
+load rouge_relative 'formatters/terminal_truecolor'
+load rouge_relative 'formatters/tex'
+load rouge_relative 'formatters/null'
 
-load_relative 'rouge/theme'
-load_relative 'rouge/tex_theme_renderer'
-load_relative 'rouge/themes/thankful_eyes'
-load_relative 'rouge/themes/colorful'
-load_relative 'rouge/themes/base16'
-load_relative 'rouge/themes/github'
-load_relative 'rouge/themes/igor_pro'
-load_relative 'rouge/themes/monokai'
-load_relative 'rouge/themes/molokai'
-load_relative 'rouge/themes/monokai_sublime'
-load_relative 'rouge/themes/gruvbox'
-load_relative 'rouge/themes/tulip'
-load_relative 'rouge/themes/pastie'
-load_relative 'rouge/themes/bw'
-load_relative 'rouge/themes/magritte'
+load rouge_relative 'theme'
+load rouge_relative 'tex_theme_renderer'
+load rouge_relative 'themes/thankful_eyes'
+load rouge_relative 'themes/colorful'
+load rouge_relative 'themes/base16'
+load rouge_relative 'themes/github'
+load rouge_relative 'themes/igor_pro'
+load rouge_relative 'themes/monokai'
+load rouge_relative 'themes/molokai'
+load rouge_relative 'themes/monokai_sublime'
+load rouge_relative 'themes/gruvbox'
+load rouge_relative 'themes/tulip'
+load rouge_relative 'themes/pastie'
+load rouge_relative 'themes/bw'
+load rouge_relative 'themes/magritte'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -505,12 +505,13 @@ module Rouge
   end
 
   module Lexers
+    BASE_DIR = "#{__dir__}/lexers".freeze
     @_loaded_lexers = {}
 
     def self.load_lexer(relpath)
       return if @_loaded_lexers.key?(relpath)
       @_loaded_lexers[relpath] = true
-      load File.join(__dir__, 'lexers', relpath)
+      load File.join(BASE_DIR, relpath)
     end
   end
 end

--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -15,7 +15,7 @@ module Rouge
         attr_reader :keywords
       end
       # Load Apache keywords from separate YML file
-      @keywords = ::YAML.load_file(File.join(__dir__, 'apache/keywords.yml')).tap do |h|
+      @keywords = ::YAML.load_file(File.join(Lexers::BASE_DIR, 'apache/keywords.yml')).tap do |h|
         h.each do |k,v|
           h[k] = Set.new v
         end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -19,7 +19,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load File.join(__dir__, 'gherkin/keywords.rb')
+        load File.join(Lexers::BASE_DIR, 'gherkin/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/isbl.rb
+++ b/lib/rouge/lexers/isbl.rb
@@ -10,7 +10,7 @@ module Rouge
       filenames '*.isbl'
 
       def self.builtins
-        load File.join(__dir__, 'isbl/builtins.rb')
+        load File.join(Lexers::BASE_DIR, 'isbl/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -39,7 +39,7 @@ module Rouge
       end
 
       # Load Lasso keywords from separate YML file
-      @keywords = ::YAML.load_file(File.join(__dir__, 'lasso/keywords.yml')).tap do |h|
+      @keywords = ::YAML.load_file(File.join(Lexers::BASE_DIR, 'lasso/keywords.yml')).tap do |h|
         h.each do |k,v|
           h[k] = Set.new v
         end

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -25,7 +25,7 @@ module Rouge
       end
 
       def self.builtins
-        load File.join(__dir__, 'lua/builtins.rb')
+        load File.join(Lexers::BASE_DIR, 'lua/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -56,7 +56,7 @@ module Rouge
 
       # The list of built-in symbols comes from a wolfram server and is created automatically by rake
       def self.builtins
-        load File.join(__dir__, 'mathematica/builtins.rb')
+        load File.join(Lexers::BASE_DIR, 'mathematica/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -20,7 +20,7 @@ module Rouge
 
       def self.builtins
         # Load Matlab keywords from separate YML file
-        @builtins ||= ::YAML.load_file(File.join(__dir__, 'matlab/builtins.yml')).tap do |a|
+        @builtins ||= ::YAML.load_file(File.join(Lexers::BASE_DIR, 'matlab/builtins.yml')).tap do |a|
           Set.new a
         end
       end

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -29,7 +29,7 @@ module Rouge
       end
 
       def self.builtins
-        load File.join(__dir__, 'php/builtins.rb')
+        load File.join(Lexers::BASE_DIR, 'php/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/sqf.rb
+++ b/lib/rouge/lexers/sqf.rb
@@ -55,7 +55,7 @@ module Rouge
       end
 
       def self.commands
-        load File.join(__dir__, "sqf/commands.rb")
+        load File.join(Lexers::BASE_DIR, "sqf/commands.rb")
         @commands = self.commands
       end
 

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -14,7 +14,7 @@ module Rouge
       mimetypes 'text/x-vim'
 
       def self.keywords
-        load File.join(__dir__, 'viml/keywords.rb')
+        load File.join(Lexers::BASE_DIR, 'viml/keywords.rb')
         self.keywords
       end
 


### PR DESCRIPTION
`__dir__` allocates a new string on each call. Using this method in string interpolation
 (`"#{__dir__}/...."`) or path based methods (`File.join(__dir__, ....)`, etc) results in duplication of the newly generated string.
This allocation can be *reduced* by stashing the value in frozen module / class constants.