### PR TITLE
Fix tokenization of compact Ruby class names

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -309,6 +309,8 @@ module Rouge
 
       state :classname do
         rule %r/\s+/, Text
+        rule %r/\w+(::\w+)+/, Name::Class
+
         rule %r/\(/ do
           token Punctuation
           push :defexpr

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -79,6 +79,45 @@ class Ipsum < Lorem
 end
 
 ########
+# Various types of class definitions
+########
+
+# Singleton class definition
+module Table
+  module Row
+    DEFAULTS = { cell_width: 80, cell_height: 60 }
+
+    class << self
+      def styles hsh
+        hsh.merge DEFAULTS
+      end
+    end
+  end
+end
+
+# Nested class name
+module Table
+  module Row
+    class Cell < Table::Block
+      WIDTH = TABLE::ROW::styles[:cell_width]
+
+      def text string, width = WIDTH
+        string.center width
+      end
+    end
+  end
+end
+
+# Compact class name
+class Table::Row::Cell < Table::Block
+  WIDTH = TABLE::ROW::styles[:cell_width]
+
+  def text string, width = WIDTH
+    string.center width
+  end
+end
+
+########
 # The popular . :bow:
 ########
 


### PR DESCRIPTION
Resolves #1469 

(*Note: I felt highlighting the entire name reference as `Name.Class` token would look better instead of highlighting just the class name proper.*)

## Before

![ruby Visual Test-before](https://user-images.githubusercontent.com/12479464/77843012-79d1ca80-71b6-11ea-8314-a919ab9ef2ad.png)

## After

![ruby Visual Test-after](https://user-images.githubusercontent.com/12479464/77843022-953cd580-71b6-11ea-90da-beaeaa01a758.png)
