### PR TITLE
Support regular expressions in Terraform lexer

### DIFF
--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -81,9 +81,24 @@ module Rouge
         mixin :expression
       end
 
+      state :regexps do
+        rule %r/"\// do
+          token Str::Delimiter
+          goto :regexp_inner
+        end
+      end
+
+      state :regexp_inner do
+        rule %r/[^"\/\\]+/, Str::Regex
+        rule %r/\\./, Str::Regex
+        rule %r/\/"/, Str::Delimiter, :pop!
+        rule %r/["\/]/, Str::Regex
+      end
+
       id = /[$a-z_\-][a-z0-9_\-]*/io
 
       state :expression do
+        mixin :regexps
         mixin :primitives
         rule %r/\s+/, Text
 

--- a/spec/visual/samples/terraform
+++ b/spec/visual/samples/terraform
@@ -79,3 +79,8 @@ resource "aws_subnet" "main" {
   vpc_id            = aws_vpc.main.id
   fqns              = aws_route53_record.cert_validation[*].fqdn
 }
+
+## Object with regular expression
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  aliases = ["www.${replace(var.domain_name, "/\\.$/", "")}"]
+}


### PR DESCRIPTION
In a Terraform file, an interpolated expression can include a regular expression of the form `"/.../"`. This PR adds rules that identify regular expressions. It fixes #1304.