### PR TITLE
Use generic string states in Python lexer

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -12,6 +12,10 @@ module Rouge
                 '*.bzl', 'BUCK', 'BUILD', 'BUILD.bazel', 'WORKSPACE'
       mimetypes 'text/x-python', 'application/x-python'
 
+      def self.string_register
+        @string_register ||= StringRegister.new
+      end
+
       def self.detect?(text)
         return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?/)
       end
@@ -109,14 +113,11 @@ module Rouge
 
         # TODO: not in python 3
         rule %r/`.*?`/, Str::Backtick
-        rule %r/(?:r|ur|ru)"""/i, Str, :raw_tdqs
-        rule %r/(?:r|ur|ru)'''/i, Str, :raw_tsqs
-        rule %r/(?:r|ur|ru)"/i,   Str, :raw_dqs
-        rule %r/(?:r|ur|ru)'/i,   Str, :raw_sqs
-        rule %r/u?"""/i,          Str, :tdqs
-        rule %r/u?'''/i,          Str, :tsqs
-        rule %r/u?"/i,            Str, :dqs
-        rule %r/u?'/i,            Str, :sqs
+        rule %r/([rfbu]{0,2})('''|"""|['"])/i do |m|
+          token Str
+          self.class.string_register.push [m[1].downcase, m[2]]
+          push :generic_string
+        end
 
         rule %r/@#{dotted_identifier}/i, Name::Decorator
 
@@ -172,26 +173,39 @@ module Rouge
         mixin :raise
       end
 
-      state :strings do
-        rule %r/%(\([a-z0-9_]+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/i, Str::Interpol
+      state :generic_string do
+        rule %r/[^'"\\{]+/, Str
+        rule %r/{{/, Str
+
+        rule %r/'''|"""|['"]/ do |m|
+          token Str
+          if self.class.string_register.delim? m[0]
+            self.class.string_register.pop
+            pop!
+          end
+        end
+
+        rule %r/\\/ do |m|
+          if self.class.string_register.type? "r"
+            token Str
+          else
+            token Str::Interpol
+          end
+          push :generic_escape
+        end
+
+        rule %r/{/ do |m|
+          if self.class.string_register.type? "f"
+            token Str::Interpol
+            push :generic_interpol
+          else
+            token Str
+          end
+        end
       end
 
-      state :strings_double do
-        rule %r/[^\\"%\n]+/, Str
-        mixin :strings
-      end
-
-      state :strings_single do
-        rule %r/[^\\'%\n]+/, Str
-        mixin :strings
-      end
-
-      state :nl do
-        rule %r/\n/, Str
-      end
-
-      state :escape do
-        rule %r(\\
+      state :generic_escape do
+        rule %r(
           ( [\\abfnrtv"']
           | \n
           | N{[a-zA-Z][a-zA-Z ]+[a-zA-Z]}
@@ -200,48 +214,33 @@ module Rouge
           | x[a-fA-F0-9]{2}
           | [0-7]{1,3}
           )
-        )x, Str::Escape
-      end
-
-      state :raw_escape do
-        rule %r/\\./, Str
-      end
-
-      state :dqs do
-        rule %r/"/, Str, :pop!
-        mixin :escape
-        mixin :strings_double
-      end
-
-      state :sqs do
-        rule %r/'/, Str, :pop!
-        mixin :escape
-        mixin :strings_single
-      end
-
-      state :tdqs do
-        rule %r/"""/, Str, :pop!
-        rule %r/"/, Str
-        mixin :escape
-        mixin :strings_double
-        mixin :nl
-      end
-
-      state :tsqs do
-        rule %r/'''/, Str, :pop!
-        rule %r/'/, Str
-        mixin :escape
-        mixin :strings_single
-        mixin :nl
-      end
-
-      %w(tdqs tsqs dqs sqs).each do |qtype|
-        state :"raw_#{qtype}" do
-          mixin :raw_escape
-          mixin :"#{qtype}"
+        )x do
+          if self.class.string_register.type? "r"
+            token Str
+          else
+            token Str::Escape
+          end
+          pop!
         end
       end
 
+      state :generic_interpol do
+        rule %r/[^{}]+/ do |m|
+          recurse m[0]
+        end
+        rule %r/{/, Str::Interpol, :generic_interpol
+        rule %r/}/, Str::Interpol, :pop!
+      end
+
+      class StringRegister < Array
+        def delim?(delim)
+          self.last[1] == delim
+        end
+
+        def type?(type)
+          self.last[0].include? type
+        end
+      end
     end
   end
 end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -241,6 +241,8 @@ module Rouge
           self.last[0].include? type
         end
       end
+
+      private_constant :StringRegister
     end
   end
 end

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -138,9 +138,13 @@ float_literals = [
     0_00E+2_34_5, 0.e+1, 00_1.E-0_2, -100.e+20, 1e01,
     0_00E+2_34_5j, 0.e+1J, 00_1.E-0_2j, -100.e+20J 1e01j
 ]
+floats = (19.0, 19.)
 
 # PEP 465
 a = b @ c
 x @= y
 
-floats = (19.0, 19.)
+# PEP 498
+f'{hello} world {int(x) + 1}'
+f'{{ {4*10} }}'
+f'result: {value:{width}.{precision}}'


### PR DESCRIPTION
Python allows for a variety of string literals (formatted, raw, unicode) as well as byte literals. In addition, strings can be delimited by `'`, `"`, `'''` and `"""`. At present, the Python lexer contains multiple states to handle the supported combination. This approach is duplicative, error-prone and doesn't scale.

This PR takes a different approach. A `StringRegister` class is added to the Python lexer that is used to hold the stack of string literals currently being lexed. Using this approach, it is possible to implement a series of generic string states and apply the appropriate tokens with reference to this register.

This PR fixes #937 and fixes #942 (or that's the goal at least).