### PR TITLE
Fix implementation of `Lexer.detectable?`

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -209,7 +209,8 @@ module Rouge
       # Determine if a lexer has a method named +:detect?+ defined in its
       # singleton class.
       def detectable?
-        @detectable ||= methods(false).include?(:detect?)
+        return @detectable if defined?(@detectable)
+        @detectable = singleton_methods(false).include?(:detect?)
       end
 
     protected


### PR DESCRIPTION
This fixes the existing memoization implemented in `Lexer.detectable?`.
Memoizing with `||=` is negated when the computed result equals `false`. Instead, check if the singleton instance variable is defined and if so, return its value. Otherwise, proceed to compute and store result in the instance variable.

*An additional change is replacing `methods(false)` with `singleton_methods(false)`. For a singleton class, the two calls are equivalent and using the latter expresses intent better.*