### PR TITLE
Fix array access priority in PowerShell lexer

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -201,8 +201,13 @@ module Rouge
         rule %r/(?:#{KEYWORDS})\b(?![-.])/i, Keyword::Reserved
 
         rule %r/-{1,2}\w+/, Name::Tag
+        
+        rule %r/(\.)?([-\w]+)(\[)/ do |m|
+          groups Operator, Name::Function, Punctuation
+          push :bracket
+        end
 
-        rule %r/([\/\\~\w][-.:\/\\~\w]*)(\n)?/ do |m|
+        rule %r/([\/\\~\w][-.:\/\\~\w]*)(\[)?(\n)?/ do |m|
           groups Name::Function, Text::Whitespace
           push :parameters unless m[2]
         end

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -207,7 +207,7 @@ module Rouge
           push :bracket
         end
 
-        rule %r/([\/\\~\w][-.:\/\\~\w]*)(\[)?(\n)?/ do |m|
+        rule %r/([\/\\~\w][-.:\/\\~\w]*)(\n)?/ do |m|
           groups Name::Function, Text::Whitespace
           push :parameters unless m[2]
         end

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -187,3 +187,9 @@ Function Get-IPv4Scopes
     }
 
 } #end function
+
+# Without Error
+$gitUserName = "$($userAdObject.Properties['sn']), $($userAdObject.Properties['givenName'])"
+
+# With Error
+$gitExeString = "$gitExeFolder\git.exe" &("$gitExeString") config --add --global user.name `"$gitUserName`"


### PR DESCRIPTION
The PowerShell lexer expects the text `.identifier` to be followed by parameters. This is not always the case as in the case where the text is `.identifier['key']`. This creates a new rule for handling this case.

This fixes #1407.