### PR TITLE
Fix fenced code blocks in Markdown lexer

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -32,7 +32,7 @@ module Rouge
         rule %r/^#(?=[^#]).*?$/, Generic::Heading
         rule %r/^##*.*?$/, Generic::Subheading
 
-        rule %r/^([ \t]*)(`{3,}|~{3,})([^\n]*\n)((.*?)(\n)(\2))?/m do |m|
+        rule %r/^([ \t]*)(`{3,}|~{3,})([^\n]*\n)((.*?)(\n\1)(\2))?/m do |m|
           name = m[3].strip
           sublexer =
             begin

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -32,7 +32,7 @@ module Rouge
         rule %r/^#(?=[^#]).*?$/, Generic::Heading
         rule %r/^##*.*?$/, Generic::Subheading
 
-        rule %r/^([ \t]*)(```|~~~)([^\n]*\n)((.*?)(\2))?/m do |m|
+        rule %r/^([ \t]*)(`{3,}|~{3,})([^\n]*\n)((.*?)(\n)(\2))?/m do |m|
           name = m[3].strip
           sublexer =
             begin
@@ -51,8 +51,10 @@ module Rouge
             delegate sublexer, m[5]
           end
 
-          if m[6]
-            token Punctuation, m[6]
+          token Text, m[6]
+
+          if m[7]
+            token Punctuation, m[7]
           else
             push do
               rule %r/^([ \t]*)(#{m[2]})/ do |mb|

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1074,3 +1074,7 @@ can't highlight me
 ``` json
 "a string": "with a triple backtick: ```"
 ```
+
+```` console
+$ hello "world"
+````


### PR DESCRIPTION
Many flavours of Markdown permit fenced code blocks. These blocks may begin with three or more `` ` `` or `~`. The current implementation only permits three. This PR fixes that.

The PR also fixes a bug in code blocks that would match the closing fence even if it occurred within code in the block.

It fixes #1439.