### PR TITLE
Fix symbol pattern in Scala lexer

### DIFF
--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -40,7 +40,7 @@ module Rouge
           groups Keyword, Text
           push :class
         end
-        rule %r/'#{idrest}[^']/, Str::Symbol
+        rule %r/'#{idrest}(?!')/, Str::Symbol
         rule %r/[^\S\n]+/, Text
 
         rule %r(//.*), Comment::Single

--- a/spec/visual/samples/scala
+++ b/spec/visual/samples/scala
@@ -64,4 +64,8 @@ class why_would_you_name_a_class_this_way_oh_well_we_need_to_highlight_it(a: Int
   def hex = 0x123
 }
 
+StorageState.table(StorageState.NewUsers()).format(
+  keyParams('app_id).asInstanceOf[String]
+)
+
 // Comment at EOF


### PR DESCRIPTION
The Scala lexer currently matches 'symbols' by ensuring that the last character in the match is not a `'`.

The problem with this approach is that if the symbol occurs within a lexical structure (e.g. parentheses), the first character after the symbol (e.g. the closing parenthesis) would be matched as part of the symbol.

This PR uses the approach of a negative lookahead to avoid this problem.

This fixes #374.