### PR TITLE
Rewrite PHP lexer to support use statements, function declarations and type declarations

### DIFF
--- a/lib/rouge/lexers/hack.rb
+++ b/lib/rouge/lexers/hack.rb
@@ -32,7 +32,7 @@ module Rouge
         )
       end
 
-      prepend :template do
+      prepend :root do
         rule %r/<\?hh(\s*\/\/\s*(strict|decl|partial))?$/, Comment::Preproc, :php
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -148,6 +148,17 @@ module Rouge
           groups Keyword, Text, Keyword
         end
 
+        # anonymous functions
+        rule %r/(function)(\s*)(?=\()/i do
+          groups Keyword, Text
+        end
+
+        # named functions
+        rule %r/(function)(\s+)(&?)(\s*)/i do
+          groups Keyword, Text, Operator, Text
+          @next_token = Name::Function
+        end
+
         rule nsid do |m|
           name = m[0].downcase
 
@@ -159,9 +170,6 @@ module Rouge
             token Keyword::Declaration
           elsif "const" == name
             @next_token = Name::Constant if @next_token.nil?
-            token Keyword
-          elsif "function" == name
-            @next_token = Name::Function
             token Keyword
           elsif self.class.keywords.include? name
             token Keyword

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -115,7 +115,7 @@ module Rouge
 
         # whitespace and comments
         rule %r/\s+/, Text
-        rule %r/(#|//).*?$/, Comment::Single
+        rule %r/#.*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single
         rule %r(/\*\*(?!/).*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -152,7 +152,7 @@ module Rouge
             token Keyword
           elsif %w(class interface use trait).include? name
             @name_kind = Name::Class
-            token Keyword
+            token Keyword::Declaration
           elsif "const" == name
             @name_kind = Name::Constant if @name_kind.nil?
             token Keyword

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -109,10 +109,13 @@ module Rouge
           token Comment::Preproc
           pop!
         end
+
         # heredocs
         rule %r/<<<(["']?)(#{id})\1\n.*?\n\s*\2;?/im, Str::Heredoc
+
+        # whitespace and comments
         rule %r/\s+/, Text
-        rule %r/#.*?$/, Comment::Single
+        rule %r/(#|//).*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single
         rule %r(/\*\*(?!/).*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline
@@ -122,8 +125,10 @@ module Rouge
         end
 
         rule %r/(void|\??(int|float|bool|string|iterable|self|callable))\b/i, Keyword::Type
+
         rule %r/[~!%^&*+=\|:.<>\/@-]+/, Operator
         rule %r/\?/, Operator
+
         rule %r/[;]/ do
           @name_kind = nil
           token Punctuation
@@ -139,7 +144,6 @@ module Rouge
           groups Keyword, Text, Keyword
         end
 
-        # may be intercepted for builtin highlighting
         rule nsid do |m|
           name = m[0].downcase
 
@@ -174,6 +178,7 @@ module Rouge
         rule %r/0b[01][01_]*/i, Num::Bin
         rule %r/0x[a-f0-9][a-f0-9_]*/i, Num::Hex
         rule %r/\d[_\d]*/, Num::Integer
+
         rule %r/'([^'\\]*(?:\\.[^'\\]*)*)'/, Str::Single
         rule %r/`([^`\\]*(?:\\.[^`\\]*)*)`/, Str::Backtick
         rule %r/"/, Str::Double, :string

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -113,6 +113,7 @@ module Rouge
             token Name::Function
           end
         end
+
         rule id_with_ns do |m|
           name = m[0].downcase
           if self.class.keywords.include? name
@@ -232,6 +233,8 @@ module Rouge
 
       state :in_assign do
         rule %r/,/, Punctuation, :pop!
+        rule %r/[\[\]]/, Punctuation
+        rule %r/\(/, Punctuation, :in_assign_function
         mixin :escape
         mixin :whitespace
         mixin :values
@@ -239,6 +242,12 @@ module Rouge
         mixin :names
         mixin :operators
         mixin :return
+      end
+
+      state :in_assign_function do
+        rule %r/\)/, Punctuation, :pop!
+        rule %r/,/, Punctuation
+        mixin :in_assign
       end
 
       state :in_catch do

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -292,8 +292,8 @@ module Rouge
       end
 
       state :in_function_return do
-        rule %r/use\b/, Keyword, :pop!
         rule %r/:/, Punctuation
+        rule %r/use\b/i, Keyword, :in_function_use
         rule %r/\??#{id}/, Keyword::Type, :in_assign
         rule %r/\{/ do
           token Punctuation
@@ -301,6 +301,16 @@ module Rouge
         end
         mixin :escape
         mixin :whitespace
+        mixin :return
+      end
+
+      state :in_function_use do
+        rule %r/[,\(]/, Punctuation
+        rule %r/&/, Operator
+        rule %r/\)/, Punctuation, :pop!
+        mixin :escape
+        mixin :whitespace
+        mixin :variables
         mixin :return
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -185,6 +185,12 @@ module Rouge
           push :in_function_name
           token Keyword
         end
+        rule %r/fn\b/i do
+          push :in_function_return
+          push :in_function_params
+          push :in_function_name
+          token Keyword
+        end
 
         # constants
         rule %r/(true|false|null)\b/i, Keyword::Constant
@@ -292,6 +298,7 @@ module Rouge
       state :in_function_params do
         rule %r/\)/, Punctuation, :pop!
         rule %r/,/, Punctuation
+        rule %r/[.]{3}/, Punctuation
         rule %r/=/, Operator, :in_assign
         rule %r/\??#{id}/, Keyword::Type, :in_assign
         mixin :escape

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -35,19 +35,16 @@ module Rouge
       end
 
       def self.keywords
-        # - isset, unset and empty are actually keywords (directly handled by PHP's lexer but let's pretend these are functions, you use them like so)
-        # - self and parent are kind of keywords, they are not handled by PHP's lexer
-        # - use, const, namespace and function are handled by specific rules to highlight what's next to the keyword
         @keywords ||= Set.new %w(
           old_function cfunction
           __class__ __dir__ __file__ __function__ __halt_compiler __line__
-          __method__ __namespace__ __trait__ abstract and array as break
-          case catch clone continue declare default die do echo else
-          elseif enddeclare endfor endforeach endif endswitch endwhile eval
-          exit extends final finally fn for foreach global goto if implements
-          include include_once instanceof insteadof list new or parent print
-          private protected public require require_once return self static
-          switch throw try var while xor yield
+          __method__ __namespace__ __trait__ abstract and array as break case
+          catch clone continue declare default die do echo else elseif
+          enddeclare endfor endforeach endif endswitch endwhile eval exit
+          extends final finally fn for foreach global goto if implements
+          include include_once instanceof insteadof isset list new or parent
+          print private protected public require require_once return self
+          static switch throw try var while xor yield
         )
       end
 
@@ -67,9 +64,6 @@ module Rouge
         end
       end
 
-      # source: http://php.net/manual/en/language.variables.basics.php
-      # the given regex is invalid utf8, so... we're using the unicode
-      # "Letter" property instead.
       id = /[\p{L}_][\p{L}\p{N}_]*/
       ns = /(?:#{id}\\)+/
       id_with_ns = /(?:#{ns})?#{id}/
@@ -95,7 +89,10 @@ module Rouge
       end
 
       state :start do
-        # some extremely rough heuristics to decide whether to start inline or not
+        # We enter this state if we aren't sure whether the PHP in the text is
+        # delimited by <?php (or <?=) tags or not. These two rules check
+        # whether there is an opening angle bracket and, if there is, delegates
+        # the tokens before it to the HTML lexer.
         rule(/\s*(?=<)/m) { delegate parent; pop! }
         rule(/[^$]+(?=<\?(php|=))/i) { delegate parent; pop! }
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -179,13 +179,7 @@ module Rouge
         rule %r/"/, Str::Double, :string
 
         # functions
-        rule %r/function\b/i do
-          push :in_function_return
-          push :in_function_params
-          push :in_function_name
-          token Keyword
-        end
-        rule %r/fn\b/i do
+        rule %r/(function|fn)\b/i do
           push :in_function_return
           push :in_function_params
           push :in_function_name

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -227,6 +227,7 @@ module Rouge
         rule %r/catch\b/i, Keyword, :in_catch
         rule %r/new\b/i, Keyword, :in_new
         rule %r/(class|interface|trait|extends|implements)\b/i, Keyword::Declaration, :in_declaration
+        rule %r/(public|protected|private)\b/i, Keyword, :in_visibility
         rule %r/stdClass\b/, Name::Class
 
         mixin :names
@@ -355,6 +356,14 @@ module Rouge
         mixin :escape
         mixin :whitespace
         mixin :names
+        mixin :return
+      end
+
+      state :in_visibility do
+        rule %r/(?=(function|const)\b)/i, Keyword, :pop!
+        rule %r/\??#{id}/, Keyword::Type, :pop!
+        mixin :escape
+        mixin :whitespace
         mixin :return
       end
     end

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -212,12 +212,18 @@ module Rouge
         mixin :values
         mixin :variables
 
+        rule %r/(namespace)(\s+)(#{id_with_ns})/i do |m|
+          groups Keyword::Namespace, Text, Name::Namespace
+        end
+
+        rule %r/(class|interface|trait|extends|implements)(\s+)(#{id_with_ns})/i do |m|
+          groups Keyword::Declaration, Text, Name::Class
+        end
+
         rule %r/use\b/i, Keyword::Namespace, :in_use
-        rule %r/namespace\b/i, Keyword::Namespace, :in_namespace
         rule %r/const\b/i, Keyword, :in_const
         rule %r/catch\b/i, Keyword, :in_catch
         rule %r/new\b/i, Keyword, :in_new
-        rule %r/(class|interface|trait|extends|implements)\b/i, Keyword::Declaration, :in_declaration
         rule %r/(public|protected|private)\b/i, Keyword, :in_visibility
         rule %r/stdClass\b/, Name::Class
 
@@ -260,13 +266,6 @@ module Rouge
       state :in_const do
         rule id, Name::Constant
         rule %r/=/, Operator, :in_assign
-        mixin :escape
-        mixin :whitespace
-        mixin :return
-      end
-
-      state :in_declaration do
-        rule id_with_ns, Name::Class, :pop!
         mixin :escape
         mixin :whitespace
         mixin :return
@@ -322,19 +321,21 @@ module Rouge
         mixin :return
       end
 
-      state :in_namespace do
-        rule id_with_ns, Name::Namespace, :pop!
+      state :in_new do
+        rule %r/class\b/i do
+          token Keyword::Declaration
+          goto :in_new_class
+        end
+        rule id_with_ns, Name::Class, :pop!
         mixin :escape
         mixin :whitespace
         mixin :return
       end
 
-      state :in_new do
-        rule %r/class\b/i, Keyword::Declaration, :pop!
-        rule id_with_ns, Name::Class, :pop!
-        mixin :escape
-        mixin :whitespace
-        mixin :return
+      state :in_new_class do
+        rule %r/\}/, Punctuation, :pop!
+        rule %r/\{/, Punctuation
+        mixin :php
       end
 
       state :in_use do

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -36,19 +36,19 @@ describe Rouge::Lexers::PHP do
     it 'recognizes double-slash comments not followed by a newline (#797)' do
       assert_tokens_equal '// comment', ['Comment.Single', '// comment']
     end
-    
+
     it 'recognizes try catch finally definition' do
       assert_tokens_equal 'try {} catch () {} finally {}', ["Keyword", "try"], ["Text", " "], ["Punctuation", "{}"], ["Text", " "], ["Keyword", "catch"], ["Text", " "], ["Punctuation", "()"], ["Text", " "], ["Punctuation", "{}"], ["Text", " "], ["Keyword", "finally"], ["Text", " "], ["Punctuation", "{}"]
     end
-    
+
     it 'recognizes class definition' do
       assert_tokens_equal 'class A {}', ["Keyword.Declaration", "class"], ["Text", " "], ["Name.Class", "A"], ["Text", " "], ["Punctuation", "{}"]
     end
-    
+
     it 'recognizes interface definition' do
       assert_tokens_equal 'interface A {}', ["Keyword.Declaration", "interface"], ["Text", " "], ["Name.Class", "A"], ["Text", " "], ["Punctuation", "{}"]
     end
-    
+
     it 'recognizes trait definition' do
       assert_tokens_equal 'trait A {}', ["Keyword.Declaration", "trait"], ["Text", " "], ["Name.Class", "A"], ["Text", " "], ["Punctuation", "{}"]
     end
@@ -66,12 +66,12 @@ describe Rouge::Lexers::PHP do
     end
 
     it 'recognizes case sensitively E_* and PHP_* as constants' do
-      assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]
-      assert_tokens_equal 'PHP_EOL_1', ["Name.Other", "PHP_EOL_1"]
+      assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]; subject.reset_token
+      assert_tokens_equal 'PHP_EOL_1', ["Name.Constant", "PHP_EOL_1"]; subject.reset_token
 
-      assert_tokens_equal 'E_user_DEPRECATED', ["Name.Other", "E_user_DEPRECATED"]
-      assert_tokens_equal 'E_USER_deprecated', ["Name.Other", "E_USER_deprecated"]
-      assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]
+      assert_tokens_equal 'E_user_DEPRECATED', ["Name", "E_user_DEPRECATED"]; subject.reset_token
+      assert_tokens_equal 'E_USER_deprecated', ["Name", "E_USER_deprecated"]; subject.reset_token
+      assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]; subject.reset_token
     end
   end
 end

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -54,15 +54,15 @@ describe Rouge::Lexers::PHP do
     end
 
     it 'recognizes case insensitively keywords' do
-      assert_tokens_equal 'While', ["Keyword", "While"]
-      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]
-      assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]
-      assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]
-      assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]
-      assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]
+      assert_tokens_equal 'While', ["Keyword", "While"]; subject.reset_token
+      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]; subject.reset_token
+      assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]; subject.reset_token
+      assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_token
+      assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]; subject.reset_token
+      assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]; subject.reset_token
       # function for anonymous functions is also recognized as a regular keyword
-      assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]
-      assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name.Function", "foo"]
+      assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]; subject.reset_token
+      assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name.Function", "foo"]; subject.reset_token
     end
 
     it 'recognizes case sensitively E_* and PHP_* as constants' do

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -55,8 +55,7 @@ describe Rouge::Lexers::PHP do
 
     it 'recognizes case insensitively keywords' do
       assert_tokens_equal 'While', ["Keyword", "While"]
-      # class for anonymous classes is recognized as a regular keyword
-      assert_tokens_equal 'Class {', ["Keyword", "Class"], ["Text", " "], ["Punctuation", "{"]
+      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]
       assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]
       assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]
       assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -69,8 +69,8 @@ describe Rouge::Lexers::PHP do
       assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]; subject.reset_stack
       assert_tokens_equal 'PHP_EOL_1', ["Name.Constant", "PHP_EOL_1"]; subject.reset_stack
 
-      assert_tokens_equal 'E_user_DEPRECATED', ["Name.Class", "E_user_DEPRECATED"]; subject.reset_stack
-      assert_tokens_equal 'E_USER_deprecated', ["Name.Class", "E_USER_deprecated"]; subject.reset_stack
+      assert_tokens_equal 'E_user_DEPRECATED', ["Name", "E_user_DEPRECATED"]; subject.reset_stack
+      assert_tokens_equal 'E_USER_deprecated', ["Name", "E_USER_deprecated"]; subject.reset_stack
       assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]; subject.reset_stack
     end
   end

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -54,24 +54,24 @@ describe Rouge::Lexers::PHP do
     end
 
     it 'recognizes case insensitively keywords' do
-      assert_tokens_equal 'While', ["Keyword", "While"]; subject.reset_token
-      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]; subject.reset_token
-      assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]; subject.reset_token
-      assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_token
-      assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Namespace", "BAR"]; subject.reset_token
-      assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]; subject.reset_token
+      assert_tokens_equal 'While', ["Keyword", "While"]; subject.reset_stack
+      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]; subject.reset_stack
+      assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]; subject.reset_stack
+      assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_stack
+      assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_stack
+      assert_tokens_equal 'NameSpace BAR', ["Keyword.Namespace", "NameSpace"], ["Text", " "], ["Name.Namespace", "BAR"]; subject.reset_stack
       # function for anonymous functions is also recognized as a regular keyword
-      assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]; subject.reset_token
-      assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name.Function", "foo"]; subject.reset_token
+      assert_tokens_equal 'Function (', ["Keyword", "Function"], ["Text", " "], ["Punctuation", "("]; subject.reset_stack
+      assert_tokens_equal 'Function foo', ["Keyword", "Function"], ["Text", " "], ["Name", "foo"]; subject.reset_stack
     end
 
     it 'recognizes case sensitively E_* and PHP_* as constants' do
-      assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]; subject.reset_token
-      assert_tokens_equal 'PHP_EOL_1', ["Name.Constant", "PHP_EOL_1"]; subject.reset_token
+      assert_tokens_equal 'PHP_EOL', ["Keyword.Constant", "PHP_EOL"]; subject.reset_stack
+      assert_tokens_equal 'PHP_EOL_1', ["Name.Constant", "PHP_EOL_1"]; subject.reset_stack
 
-      assert_tokens_equal 'E_user_DEPRECATED', ["Name", "E_user_DEPRECATED"]; subject.reset_token
-      assert_tokens_equal 'E_USER_deprecated', ["Name", "E_USER_deprecated"]; subject.reset_token
-      assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]; subject.reset_token
+      assert_tokens_equal 'E_user_DEPRECATED', ["Name.Class", "E_user_DEPRECATED"]; subject.reset_stack
+      assert_tokens_equal 'E_USER_deprecated', ["Name.Class", "E_USER_deprecated"]; subject.reset_stack
+      assert_tokens_equal 'E_USER_DEPRECATED', ["Keyword.Constant", "E_USER_DEPRECATED"]; subject.reset_stack
     end
   end
 end

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -55,7 +55,6 @@ describe Rouge::Lexers::PHP do
 
     it 'recognizes case insensitively keywords' do
       assert_tokens_equal 'While', ["Keyword", "While"]; subject.reset_stack
-      assert_tokens_equal 'Class {', ["Keyword.Declaration", "Class"], ["Text", " "], ["Punctuation", "{"]; subject.reset_stack
       assert_tokens_equal 'Class BAR', ["Keyword.Declaration", "Class"], ["Text", " "], ["Name.Class", "BAR"]; subject.reset_stack
       assert_tokens_equal 'Const BAR', ["Keyword", "Const"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_stack
       assert_tokens_equal 'Use BAR', ["Keyword.Namespace", "Use"], ["Text", " "], ["Name.Constant", "BAR"]; subject.reset_stack

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -90,6 +90,8 @@ interface SomeInterface {
 class Foo extends AbstractFoo implements Bar {
 }
 
+public abstract function thing(mysqli $mysqli, int FOO + BAR, ?mysqli $mysqli): mysqli $mysqli;
+
 function sort_on(array &$array, string $key) {
     usort($array, function ($a, $b) use($key) { return $a <=> $b; });
 }

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -77,6 +77,7 @@ $app->setLogger(new class implements Logger {
 });
 
 // some uses
+use Class1, Class2, Class3;
 use some\namespace\ClassA;
 use some\namespace\ClassB;
 use some\namespace\ClassC as C;

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -27,7 +27,7 @@ $a = 1;
 /* another comment */
 $a = 1;
 /* a multi
-line comemnt 
+line comemnt
 followed by an empty comment */
 $a = 1;
 /**/
@@ -55,7 +55,7 @@ trait SomeTrait {
   public const PUBLIC_CONST_B = 2;
   protected const PROTECTED_CONST = 3;
   private const PRIVATE_CONST = 4;
-      
+
   function afunc(string $arg, SomeInterface $arg2, callable $arg3, object $arg4): void {
     echo "hello";
     if (1 <=> 1) {
@@ -257,7 +257,7 @@ class Zip extends Archive {
       $dir_data .= pack("V", 0);            // Compressed size
       $dir_data .= pack("V", 0);            // Uncompressed size
       */
-  
+
       // Append dir data to the central directory data
       $cd_data[] = $dir_data;
     }
@@ -271,7 +271,7 @@ class Zip extends Archive {
 
       // Reset file data
       $fd = '';
-  
+
       // Detect possible compressions
       // Use deflate
       if(function_exists('gzdeflate')) {
@@ -313,7 +313,7 @@ class Zip extends Archive {
 
       // File data
       $fd .= $compressed_data;
-  
+
       // Data descriptor
       $fd .= pack("V", crc32($content));          // crc-32
       $fd .= pack("V", strlen($compressed_data)); // Compressed size
@@ -395,7 +395,7 @@ class Zip extends Archive {
     // Return content?
     if(!$filename)
       return $data;
-  
+
     // Write to file
     return file_put_contents($filename, $data);
   }

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -1,4 +1,9 @@
 <p>It's html outside php!</p>
+<?php use Foo, Bar ?>
+<?php use /*Foo, */Bar ?>
+<?php use Class1, Class2; ?>
+<?php const FOO = 42, BAR = C ?>
+<?php const /*FOO = 42, */BAR = C; ?>
 <?php
 file_put_contents("log.txt", "\u{FEFF}===== Début du fichier =====\n");
 
@@ -69,6 +74,13 @@ interface SomeInterface {
   function nullableTypes(?bool $arg): ?iterable;
 }
 
+class Foo extends AbstractFoo implements Bar {
+}
+
+function sort_on(array &$array, string $key) {
+    usort($array, function ($a, $b) use($key) { return $a <=> $b; });
+}
+
 //Anonymous class example
 $app->setLogger(new class implements Logger {
     public function log(string $msg) {
@@ -77,7 +89,6 @@ $app->setLogger(new class implements Logger {
 });
 
 // some uses
-use Class1, Class2, Class3;
 use some\namespace\ClassA;
 use some\namespace\ClassB;
 use some\namespace\ClassC as C;
@@ -94,6 +105,23 @@ use const some\namespace\ConstC;
 use some\namespace\{ClassA, ClassB, ClassC as C};
 use function some\namespace\{fn_a, fn_b, fn_c};
 use const some\namespace\{ConstA, ConstB, ConstC};
+
+use const some\namespace\{
+    ConstA,
+    #ConstB,
+    ConstC
+};
+
+use some\name\{function some_fn, const Foo\BAR, SomeClass};
+
+use Class1, /*Class2, */Class3;
+
+class ClassB
+{
+    use TraitA, TraitB, TraitC {
+        TraitB::foo insteadof TraitA;
+    }
+}
 
 namespace some\namespace;
 
@@ -638,30 +666,4 @@ class Zip extends Archive {
   <p>Hello world!</p>
 <?php endif ?>
 
-<?php
-
-// Trait Examples
-
-class ClassA
-{
-    use TraitA {
-        foo as private bar;
-    }
-}
-
-class ClassB
-{
-    use TraitA, TraitB {
-        TraitB::foo insteadof TraitA;
-    }
-}
-
-
-class ClassC
-{
-    use TraitA, TraitB {
-        TraitB::foo as bar;
-    }
-}
-?>
 <p>it's html here at the end, too.</p>

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -637,4 +637,30 @@ class Zip extends Archive {
   <p>Hello world!</p>
 <?php endif ?>
 
+<?php
+
+// Trait Examples
+
+class ClassA
+{
+    use TraitA {
+        foo as private bar;
+    }
+}
+
+class ClassB
+{
+    use TraitA, TraitB {
+        TraitB::foo insteadof TraitA;
+    }
+}
+
+
+class ClassC
+{
+    use TraitA, TraitB {
+        TraitB::foo as bar;
+    }
+}
+?>
 <p>it's html here at the end, too.</p>

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -54,6 +54,19 @@ function &byref() {
     return $x;
 }
 
+// No "use"
+$example = function () {
+    some_fn($message);
+};
+$example();
+
+// Inherit $message
+$example = function () use ($message) {
+    some_fn($message);
+};
+
+$example();
+
 trait SomeTrait {
   // Some visibility
   const PUBLIC_CONST_A = 1;

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -124,6 +124,14 @@ $gen = (function() {
     return 3;
 })();
 
+$fn = fn($x) => fn($y) => $x * $y + $z;
+fn(array $x) => $x;
+static fn(): int => $x;
+fn($x = 42) => $x;
+fn(&$x) => $x;
+fn&($x) => $x;
+fn($x, ...$rest) => $rest;
+
 
 /* Classes */
 

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -212,6 +212,7 @@ namespace some\namespace;
 
 list($id1, $name1) = $data[0];
 [$id1, $name1] = $data[0];
+const A = f(1, 2, g(3, 4, $my_var[0])), B = "abc";
 
 
 /* Conditionals */

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -164,6 +164,18 @@ class Zip extends Archive {
   }
 }
 
+class User
+{
+    public int $id;
+    public ?string $name;
+
+    public function __construct(int $id, ?string $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}
+
 
 /* Traits */
 

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -1,32 +1,34 @@
 <p>It's html outside php!</p>
+
+
+<?php /* Single statements */ ?>
+
 <?php use Foo, Bar ?>
 <?php use /*Foo, */Bar ?>
 <?php use Class1, Class2; ?>
 <?php const FOO = 42, BAR = C ?>
 <?php const /*FOO = 42, */BAR = C; ?>
+
+
+<?php /* Multiple statements */ ?>
+
 <?php
-file_put_contents("log.txt", "\u{FEFF}===== Début du fichier =====\n");
+  file_put_contents("log.txt", "\u{FEFF}===== Début du fichier =====\n");
+  $test = function($a) { $lambda = 1; }
+?>
 
-$test = function($a) { $lambda = 1; }
 
-?><a href="<?= $url ?>">I can close php tags and get html!</a><?php
+<?php /* Embedded PHP */ ?>
 
-/** snippet from wordpress */
-if (! isset($wp_did_header)):
-if ( !file_exists( dirname(__FILE__) . '/wp-config.php') ) {
-    if ( strstr( $_SERVER['PHP_SELF'], 'wp-admin') ) $path = '';
-    else $path = 'wp-admin/';
-    die("There doesn't seem to be a <code>wp-config.php</code>" .
-        "file. I need this before we can get started. Need more" .
-        "help? <a href='http://wordpress.org/docs/faq/#wp-config'>We" .
-        "got it</a>. You can <a href='{$path}setup-config.php'>create" .
-        "a <code>wp-config.php</code> file through a web interface</a>," .
-        "but this doesn't work for all server setups. The safest way is" .
-        "to manually create the file."
-    );
-}
+<a href="<?= $url ?>">I can close php tags and get html!</a>
+
+
+<?php
+
+/* Comments */
 
 # A comment
+$a = 1;
 // Another comment
 $a = 1;
 /* another comment */
@@ -42,118 +44,30 @@ $a = 1;
  */
 $a = 1;
 
-// unicode variable names
+
+/* Variable names */
+
+$a = 1;
 $Δ = 1;
 ++$_Δ;
 echo $ΔΔ;
 
-"thing {$thing->other_thing()}"
 
-function &byref() {
-    $x = array();
-    return $x;
-}
+/* Numbers */
 
-// No "use"
-$example = function () {
-    some_fn($message);
-};
-$example();
+1;
+3.14;
+1.414e10;
+1_000_000;
+007;
+0b1010;
+0xabcdef;
 
-// Inherit $message
-$example = function () use ($message) {
-    some_fn($message);
-};
 
-$example();
+/* Strings */
 
-trait SomeTrait {
-  // Some visibility
-  const PUBLIC_CONST_A = 1;
-  public const PUBLIC_CONST_B = 2;
-  protected const PROTECTED_CONST = 3;
-  private const PRIVATE_CONST = 4;
-
-  function afunc(string $arg, SomeInterface $arg2, callable $arg3, object $arg4): void {
-    echo "hello";
-    if (1 <=> 1) {
-      echo "yep!";
-    }
-  }
-}
-
-interface SomeInterface {
-  function interfaceFunc(bool $arg): iterable;
-  function nullableTypes(?bool $arg): ?iterable;
-}
-
-class Foo extends AbstractFoo implements Bar {
-}
-
-public abstract function thing(mysqli $mysqli, int FOO + BAR, ?mysqli $mysqli): mysqli $mysqli;
-
-function sort_on(array &$array, string $key) {
-    usort($array, function ($a, $b) use($key) { return $a <=> $b; });
-}
-
-//Anonymous class example
-$app->setLogger(new class implements Logger {
-    public function log(string $msg) {
-        echo $msg;
-    }
-});
-
-// some uses
-use some\namespace\ClassA;
-use some\namespace\ClassB;
-use some\namespace\ClassC as C;
-
-use function some\namespace\fn_a;
-use function some\namespace\fn_b;
-use function some\namespace\fn_c;
-
-use const some\namespace\ConstA;
-use const some\namespace\ConstB;
-use const some\namespace\ConstC;
-
-// Grouped uses
-use some\namespace\{ClassA, ClassB, ClassC as C};
-use function some\namespace\{fn_a, fn_b, fn_c};
-use const some\namespace\{ConstA, ConstB, ConstC};
-
-use const some\namespace\{
-    ConstA,
-    #ConstB,
-    ConstC
-};
-
-use some\name\{function some_fn, const Foo\BAR, SomeClass};
-
-use Class1, /*Class2, */Class3;
-
-class ClassB
-{
-    use TraitA, TraitB, TraitC {
-        TraitB::foo insteadof TraitA;
-    }
-}
-
-namespace some\namespace;
-
-// A generator
-$gen = (function() {
-    yield 1;
-    yield 2;
-
-    return 3;
-})();
-
-// descructuring
-// list() style
-list($id1, $name1) = $data[0];
-
-// [] style
-[$id1, $name1] = $data[0];
+'A single-quoted string';
+"A double-quoted string";
 
 // heredoc
 $a = <<<EOF
@@ -175,503 +89,198 @@ callingFunc(<<<EOF
     Another string
     EOF);
 
-/**
- *  Zip class file
- *
- *  @package     fnord.bb
- *  @subpackage  archive
- */
+// Interpolation
+"thing {$thing->other_thing()}"
 
-// Unlock?
-if(!defined('UNLOCK') || !UNLOCK)
-  die();
 
-// Load the parent archive class
-require_once(ROOT_PATH.'/classes/archive.class.php');
+/* Functions */
+
+function &byref() {
+    $x = array();
+    return $x;
+}
+
+public abstract function thing(mysqli $mysqli, int FOO + BAR, ?mysqli $mysqli): mysqli $mysqli;
+
+function sort_on(array &$array, string $key) {
+    usort($array, function ($a, $b) use($key) { return $a <=> $b; });
+}
+
+// No "use"
+$example = function () {
+    some_fn($message);
+};
+
+// Inherit $message
+$example = function () use ($message) {
+    some_fn($message);
+};
+
+// A generator
+$gen = (function() {
+    yield 1;
+    yield 2;
+
+    return 3;
+})();
+
+
+/* Classes */
+
+class Foo extends AbstractFoo implements Bar {
+}
+
+//Anonymous class example
+$app->setLogger(new class implements Logger {
+    public function log(string $msg) {
+        echo $msg;
+    }
+});
+
+class ClassB
+{
+    use TraitA, TraitB, TraitC {
+        TraitB::foo insteadof TraitA;
+    }
+}
 
 class Zip\Zipp {
 
 }
 
-/**
- *  Zip class
- *
- *  @author      Manni <manni@fnord.name>
- *  @copyright   Copyright (c) 2006, Manni
- *  @version     1.0
- *  @link        http://www.pkware.com/business_and_developers/developer/popups/appnote.txt
- *  @link        http://mannithedark.is-a-geek.net/
- *  @since       1.0
- *  @package     fnord.bb
- *  @subpackage  archive
- */
 class Zip extends Archive {
- /**
-  *  Outputs the zip file
-  *
-  *  This function creates the zip file with the dirs and files given.
-  *  If the optional parameter $file is given, the zip file is will be
-  *  saved at that location. Otherwise the function returns the zip file's content.
-  *
-  *  @access                   public
-  *
-  *  @link                     http://www.pkware.com/business_and_developers/developer/popups/appnote.txt
-  *  @param  string $filename  The path where the zip file will be saved
-  *
-  *  @return bool|string       Returns either true if the fil is sucessfully created or the content of the zip file
-  */
   function out($filename = false) {
     // Empty output
     $file_data = array(); // Data of the file part
     $cd_data   = array(); // Data of the central directory
-
-    // Sort dirs and files by path length
-    uksort($this->dirs,  'sort_by_length');
-    uksort($this->files, 'sort_by_length');
-
-    // Handle dirs
-    foreach($this->dirs as $dir) {
-      $dir .= '/';
-      // File part
-
-      // Reset dir data
-      $dir_data = '';
-
-      // Local file header
-      $dir_data .= "\x50\x4b\x03\x04";      // Local file header signature
-      $dir_data .= pack("v", 10);           // Version needed to extract
-      $dir_data .= pack("v", 0);            // General purpose bit flag
-      $dir_data .= pack("v", 0);            // Compression method
-      $dir_data .= pack("v", 0);            // Last mod file time
-      $dir_data .= pack("v", 0);            // Last mod file date
-      $dir_data .= pack("V", 0);            // crc-32
-      $dir_data .= pack("V", 0);            // Compressed size
-      $dir_data .= pack("V", 0);            // Uncompressed size
-      $dir_data .= pack("v", strlen($dir)); // File name length
-      $dir_data .= pack("v", 0);            // Extra field length
-
-      $dir_data .= $dir;                    // File name
-      $dir_data .= '';                      // Extra field (is empty)
-
-      // File data
-      $dir_data .= '';                      // Dirs have no file data
-
-      // Data descriptor
-      $dir_data .= pack("V", 0);            // crc-32
-      $dir_data .= pack("V", 0);            // Compressed size
-      $dir_data .= pack("V", 0);            // Uncompressed size
-
-      // Save current offset
-      $offset = strlen(implode('', $file_data));
-
-      // Append dir data to the file part
-      $file_data[] = $dir_data;
-
-      // Central directory
-
-      // Reset dir data
-      $dir_data = '';
-
-      // File header
-      $dir_data .= "\x50\x4b\x01\x02";      // Local file header signature
-      $dir_data .= pack("v", 0);            // Version made by
-      $dir_data .= pack("v", 10);           // Version needed to extract
-      $dir_data .= pack("v", 0);            // General purpose bit flag
-      $dir_data .= pack("v", 0);            // Compression method
-      $dir_data .= pack("v", 0);            // Last mod file time
-      $dir_data .= pack("v", 0);            // Last mod file date
-      $dir_data .= pack("V", 0);            // crc-32
-      $dir_data .= pack("V", 0);            // Compressed size
-      $dir_data .= pack("V", 0);            // Uncompressed size
-      $dir_data .= pack("v", strlen($dir)); // File name length
-      $dir_data .= pack("v", 0);            // Extra field length
-      $dir_data .= pack("v", 0);            // File comment length
-      $dir_data .= pack("v", 0);            // Disk number start
-      $dir_data .= pack("v", 0);            // Internal file attributes
-      $dir_data .= pack("V", 16);           // External file attributes
-      $dir_data .= pack("V", $offset);      // Relative offset of local header
-
-      $dir_data .= $dir;                    // File name
-      $dir_data .= '';                      // Extra field (is empty)
-      $dir_data .= '';                      // File comment (is empty)
-
-      /*
-      // Data descriptor
-      $dir_data .= pack("V", 0);            // crc-32
-      $dir_data .= pack("V", 0);            // Compressed size
-      $dir_data .= pack("V", 0);            // Uncompressed size
-      */
-
-      // Append dir data to the central directory data
-      $cd_data[] = $dir_data;
-    }
-
-    // Handle files
-    foreach($this->files as $name => $file) {
-      // Get values
-      $content = $file[0];
-
-      // File part
-
-      // Reset file data
-      $fd = '';
-
-      // Detect possible compressions
-      // Use deflate
-      if(function_exists('gzdeflate')) {
-        $method = 8;
-
-        // Compress file content
-        $compressed_data = gzdeflate($content);
-
-      // Use bzip2
-      } elseif(function_exists('bzcompress')) {
-        $method = 12;
-
-        // Compress file content
-        $compressed_data = bzcompress($content);
-
-      // No compression
-      } else {
-        $method = 0;
-
-        // Do not compress the content :P
-        $compressed_data = $content;
-      }
-
-      // Local file header
-      $fd .= "\x50\x4b\x03\x04";                  // Local file header signature
-      $fd .= pack("v", 20);                       // Version needed to extract
-      $fd .= pack("v", 0);                        // General purpose bit flag
-      $fd .= pack("v", $method);                  // Compression method
-      $fd .= pack("v", 0);                        // Last mod file time
-      $fd .= pack("v", 0);                        // Last mod file date
-      $fd .= pack("V", crc32($content));          // crc-32
-      $fd .= pack("V", strlen($compressed_data)); // Compressed size
-      $fd .= pack("V", strlen($content));         // Uncompressed size
-      $fd .= pack("v", strlen($name));            // File name length
-      $fd .= pack("v", 0);                        // Extra field length
-
-      $fd .= $name;                               // File name
-      $fd .= '';                                  // Extra field (is empty)
-
-      // File data
-      $fd .= $compressed_data;
-
-      // Data descriptor
-      $fd .= pack("V", crc32($content));          // crc-32
-      $fd .= pack("V", strlen($compressed_data)); // Compressed size
-      $fd .= pack("V", strlen($content));         // Uncompressed size
-
-      // Save current offset
-      $offset = strlen(implode('', $file_data));
-
-      // Append file data to the file part
-      $file_data[] = $fd;
-
-      // Central directory
-
-      // Reset file data
-      $fd = '';
-
-      // File header
-      $fd .= "\x50\x4b\x01\x02";                  // Local file header signature
-      $fd .= pack("v", 0);                        // Version made by
-      $fd .= pack("v", 20);                       // Version needed to extract
-      $fd .= pack("v", 0);                        // General purpose bit flag
-      $fd .= pack("v", $method);                  // Compression method
-      $fd .= pack("v", 0);                        // Last mod file time
-      $fd .= pack("v", 0);                        // Last mod file date
-      $fd .= pack("V", crc32($content));          // crc-32
-      $fd .= pack("V", strlen($compressed_data)); // Compressed size
-      $fd .= pack("V", strlen($content));         // Uncompressed size
-      $fd .= pack("v", strlen($name));            // File name length
-      $fd .= pack("v", 0);                        // Extra field length
-      $fd .= pack("v", 0);                        // File comment length
-      $fd .= pack("v", 0);                        // Disk number start
-      $fd .= pack("v", 0);                        // Internal file attributes
-      $fd .= pack("V", 32);                       // External file attributes
-      $fd .= pack("V", $offset);                  // Relative offset of local header
-
-      $fd .= $name;                               // File name
-      $fd .= '';                                  // Extra field (is empty)
-      $fd .= '';                                  // File comment (is empty)
-
-      /*
-      // Data descriptor
-      $fd .= pack("V", crc32($content));          // crc-32
-      $fd .= pack("V", strlen($compressed_data)); // Compressed size
-      $fd .= pack("V", strlen($content));         // Uncompressed size
-      */
-
-      // Append file data to the central directory data
-      $cd_data[] = $fd;
-    }
-
-    // Digital signature
-    $digital_signature = '';
-    $digital_signature .= "\x50\x4b\x05\x05";  // Header signature
-    $digital_signature .= pack("v", 0);        // Size of data
-    $digital_signature .= '';                  // Signature data (is empty)
-
-    $tmp_file_data = implode('', $file_data);  // File data
-    $tmp_cd_data   = implode('', $cd_data).    // Central directory
-                     $digital_signature;       // Digital signature
-
-    // End of central directory
-    $eof_cd = '';
-    $eof_cd .= "\x50\x4b\x05\x06";                // End of central dir signature
-    $eof_cd .= pack("v", 0);                      // Number of this disk
-    $eof_cd .= pack("v", 0);                      // Number of the disk with the start of the central directory
-    $eof_cd .= pack("v", count($cd_data));        // Total number of entries in the central directory on this disk
-    $eof_cd .= pack("v", count($cd_data));        // Total number of entries in the central directory
-    $eof_cd .= pack("V", strlen($tmp_cd_data));   // Size of the central directory
-    $eof_cd .= pack("V", strlen($tmp_file_data)); // Offset of start of central directory with respect to the starting disk number
-    $eof_cd .= pack("v", 0);                      // .ZIP file comment length
-    $eof_cd .= '';                                // .ZIP file comment (is empty)
-
-    // Content of the zip file
-    $data = $tmp_file_data.
-            // $extra_data_record.
-            $tmp_cd_data.
-            $eof_cd;
-
-    // Return content?
-    if(!$filename)
-      return $data;
-
-    // Write to file
-    return file_put_contents($filename, $data);
-  }
-
- /**
-  *  Load a zip file
-  *
-  *  This function loads the files and dirs from a zip file from the harddrive.
-  *
-  *  @access                public
-  *
-  *  @param  string $file   The path to the zip file
-  *  @param  bool   $reset  Reset the files and dirs before adding the zip file's content?
-  *
-  *  @return bool           Returns true if the file was loaded sucessfully
-  */
-  function load_file($file, $reset = true) {
-    // Check whether the file exists
-    if(!file_exists($file))
-      return false;
-
-    // Load the files content
-    $content = @file_get_contents($file);
-
-    // Return false if the file cannot be opened
-    if(!$content)
-      return false;
-
-    // Read the zip
-    return $this->load_string($content, $reset);
-  }
-
- /**
-  *  Load a zip string
-  *
-  *  This function loads the files and dirs from a string
-  *
-  *  @access                 public
-  *
-  *  @param  string $string  The string the zip is generated from
-  *  @param  bool   $reset   Reset the files and dirs before adding the zip file's content?
-  *
-  *  @return bool            Returns true if the string was loaded sucessfully
-  */
-  function load_string($string, $reset = true) {
-    // Reset the zip?
-    if($reset) {
-      $this->dirs  = array();
-      $this->files = array();
-    }
-
-    // Get the starting position of the end of central directory record
-    $start = strpos($string, "\x50\x4b\x05\x06");
-
-    // Error
-    if($start === false)
-      die('Could not find the end of central directory record');
-
-    // Get the ecdr
-    $eof_cd = substr($string, $start+4, 18);
-
-    // Unpack the ecdr infos
-    $eof_cd = unpack('vdisc1/'.
-                     'vdisc2/'.
-                     'ventries1/'.
-                     'ventries2/'.
-                     'Vsize/'.
-                     'Voffset/'.
-                     'vcomment_lenght', $eof_cd);
-
-    // Do not allow multi disc zips
-    if($eof_cd['disc1'] != 0)
-      die('multi disk stuff is not yet implemented :/');
-
-    // Save the interesting values
-    $cd_entries = $eof_cd['entries1'];
-    $cd_size    = $eof_cd['size'];
-    $cd_offset  = $eof_cd['offset'];
-
-    // Get the central directory record
-    $cdr = substr($string, $cd_offset, $cd_size);
-
-    // Reset the position and the list of the entries
-    $pos     = 0;
-    $entries = array();
-
-    // Handle cdr
-    while($pos < strlen($cdr)) {
-      // Check header signature
-      // Digital signature
-      if(substr($cdr, $pos, 4) == "\x50\x4b\x05\x05") {
-        // Get digital signature size
-        $tmp_info = unpack('vsize', substr($cdr, $pos + 4, 2));
-
-        // Read out the digital signature
-        $digital_sig = substr($header, $pos + 6, $tmp_info['size']);
-
-        break;
-      }
-
-      // Get file header
-      $header = substr($cdr, $pos, 46);
-
-      // Unpack the header information
-      $header_info = @unpack('Vheader/'.
-                             'vversion_made_by/'.
-                             'vversion_needed/'.
-                             'vgeneral_purpose/'.
-                             'vcompression_method/'.
-                             'vlast_mod_time/'.
-                             'vlast_mod_date/'.
-                             'Vcrc32/'.
-                             'Vcompressed_size/'.
-                             'Vuncompressed_size/'.
-                             'vname_length/'.
-                             'vextra_length/'.
-                             'vcomment_length/'.
-                             'vdisk_number/'.
-                             'vinternal_attributes/'.
-                             'Vexternal_attributes/'.
-                             'Voffset',
-                             $header);
-
-      // Valid header?
-      if($header_info['header'] != 33_639_248)
-        return false;
-
-      // New position
-      $pos += 46;
-
-      // Read out the file name
-      $header_info['name'] = substr($cdr, $pos, $header_info['name_length']);
-
-      // New position
-      $pos += $header_info['name_length'];
-
-      // Read out the extra stuff
-      $header_info['extra'] = substr($cdr, $pos, $header_info['extra_length']);
-
-      // New position
-      $pos += $header_info['extra_length'];
-
-      // Read out the comment
-      $header_info['comment'] = substr($cdr, $pos, $header_info['comment_length']);
-
-      // New position
-      $pos += $header_info['comment_length'];
-
-      // Append this file/dir to the entry list
-      $entries[] = $header_info;
-    }
-
-    // Check whether all entries where read sucessfully
-    if(count($entries) != $cd_entries)
-      return false;
-
-    // Handle files/dirs
-    foreach($entries as $entry) {
-      // Is a dir?
-      if($entry['external_attributes'] & 16) {
-        $this->add_dir($entry['name']);
-        continue;
-      }
-
-      // Get local file header
-      $header = substr($string, $entry['offset'], 30);
-
-      // Unpack the header information
-      $header_info = @unpack('Vheader/'.
-                             'vversion_needed/'.
-                             'vgeneral_purpose/'.
-                             'vcompression_method/'.
-                             'vlast_mod_time/'.
-                             'vlast_mod_date/'.
-                             'Vcrc32/'.
-                             'Vcompressed_size/'.
-                             'Vuncompressed_size/'.
-                             'vname_length/'.
-                             'vextra_length',
-                             $header);
-
-      // Valid header?
-      if($header_info['header'] != 67_324_752)
-        return false;
-
-      // Get content start position
-      $start = $entry['offset'] + 30 + $header_info['name_length'] + $header_info['extra_length'];
-
-      // Get the compressed data
-      $data = substr($string, $start, $header_info['compressed_size']);
-
-      // Detect compression type
-      switch($header_info['compression_method']) {
-        // No compression
-        case 0:
-          // Ne decompression needed
-          $content = $data;
-          break;
-
-        // Gzip
-        case 8:
-          if(!function_exists('gzinflate'))
-            return false;
-
-          // Uncompress data
-          $content = gzinflate($data);
-          break;
-
-        // Bzip2
-        case 12:
-          if(!function_exists('bzdecompress'))
-            return false;
-
-          // Decompress data
-          $content = bzdecompress($data);
-          break;
-
-        // Compression not supported -> error
-        default:
-          return false;
-      }
-
-      // Try to add file
-      if(!$this->add_file($entry['name'], $content))
-        return false;
-    }
-
-    return true;
   }
 }
 
+
+/* Traits */
+
+trait SomeTrait {
+  // Some visibility
+  const PUBLIC_CONST_A = 1;
+  public const PUBLIC_CONST_B = 2;
+  protected const PROTECTED_CONST = 3;
+  private const PRIVATE_CONST = 4;
+
+  function afunc(string $arg, SomeInterface $arg2, callable $arg3, object $arg4): void {
+    echo "hello";
+    if (1 <=> 1) {
+      echo "yep!";
+    }
+  }
+}
+
+
+/* Interfaces */
+
+interface SomeInterface {
+  function interfaceFunc(bool $arg): iterable;
+  function nullableTypes(?bool $arg): ?iterable;
+}
+
+
+/* Imports */
+
+use some\namespace\ClassA;
+use some\namespace\ClassB as B;
+use function some\namespace\fn_a;
+use const some\namespace\ConstA;
+use Class1, /*Class2, */Class3;
+
+use some\namespace\{ClassA, ClassB, ClassC as C};
+use function some\namespace\{fn_a, fn_b, fn_c};
+use const some\namespace\{ConstA, ConstB, ConstC};
+use some\name\{function some_fn, const Foo\BAR, SomeClass};
+
+use const some\namespace\{
+    ConstA,
+    #ConstB,
+    ConstC
+};
+
+
+/* Namespaces */
+
+namespace some\namespace;
+
+
+/* Assignments */
+
+list($id1, $name1) = $data[0];
+[$id1, $name1] = $data[0];
+
+
+/* Conditionals */
+
+if(!defined('UNLOCK') || !UNLOCK)
+  die();
+
+if(function_exists('gzdeflate')) {
+  $method = 8;
+  $compressed_data = gzdeflate($content);
+} elseif(function_exists('bzcompress')) {
+  $method = 12;
+  $compressed_data = bzcompress($content);
+} else {
+  $compressed_data = $content;
+}
+
+switch($header_info['compression_method']) {
+  case 0:
+    $content = $data;
+    break;
+
+  case 8:
+    $content = gzinflate($data);
+    break;
+
+  case 12:
+    if(!function_exists('bzdecompress'))
+      return false;
+    break;
+
+  default:
+    return false;
+}
+
+/* Loops */
+
+foreach($this->files as $name => $file) {
+  $content = $file[0];
+  $fd .= "\x50\x4b\x03\x04";                  // Local file header signature
+  $fd .= pack("v", 20);                       // Version needed to extract
+  $fd .= pack("V", crc32($content));          // crc-32
+  $fd .= pack("V", strlen($compressed_data)); // Compressed size
+}
+
+while($pos < strlen($cdr)) {
+  if(substr($cdr, $pos, 4) == "\x50\x4b\x05\x05") {
+    $tmp_info = unpack('vsize', substr($cdr, $pos + 4, 2));
+    $digital_sig = substr($header, $pos + 6, $tmp_info['size']);
+    break;
+  }
+}
+
+
+/* Exceptions */
+
+class Test {
+    public function testing() {
+        try {
+            throw new MyException();
+        } catch (MyException | MyOtherException $e) {
+            var_dump(get_class($e));
+        }
+    }
+}
+
 ?>
+
+<?php /* Edge cases */ ?>
 
 <?php if (true): ?><!-- Notice the space between the colon & question mark -->
   <p>Hello world!</p>


### PR DESCRIPTION
PHP's `use` keyword can be used to (1) [import namespaces](https://www.php.net/manual/en/language.namespaces.importing.php) into the current scope and (2) [include traits](https://www.php.net/manual/en/language.oop5.traits.php) in a class. While the PHP lexer currently supports `use` in some contexts, it doesn't allow for the importing of multiple namespaces at once, nor does it tokenise a given input correctly when `use` is used inside a class.

This PR improves the support for `use`. It uses a simple conditional to determine whether identifiers that are captured by the rules in the `:uselist` state are keywords, namespaces or function names.

It fixes #1353 and it fixes #1361.