### PR TITLE
Add jsonc alias to JSONDOC lexer

### DIFF
--- a/lib/rouge/lexers/json_doc.rb
+++ b/lib/rouge/lexers/json_doc.rb
@@ -8,6 +8,7 @@ module Rouge
     class JSONDOC < JSON
       desc "JavaScript Object Notation with extensions for documentation"
       tag 'json-doc'
+      aliases 'jsonc'
 
       prepend :name do
         rule %r/([$\w]+)(\s*)(:)/ do


### PR DESCRIPTION
GitHub supports the use of the `jsonc` info string to permit comments in JSON. The Rouge JSONDOC lexer provides a lexer that would lex this correctly but which does not support the use of `jsonc` as an alias. This PR adds that alias.

This fixes #1028.