### PR TITLE
Fix multiple operator rule in PHP lexer

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -118,7 +118,7 @@ module Rouge
 
         rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
         rule %r/[~!%^&*+=\|:.<>\/@-]+/, Operator
-        rule %r/\?+/, Operator
+        rule %r/\?/, Operator
         rule %r/[\[\]{}();,]/, Punctuation
         rule %r/(class|interface|trait)(\s+)(#{nsid})/i do
           groups Keyword::Declaration, Text, Name::Class

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -117,7 +117,8 @@ module Rouge
         end
 
         rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
-        rule %r/[~!%^&*+=\|:.<>\/?@-]+/, Operator
+        rule %r/[~!%^&*+=\|:.<>\/@-]+/, Operator
+        rule %r/\?+/, Operator
         rule %r/[\[\]{}();,]/, Punctuation
         rule %r/(class|interface|trait)(\s+)(#{nsid})/i do
           groups Keyword::Declaration, Text, Name::Class

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -628,4 +628,13 @@ class Zip extends Archive {
 }
 
 ?>
+
+<?php if (true): ?><!-- Notice the space between the colon & question mark -->
+  <p>Hello world!</p>
+<?php endif ?>
+
+<?php if (true) :?><!-- No space -->
+  <p>Hello world!</p>
+<?php endif ?>
+
 <p>it's html here at the end, too.</p>


### PR DESCRIPTION
PHP has a rule that can match one or more symbols as operators. Although this permits combinations that are not syntactically correct, it provides some performance improvement for code that has sequential operators.

The problem is that two of these operators, `?>`, have a special meaning in PHP. Matching multiple operators in one pass causes the `?>` to be lexed incorrectly if it is immediately preceded by an operator. This is possible with the `:` operator. This PR fixes the rule by splitting it between operators that can appear multiple times in sequence and those that cannot.

This fixes #1362.