### PR TITLE
fix number literals in the Ruby lexer

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -170,8 +170,11 @@ module Rouge
         rule %r/0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule %r/0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
         rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
-        rule %r/\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
-        rule %r/[\d]+(?:_\d+)*/, Num::Integer
+
+        decimal = %r/[\d]+(?:_\d+)*/
+        exp = %r/e[\+\-]?\d+/i
+        rule %r/#{decimal}(?:\.#{decimal}#{exp}?|#{exp})/, Num::Float
+        rule decimal, Num::Integer
 
         # names
         rule %r/@@[a-z_]\w*/i, Name::Variable::Class

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -172,7 +172,7 @@ module Rouge
         rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
 
         decimal = %r/[\d]+(?:_\d+)*/
-        exp = %r/e[\+\-]?\d+/i
+        exp = %r/e[+-]?\d+/i
         rule %r/#{decimal}(?:\.#{decimal}#{exp}?|#{exp})/, Num::Float
         rule decimal, Num::Integer
 

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -84,6 +84,9 @@ end
 
 # It appears in Floats
 2.3
+1.2e3
+1e23
+1_2.3_4e5
 
 # It appears in Range
 1..10


### PR DESCRIPTION
Fix a problem that the following number literals are not tokenized properly:

* `1e23`
* `1_2.3_4`

I think we'd better add the common utility for such common-but-complex tokens.