### PR TITLE
Simplify default rule in YANG lexer

### DIFF
--- a/lib/rouge/lexers/yang.rb
+++ b/lib/rouge/lexers/yang.rb
@@ -140,7 +140,7 @@ module Rouge
           end
         end
 
-        rule %r/[^;{}\s*+'"]+/, Name
+        rule %r/[^;{}\s'"]+/, Name
       end
     end
   end

--- a/spec/lexers/yang_spec.rb
+++ b/spec/lexers/yang_spec.rb
@@ -68,6 +68,16 @@ describe Rouge::Lexers::YANG do
           ['Punctuation', ';']
       end
 
+      it 'parse complex name' do
+        assert_tokens_equal ' +abc*iu{ asd;}',
+          ['Text.Whitespace', ' '],
+          ['Name', '+abc*iu'],
+          ['Punctuation', '{'],
+          ['Text.Whitespace', ' '],
+          ['Name', 'asd'],
+          ['Punctuation', ';}']
+      end
+
     end
 
   end


### PR DESCRIPTION
Simplify rule to reduce complexity.

**Example**: 
Strings like `+abc*iu` should be valid names for syntax highlighting.
In old version `+` and `*` would be an invalid token and marked as red.

Correct validation will be done through compiler.