### PR TITLE
Add support for slot shorthand syntax to Vue lexer

### DIFF
--- a/lib/rouge/lexers/vue.rb
+++ b/lib/rouge/lexers/vue.rb
@@ -58,6 +58,10 @@ module Rouge
         end
       end
 
+      prepend :tag do
+        rule %r/[a-zA-Z0-9_:#\[\]()*.-]+\s*=\s*/m, Name::Attribute, :attr
+      end
+
       state :style do
         rule %r/(<\s*\/\s*)(style)(\s*>)/ do
           groups Name::Tag, Keyword, Name::Tag
@@ -121,4 +125,3 @@ module Rouge
     end
   end
 end
-

--- a/spec/visual/samples/vue
+++ b/spec/visual/samples/vue
@@ -73,3 +73,11 @@ p {
 <script lang="coffee">
   module.exports = { data: -> { greeting: 'Hello' } }
 </script>
+
+<!-- Slot Shorthand -->
+<current-user v-slot:default="{ user }">
+  {{ user.firstName }}
+</current-user>
+<current-user #default="{ user }">
+  {{ user.firstName }}
+</current-user>


### PR DESCRIPTION
As of Vue 2.6.0, it is possible to use a shorthand syntax for specifying slots. To tokenise the syntax correctly, the HTML `:tag` state must be amended to allow a tag's attributes to include the `#` character.

This fixes #1479.