### PR TITLE
Add support for optional chaining operator to TypeScript lexer

### DIFF
--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -19,6 +19,10 @@ module Rouge
 
       mimetypes 'text/typescript'
 
+      prepend :root do
+        rule %r/[?][.]/, Punctuation
+      end
+
       prepend :statement do
         rule %r/(#{Javascript.id_regex})(\??)(\s*)(:)/ do
           groups Name::Label, Punctuation, Text, Punctuation

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -198,3 +198,8 @@ declare module "foo" {
     [K in keyof IFoo]?: IFoo[K]
   }
 }
+
+// Template strings
+const x = `Hello world ${a.b}`;
+const y = `Hello world ${a?.b}`;
+const z = `Hello world`;


### PR DESCRIPTION
As discussed in #1420, TypeScript had added support for the optional chaining operator `?.`. This PR adds support by prepending a rule to the `:root` state. Eventually, when JavaScript adopts the operator, the rule should be moved into the `:root` state there and removed from this lexer.

This closes #1420.