### PR TITLE
Enable multi-line links in Markdown

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -102,7 +102,7 @@ module Rouge
         end
 
         # links and images
-        rule %r/(!?\[)(#{edot}*?)(\])(?=[\[(])/ do
+        rule %r/(!?\[)(#{edot}*?|[^\]]*?)(\])(?=( ?\[|\())/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -102,7 +102,7 @@ module Rouge
         end
 
         # links and images
-        rule %r/(!?\[)(#{edot}*?|[^\]]*?)(\])(?=( ?\[|\())/ do
+        rule %r/(!?\[)(#{edot}*?|[^\]]*?)(\])(?=[\[(])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1097,8 +1097,3 @@ has (parens too)](example.com), and text after it.
 
 [this is not a
 link]
-
-[this is a link
-split over two lines] [link ref]
-
-[link ref]: example.com

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1091,3 +1091,14 @@ $ echo "Sample feature output"
 [This is a link to a TOML section `[with brackets]` (and backticks)](example.com)
 [This is a link to a TOML section `[[with double brackets]]` (and backticks)](example.com)
 [This is not a link `with backticks`] (example.com)
+
+This link has text before it, [it's over two (lines),
+has (parens too)](example.com), and text after it.
+
+[this is not a
+link]
+
+[this is a link
+split over two lines] [link ref]
+
+[link ref]: example.com


### PR DESCRIPTION
Fixes #1450 

The markdown standard allows for link text split over multiple lines. This expands the
link regex to enable this.

~~While I was there, I also allowed for a space between links and link references as well, which is allowed in the spec, and added an example to the markdown test for that as well.~~ Edit: Reverted this change, as per discussion.

When tested with `rackup`:

<img width="660" alt="Screen Shot 2020-03-18 at 16 20 50" src="https://user-images.githubusercontent.com/36979740/76935472-82afda00-6934-11ea-9193-94a2489e3fa5.png">

cc @pyrmont 
