### PR TITLE
Update GitHub Issues settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/lexer-bug.md
+++ b/.github/ISSUE_TEMPLATE/lexer-bug.md
@@ -17,8 +17,9 @@ A sample of the code that produces the bug.
 <insert code>
 ```
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+It also helps if you can provide a link to a code sample on [rouge.jneen.net][dingus].
 
 **Additional context**
 Add any other context about the problem here.
+
+[dingus]: http://rouge.jneen.net/

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,8 +4,9 @@ daysUntilStale: 365
 daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - security
+  - lexer-request
   - pr-open
+  - security
 # Label to use when marking an issue as stale
 staleLabel: stale-issue
 # Comment to post when marking an issue as stale. Set to `false` to disable
@@ -13,7 +14,7 @@ markComment: >
   This issue has been automatically marked as stale because it has not
   had any activity for more than a year. It will be closed if no additional
   activity occurs within the next 14 days.
-   
+
   If you would like this issue to remain open, please reply and let us know if
   the issue is still reproducible.
 # Comment to post when closing a stale issue. Set to `false` to disable


### PR DESCRIPTION
This PR updates two settings relating to Rouge's Issues section. First, it prevents issues marked with the `lexer-request` tag from being marked as stale. Second, it suggests a user filing a lexer bug include a link to the code sample on [rouge.jneen.net](http://rouge.jneen.net).