### PR TITLE
Added lpr filename

### DIFF
--- a/lib/rouge/lexers/pascal.rb
+++ b/lib/rouge/lexers/pascal.rb
@@ -7,7 +7,7 @@ module Rouge
       tag 'pascal'
       title "Pascal"
       desc 'a procedural programming language commonly used as a teaching language.'
-      filenames '*.pas'
+      filenames '*.pas', '*.lpr'
 
       mimetypes 'text/x-pascal'
 

--- a/spec/lexers/pascal_spec.rb
+++ b/spec/lexers/pascal_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::Pascal do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.pas'
+      assert_guess :filename => 'foo.lpr'      
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
Added Lazarus Program file; contains Pascal source of main program.

As noted by original pull request #349 no other flavors of pascal get syntax highlighted.

#500 shows one can use `.gitattributes` to select the language. But Lazarus is relatively popular and there is a bunch of gitlab repo with `.lpr` ext that is not getting highlighted.

If I should be rather raising this issue on gitlab please let me know where.

Thanks,