### PR TITLE
Improve regex and string lexing in CoffeeScript lexer

### DIFF
--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -49,17 +49,21 @@ module Rouge
 
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/
 
-      state :comments_and_whitespace do
-        rule %r/\s+/m, Text
+      state :comments do
         rule %r/###[^#].*?###/m, Comment::Multiline
         rule %r/#.*$/, Comment::Single
+      end
+
+      state :whitespace do
+        rule %r/\s+/m, Text
       end
 
       state :multiline_regex do
         # this order is important, so that #{ isn't interpreted
         # as a comment
         mixin :has_interpolation
-        mixin :comments_and_whitespace
+        mixin :comments
+        mixin :whitespace
 
         rule %r(///([gim]+\b|\B)), Str::Regex, :pop!
         rule %r(/), Str::Regex
@@ -67,7 +71,8 @@ module Rouge
       end
 
       state :slash_starts_regex do
-        mixin :comments_and_whitespace
+        mixin :comments
+        mixin :whitespace
         rule %r(///) do
           token Str::Regex
           goto :multiline_regex
@@ -83,7 +88,8 @@ module Rouge
 
       state :root do
         rule(%r(^(?=\s|/|<!--))) { push :slash_starts_regex }
-        mixin :comments_and_whitespace
+        mixin :comments
+        mixin :whitespace
         rule %r(
           [+][+]|--|~|&&|\band\b|\bor\b|\bis\b|\bisnt\b|\bnot\b|\bin\b|\bof\b|
           [?]|:|=|[|][|]|\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*`%&|^/])=?

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -163,7 +163,7 @@ module Rouge
       state :strings do
         # all coffeescript strings are multi-line
         rule %r/[^#\\'"]+/m, Str
-
+        mixin :code_escape
         rule %r/\\./, Str::Escape
         rule %r/#/, Str
       end

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -59,8 +59,8 @@ module Rouge
       end
 
       state :regex_comment do
-        rule /^#(?!\{).*$/, Comment::Single
-        rule /(\s+)(#(?!\{).*)$/ do
+        rule %r/^#(?!\{).*$/, Comment::Single
+        rule %r/(\s+)(#(?!\{).*)$/ do
           groups Text, Comment::Single
         end
       end
@@ -106,8 +106,6 @@ module Rouge
         rule(%r(^(?=\s|/|<!--))) { push :slash_starts_regex }
         mixin :comments
         mixin :whitespace
-
-        rule /#{id}(?=\s*:)/, Name::Attribute
 
         rule %r(
           [+][+]|--|~|&&|\band\b|\bor\b|\bis\b|\bisnt\b|\bnot\b|\bin\b|\bof\b|

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -106,6 +106,9 @@ module Rouge
         rule(%r(^(?=\s|/|<!--))) { push :slash_starts_regex }
         mixin :comments
         mixin :whitespace
+
+        rule /#{id}(?=\s*:)/, Name::Attribute
+
         rule %r(
           [+][+]|--|~|&&|\band\b|\bor\b|\bis\b|\bisnt\b|\bnot\b|\bin\b|\bof\b|
           [?]|:|=|[|][|]|\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*`%&|^/])=?


### PR DESCRIPTION
This PR contains changes to the CoffeeScript lexer that were originally submitted as part of #650. As discussed in that PR, the CoffeeScript changes are independent of the addition of a LiveScript lexer and so are submitted separately here.

The changes concern improvements to the lexing of regular expressions and strings (in particular the way that escaping is handled).