### PR TITLE
Fix brackets in links in markdown lexer

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -102,7 +102,7 @@ module Rouge
         end
 
         # links and images
-        rule %r/(!?\[)(#{edot}*?)(\])/ do
+        rule %r/(!?\[)(#{edot}*?)(\])(?=[ \t]*[\[(])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end
@@ -117,7 +117,6 @@ module Rouge
         rule %r/<.*?@.+[.].+>/, Name::Variable
         rule %r[<(https?|mailto|ftp)://#{edot}*?>], Name::Variable
 
-
         rule %r/[^\\`\[*\n&<]+/, Text
 
         # inline html
@@ -125,11 +124,14 @@ module Rouge
         rule(/<#{edot}*?>/) { delegate html }
         rule %r/[&<]/, Text
 
+        # An opening square bracket that is not a link
+        rule %r/\[/, Text
+
         rule %r/\n/, Text
       end
 
       state :link do
-        rule %r/(\[)(#{edot}*?)(?=\][\[(])/ do
+        rule %r/(\[)(#{edot}*?)(\])/ do
           groups Punctuation, Str::Symbol, Punctuation
           pop!
         end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -102,7 +102,7 @@ module Rouge
         end
 
         # links and images
-        rule %r/(!?\[)(#{edot}*?)(\])(?=[ \t]*[\[(])/ do
+        rule %r/(!?\[)(#{edot}*?)(\])(?=[\[(])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -129,7 +129,7 @@ module Rouge
       end
 
       state :link do
-        rule %r/(\[)(#{edot}*?)(\])/ do
+        rule %r/(\[)(#{edot}*?)(?=\][\[(])/ do
           groups Punctuation, Str::Symbol, Punctuation
           pop!
         end

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1078,3 +1078,15 @@ can't highlight me
 ```` console
 $ hello "world"
 ````
+
+````markdown
+Here is an example of [feature](../feature.md):
+
+```console
+$ echo "Sample feature output"
+```
+````
+
+[This is a link `with backticks`](example.com)
+[This is a link to a TOML section `[with brackets]` (and backticks)](example.com)
+[This is a link to a TOML section `[[with double brackets]]` (and backticks)](example.com)

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1090,3 +1090,4 @@ $ echo "Sample feature output"
 [This is a link `with backticks`](example.com)
 [This is a link to a TOML section `[with brackets]` (and backticks)](example.com)
 [This is a link to a TOML section `[[with double brackets]]` (and backticks)](example.com)
+[This is not a link `with backticks`] (example.com)


### PR DESCRIPTION
When hiding brackets inside links with backticks, rendering
was breaking. This makes the lexer search for `][` or `](`
to find the end delimiting the link text.

This fixes #1444. 