### PR TITLE
Fix parenthesis after links in markdown lexer

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -136,10 +136,9 @@ module Rouge
           pop!
         end
 
-        rule %r/[(]/ do
-          token Punctuation
-          push :inline_title
-          push :inline_url
+        rule %r/(\()(#{edot}*?)(\))/ do
+          groups Punctuation, Str::Other, Punctuation
+          pop!
         end
 
         rule %r/[ \t]+/, Text
@@ -167,16 +166,6 @@ module Rouge
         rule(//) { pop! }
       end
 
-      state :inline_title do
-        rule %r/[)]/, Punctuation, :pop!
-        mixin :title
-      end
-
-      state :inline_url do
-        rule %r/[^<\s)]+/, Str::Other, :pop!
-        rule %r/\s+/m, Text
-        mixin :url
-      end
     end
   end
 end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -94,15 +94,15 @@ module Rouge
           (\s*) # leading whitespace
           (\[) (#{edot}+?) (\]) # the reference
           (\s*) (:) # colon
+          (\s*) # trailing whitespace
         )x do
-          groups Text, Punctuation, Str::Symbol, Punctuation, Text, Punctuation
-
-          push :title
+          groups Text, Punctuation, Str::Symbol, Punctuation, Text, Punctuation, Text
+          push :ref
           push :url
         end
 
         # links and images
-        rule %r/(!?\[)(#{edot}*?|[^\]]*?)(\])(?=[\[(])/ do
+        rule %r/(!?\[)((?:\\.|[^\\\]]|`.*?`)*?)(\])(?=[\[(])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end
@@ -130,42 +130,57 @@ module Rouge
         rule %r/\n/, Text
       end
 
+      state :ref do
+        rule %r/\s+(?=["'(])/ do
+          token Text
+          goto :title
+        end
+
+        rule(//) { pop! }
+      end
+
       state :link do
         rule %r/(\[)(#{edot}*?)(\])/ do
           groups Punctuation, Str::Symbol, Punctuation
           pop!
         end
 
-        rule %r/(\()(#{edot}*?)(\))/ do
-          groups Punctuation, Str::Other, Punctuation
-          pop!
-        end
+        rule %r/[(]/, Punctuation, :url
+        rule %r/[)]/, Punctuation, :pop!
 
-        rule %r/[ \t]+/, Text
+        rule %r/[ \t]+/, Text, :title
 
         rule(//) { pop! }
       end
 
       state :url do
-        rule %r/[ \t]+/, Text
-
-        # the url
         rule %r/(<)(#{edot}*?)(>)/ do
           groups Name::Tag, Str::Other, Name::Tag
-          pop!
         end
 
-        rule %r/\S+/, Str::Other, :pop!
-      end
+        rule %r/[^\s()]+/, Str::Other
+        rule %r/[(]/, Str::Other, :url
 
-      state :title do
-        rule %r/"#{edot}*?"/, Name::Namespace
-        rule %r/'#{edot}*?'/, Name::Namespace
-        rule %r/[(]#{edot}*?[)]/, Name::Namespace
-        rule %r/\s*(?=["'()])/, Text
+        rule %r/[)]/ do |m|
+          pop!
+          if state?(:link)
+            token Punctuation
+            pop!
+          else
+            token Str::Other
+          end
+        end
+
         rule(//) { pop! }
       end
 
+      state :title do
+        rule %r/"#{edot}*?"/, Name::Namespace, :pop!
+        rule %r/'#{edot}*?'/, Name::Namespace, :pop!
+        rule %r/[(]#{edot}*?[)]/, Name::Namespace, :pop!
+        # rule %r/\s*(?=["'()])/, Text
+        rule(//) { pop! }
+      end
     end
   end
 end

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1103,7 +1103,7 @@ link]
 
 [This link is followed by text in](example.com) (parentheses)
 [This link is followed by text in](example.com) (paren theses)
-[This link is followed by text in](example.com) paren (theses)
+[This link is followed by text in](example.com "Title text") paren (theses)
 
 [This link is referenced][exampleref]
 

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1090,6 +1090,7 @@ $ echo "Sample feature output"
 [This is a link `with backticks`](example.com)
 [This is a link to a TOML section `[with brackets]` (and backticks)](example.com)
 [This is a link to a TOML section `[[with double brackets]]` (and backticks)](example.com)
+
 [This is not a link `with backticks`] (example.com)
 
 This link has text before it, [it's over two (lines),
@@ -1097,3 +1098,13 @@ has (parens too)](example.com), and text after it.
 
 [this is not a
 link]
+
+[This is not a link] (example.com)
+
+[This link is followed by text in](example.com) (parentheses)
+[This link is followed by text in](example.com) (paren theses)
+[This link is followed by text in](example.com) paren (theses)
+
+[This link is referenced][exampleref]
+
+[exampleref]: http://example.com


### PR DESCRIPTION
Fixes #1448 

Currently, there is an odd edge case where a link followed by an open parenthesis triggers incorrect coloring: the last text should be uncolored, it's plaintext. (You can ignore the reference link in the screenshot, I was just making sure the code coloring was properly "different" for regular and referenced links):

<img width="526" alt="Screen Shot 2020-03-04 at 14 59 57" src="https://user-images.githubusercontent.com/36979740/75849756-00e68980-5e29-11ea-9dcf-f2ab947c5a96.png">

When looking at the code, I couldn't understand why it was done as:

```ruby
token Punctuation
push :inline_title
push :inline_url
```

It seemed to make sense to just do it the same as for link references:

```ruby
rule %r/(\()(#{edot}*?)(\))/ do
  groups Punctuation, Str::Other, Punctuation
  pop!
end
```

and remove `inline_title` and `inline_url`. When removed, everything seemed to work as expected:

<img width="526" alt="Screen Shot 2020-03-04 at 14 59 02" src="https://user-images.githubusercontent.com/36979740/75849934-6dfa1f00-5e29-11ea-8212-607ff36bf0fb.png">


@pyrmont Could you take a look? I couldn't find any failures in the markdown sample file, but I might not be considering all the possibilities.