### PR TITLE
Fix handling of escaped quotes in CMake lexer

### DIFF
--- a/lib/rouge/lexers/cmake.rb
+++ b/lib/rouge/lexers/cmake.rb
@@ -164,6 +164,7 @@ module Rouge
           goto :bracket_string
         end
 
+        rule %r/\\"/, Text
         rule %r/"/, Str::Double, :quoted_argument
 
         rule %r/([A-Za-z_][A-Za-z0-9_]*)(#{SPACE}*)(\()/ do |m|

--- a/spec/visual/samples/cmake
+++ b/spec/visual/samples/cmake
@@ -27,3 +27,6 @@ message("abc${outer_${inner_variable}_variable}def")
 
 if (FOO)
 endif(FOO)
+
+list(APPEND CFLAGS -foo=\"${CMAKE_CURRENT_SOURCE_DIR}/bar\")
+message("everything else is counted as part of the string")


### PR DESCRIPTION
As identified in #1452, Rouge's CMake lexer doesn't handle escaped quotes correctly in unquoted arguments. It incorrectly treats the escaped quote as beginning a quoted argument. This PR fixes that error.

It will close #1452.