### PR TITLE
Update latest Ruby checked by Travis to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - "2.3"
   - "2.4"
   - "2.5"
-  - &latest_ruby "2.6"
+  - "2.6"
+  - &latest_ruby "2.7"
 cache:
   bundler: true
 bundler_args: --without development


### PR DESCRIPTION
Ruby 2.7.0 was released on 25 December 2019. This adds 2.7.0 to the list of Rubies checked by Travis as part of Rouge's continuous integration testing.