### PR TITLE
Support dictionary indexers on nested properties in F# lexer

### DIFF
--- a/lib/rouge/lexers/fsharp.rb
+++ b/lib/rouge/lexers/fsharp.rb
@@ -113,6 +113,7 @@ module Rouge
         rule %r/#{upper_id}(?=\s*[.])/, Name::Namespace
         rule upper_id, Name::Class, :pop!
         rule id, Name, :pop!
+        rule %r/\[/, Punctuation, :pop!
       end
     end
   end

--- a/spec/visual/samples/fsharp
+++ b/spec/visual/samples/fsharp
@@ -199,7 +199,8 @@ finally
     if !TargetHelper.ExitCode.exitCode <> 0 then exit !TargetHelper.ExitCode.exitCode
     if Environment.ExitCode <> 0 then exit Environment.ExitCode
 
-let test = something.Dictionary.["someKey"]
+let value = array.[0]
+let value = dict.Test.["key"]
 
 // syntax highlighting
 let number = 123

--- a/spec/visual/samples/fsharp
+++ b/spec/visual/samples/fsharp
@@ -198,3 +198,8 @@ finally
     traceEndBuild()
     if !TargetHelper.ExitCode.exitCode <> 0 then exit !TargetHelper.ExitCode.exitCode
     if Environment.ExitCode <> 0 then exit Environment.ExitCode
+
+let test = something.Dictionary.["someKey"]
+
+// syntax highlighting
+let number = 123


### PR DESCRIPTION
A dictionary indexer on a nested property currently breaks the F# lexer. This PR adds support for this by popping the `:dotted` state when a `[` is encountered.

This fixes #1480.