### PR TITLE
Revert Rubocop splat expansion cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Lint/EndAlignment:
 Lint/EmptyWhen:
   Enabled: false
 
-Lint/RedundantSplatExpansion:
+Lint/UnneededSplatExpansion:
   Enabled: false
 
 Lint/IneffectiveAccessModifier:


### PR DESCRIPTION
This PR reverses the change made in #1451. The problem is support for versions of Ruby prior to v2.3. RuboCop ended support for these versions with RuboCop v0.50 but Rouge has not. (The renamed cop was not introduced until [RuboCop v0.76](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintredundantsplatexpansion).) Dropping support for older versions of Ruby may be implemented as part of Rouge v4.0 but it won't occur as part of v3.0. 