### PR TITLE
Improve lexing of ternaries that include symbols in Ruby lexer

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -329,12 +329,14 @@ module Rouge
       end
 
       state :ternary do
-        rule %r/(\s+)(:)(\s+)/ do
-          groups Text, Punctuation, Text
+        # rule(/:(?!:)/) { token Punctuation; goto :expr_start }
+
+        rule %r/(:)(\s+)/ do
+          groups Punctuation, Text
           goto :expr_start
         end
 
-        rule %r/:(?!.*?[:\\])/ do
+        rule %r/:(?![^#\n]*?[:\\])/ do
           token Punctuation
           goto :expr_start
         end

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -229,7 +229,7 @@ module Rouge
         rule %r/\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
         rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
-        rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }
+        rule(%r/[?]/) { token Punctuation; push :ternary; push :expr_start }
         rule %r<[\[({,:\\;/]>, Punctuation, :expr_start
         rule %r<[\])}]>, Punctuation
       end
@@ -329,7 +329,15 @@ module Rouge
       end
 
       state :ternary do
-        rule(/:(?!:)/) { token Punctuation; goto :expr_start }
+        rule %r/(\s+)(:)(\s+)/ do
+          groups Text, Punctuation, Text
+          goto :expr_start
+        end
+
+        rule %r/:(?!.*?[:\\])/ do
+          token Punctuation
+          goto :expr_start
+        end
 
         mixin :root
       end

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -229,7 +229,7 @@ module Rouge
         rule %r/\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
         rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
-        rule(%r/[?]/) { token Punctuation; push :ternary; push :expr_start }
+        rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }
         rule %r<[\[({,:\\;/]>, Punctuation, :expr_start
         rule %r<[\])}]>, Punctuation
       end

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -329,8 +329,6 @@ module Rouge
       end
 
       state :ternary do
-        # rule(/:(?!:)/) { token Punctuation; goto :expr_start }
-
         rule %r/(:)(\s+)/ do
           groups Punctuation, Text
           goto :expr_start

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -47,7 +47,7 @@ a ?b :c       # parsed as (a) ? (b) : (c)
 (a)    \      # parsed as (a) ? (:b) : (:c)
  ? :b  \
  : :c
-(a) ?         # parsed as (a) ? (:b) (:c)
+(a) ?         # parsed as (a) ? (:b) : (:c)
  :b :
  :c
 a             # parsed as (a) ? (b) : (c)

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -26,30 +26,41 @@ end
 hash = { answer: 42, special?: true }
 link_to 'new', new_article_path, class: 'btn'
 
-#####
-# ternaries
+########
+# Ternaries
+########
+
 # NB [jneen]: MRI ruby actually has different parsing behavior depending on
 # ~what variables are defined~, which we can't know in a highlighting context.
 # So... we're going to be wrong here, sometimes. Whatever. These cases look
 # okay though, but if they break I don't care a whole lot, because Ruby itself
 # doesn't parse them consistently.
-a ? b::c : :d
-a ? b:c
-a ? :b : :c
-a ? :b :c
-(a) ? b : c
-(a)   \
+
+a ? b::c : :d # parsed as (a) ? (b::c) : (:d)
+a ? b : :c    # parsed as (a) ? (b) : (:c)
+a ? b:c       # parsed as (a) ? (b) : (c)
+a ? :b : :c   # parsed as (a) ? (:b) : (:c)
+a ? :b :c     # parsed as (a) ? (:b) : (c)
+a ?b:c        # parsed as (a) ? (b) : (c)
+a ?b :c       # parsed as (a) ? (b) : (c)
+(a) ? b : c   # parsed as (a) ? (b) : (c)
+(a)    \      # parsed as (a) ? (:b) : (:c)
  ? :b  \
  : :c
-(a) ?
+(a) ?         # parsed as (a) ? (:b) (:c)
  :b :
  :c
+a             # parsed as (a) ? (b) : (c)
+ ? b
+ : c
+?????:??      # parsed as (??) ? (??) : (??)
+//?//://      # parsed as (//) ? (//) : (//)
+
 method_that_takes_a_char ?b
 cond??b::c : d
+a?b :c        # parsed as a? (b) (:c), syntax error for missing comma
+a?b:c         # parsed as a?(b: c), b is a symbol
 
-# lol
-?????:??
-//?//://
 
 a/1 # comment
 a / b # comment

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -35,6 +35,15 @@ link_to 'new', new_article_path, class: 'btn'
 # doesn't parse them consistently.
 a ? b::c : :d
 a ? b:c
+a ? :b : :c
+a ? :b :c
+(a) ? b : c
+(a)   \
+ ? :b  \
+ : :c
+(a) ?
+ :b :
+ :c
 method_that_takes_a_char ?b
 cond??b::c : d
 


### PR DESCRIPTION
Ruby's rules for how it parses ternaries are complicated. This is all the more the case if the ternary contains symbols. The current lexer uses a simple test to determine whether a colon demarcates the branches of the ternary: is the colon immediately followed by another colon. While this rule suffices for many cases, it can have problems with symbols.

This PR replaces the simple rule with two rules:

1. **Simple case**: The simple case is where there is whitespace surrounding the colon. If this is the case, the colon demarcates the branches of the ternary.

2. **Complex case**: The complex case tests whether there are no more colons or backslashes on the line. If there aren't any, the colon should be treated as demarcating the branches (see [this StackOverflow question](https://stackoverflow.com/a/4258497/308909) for edge case examples).

This fixes #1038.