### PR TITLE
rego file parser

### DIFF
--- a/lib/rouge/demos/rego
+++ b/lib/rouge/demos/rego
@@ -1,0 +1,27 @@
+package httpapi.authz
+
+subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie"]}
+
+# HTTP API request
+import input
+# input = {
+#   "path": ["finance", "salary", "alice"],
+#   "user": "alice",
+#   "method": "GET"
+# }
+
+default allow = false
+
+# Allow users to get their own salaries.
+allow {
+  input.method = "GET"
+  input.path = ["finance", "salary", username]
+  input.user == username
+}
+
+# Allow managers to get their subordinates' salaries.
+allow {
+  input.method = "GET"
+  input.path = ["finance", "salary", username]
+  subordinates[input.user][_] == username
+}

--- a/lib/rouge/demos/rego
+++ b/lib/rouge/demos/rego
@@ -1,5 +1,4 @@
 package httpapi.authz
-# taken from https://github.com/open-policy-agent/contrib/blob/f9e71d7/api_authz/docker/policy/api_authz.rego
 
 subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie"]}
 
@@ -7,10 +6,3 @@ subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie
 import input
 
 default allow = false
-
-# Allow users to get their own salaries.
-allow {
-  input.method = "GET"
-  input.path = ["finance", "salary", username]
-  input.user == username
-}

--- a/lib/rouge/demos/rego
+++ b/lib/rouge/demos/rego
@@ -1,14 +1,10 @@
 package httpapi.authz
+# taken from https://github.com/open-policy-agent/contrib/blob/f9e71d7/api_authz/docker/policy/api_authz.rego
 
 subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie"]}
 
 # HTTP API request
 import input
-# input = {
-#   "path": ["finance", "salary", "alice"],
-#   "user": "alice",
-#   "method": "GET"
-# }
 
 default allow = false
 
@@ -17,11 +13,4 @@ allow {
   input.method = "GET"
   input.path = ["finance", "salary", username]
   input.user == username
-}
-
-# Allow managers to get their subordinates' salaries.
-allow {
-  input.method = "GET"
-  input.path = ["finance", "salary", username]
-  subordinates[input.user][_] == username
 }

--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -27,7 +27,6 @@ module Rouge
             state :atoms do
               rule %r/(true|false|null)/, Keyword::Constant
               rule %r/[[:word:]]*/, Str::Symbol
-              rule %r/'[^']*'/, Str::Symbol
             end
       
             state :operators do

--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
-# example file taken from https://github.com/open-policy-agent/contrib/blob/f9e71d7/api_authz/docker/policy/api_authz.rego
 
 module Rouge
     module Lexers
@@ -8,7 +7,6 @@ module Rouge
             title "Rego"
             desc "The Rego open-policy-agent (OPA) policy language (openpolicyagent.org)"
             tag 'rego'
-            aliases 'rego'
             filenames '*.rego'
 
             state :basic do
@@ -35,7 +33,7 @@ module Rouge
             state :operators do
               rule %r/(=|!=|>=|<=|>|<|\+|-|\*|%|\/|\||&|:=)/, Operator
               rule %r/(default|not|package|import|as|with|else|some)/, Operator
-              rule %r/[#&*+-.\/:<=>?@^~]+/, Operator
+              rule %r/[\/:?@^~]+/, Operator
             end
       
             state :root do

--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -6,7 +6,7 @@ module Rouge
     module Lexers
         class Rego < RegexLexer
             title "Rego"
-            desc "The Rego open-policy-agent (OPA) policy language (https://www.openpolicyagent.org/)"
+            desc "The Rego open-policy-agent (OPA) policy language (openpolicyagent.org)"
             tag 'rego'
             aliases 'rego'
             filenames '*.rego'
@@ -23,7 +23,7 @@ module Rouge
               rule %r/-?\d+([eE][+-]?\d+)?/, Num
 
               rule %r/\\u[0-9a-fA-F]{4}/, Num::Hex
-              rule %r/\\["\/bfnrt]/, Str::Delimiter
+              rule %r/\\["\/bfnrt]/, Str::Escape
             end
       
             state :atoms do
@@ -33,7 +33,7 @@ module Rouge
             end
       
             state :operators do
-              rule %r/(=|!=|>|<|>=|<=|\+|-|\*|%|\/|\||&|:=)/, Operator
+              rule %r/(=|!=|>=|<=|>|<|\+|-|\*|%|\/|\||&|:=)/, Operator
               rule %r/(default|not|package|import|as|with|else|some)/, Operator
               rule %r/[#&*+-.\/:<=>?@^~]+/, Operator
             end

--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+# example file taken from https://github.com/open-policy-agent/contrib/blob/f9e71d7/api_authz/docker/policy/api_authz.rego
+
+module Rouge
+    module Lexers
+        class Rego < RegexLexer
+            title "Rego"
+            desc "The Rego open-policy-agent (OPA) policy language (https://www.openpolicyagent.org/)"
+            tag 'rego'
+            aliases 'rego'
+            filenames '*.rego'
+
+            state :basic do
+              rule %r/\s+/, Text
+              rule %r/#.*/, Comment::Single
+      
+              rule %r/[\[\](){}|.,;!]/, Punctuation
+      
+              rule %r/"[^"]*"/, Str::Double
+      
+              rule %r/-?\d+\.\d+([eE][+-]?\d+)?/, Num::Float
+              rule %r/-?\d+([eE][+-]?\d+)?/, Num
+
+              rule %r/\\u[0-9a-fA-F]{4}/, Num::Hex
+              rule %r/\\["\/bfnrt]/, Str::Delimiter
+            end
+      
+            state :atoms do
+              rule %r/(true|false|null)/, Keyword::Constant
+              rule %r/[[:word:]]*/, Str::Symbol
+              rule %r/'[^']*'/, Str::Symbol
+            end
+      
+            state :operators do
+              rule %r/(=|!=|>|<|>=|<=|\+|-|\*|%|\/|\||&|:=)/, Operator
+              rule %r/(default|not|package|import|as|with|else|some)/, Operator
+              rule %r/[#&*+-.\/:<=>?@^~]+/, Operator
+            end
+      
+            state :root do
+              mixin :basic
+              mixin :operators
+              mixin :atoms
+            end
+        end
+    end
+end

--- a/spec/lexers/rego_spec.rb
+++ b/spec/lexers/rego_spec.rb
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Rego do
+    let(:subject) { Rouge::Lexers::Rego.new }
+  
+    describe 'guessing' do
+      include Support::Guessing
+  
+      it 'guesses by filename' do
+        assert_guess :filename => 'foo.rego'
+      end
+    end
+end
+  

--- a/spec/visual/samples/rego
+++ b/spec/visual/samples/rego
@@ -1,0 +1,27 @@
+package httpapi.authz
+
+subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie"]}
+
+# HTTP API request
+import input
+# input = {
+#   "path": ["finance", "salary", "alice"],
+#   "user": "alice",
+#   "method": "GET"
+# }
+
+default allow = false
+
+# Allow users to get their own salaries.
+allow {
+  input.method = "GET"
+  input.path = ["finance", "salary", username]
+  input.user == username
+}
+
+# Allow managers to get their subordinates' salaries.
+allow {
+  input.method = "GET"
+  input.path = ["finance", "salary", username]
+  subordinates[input.user][_] == username
+}

--- a/spec/visual/samples/rego
+++ b/spec/visual/samples/rego
@@ -4,16 +4,18 @@ subordinates = {"alice": [], "charlie": [], "bob": ["alice"], "betty": ["charlie
 
 # HTTP API request
 import input
-# input = {
+# input = { # example input
 #   "path": ["finance", "salary", "alice"],
 #   "user": "alice",
 #   "method": "GET"
+#   "version": 1
 # }
 
 default allow = false
 
 # Allow users to get their own salaries.
 allow {
+  input.version = 1.0e1
   input.method = "GET"
   input.path = ["finance", "salary", username]
   input.user == username
@@ -21,6 +23,7 @@ allow {
 
 # Allow managers to get their subordinates' salaries.
 allow {
+  input.version = 1.0
   input.method = "GET"
   input.path = ["finance", "salary", username]
   subordinates[input.user][_] == username


### PR DESCRIPTION
* Add lexer for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego), which is a datalog-like language used to write policy files for authentication/authorization.
* Reference taken from the official [Rego.tmLanguage](https://github.com/open-policy-agent/vscode-opa/blob/master/syntaxes/Rego.tmLanguage) as well as the prolog lexer (very similar language). It's a pretty simple implementation!
* This will close #1435.