### PR TITLE
Enable StringScanner with fixed_anchors in Ruby v2.7.0+

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -52,6 +52,8 @@ load_relative 'rouge/util'
 load_relative 'rouge/text_analyzer'
 load_relative 'rouge/token'
 
+load_relative 'rouge/string_scanner'
+
 load_relative 'rouge/lexer'
 load_relative 'rouge/regex_lexer'
 load_relative 'rouge/template_lexer'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 # stdlib
-require 'strscan'
 require 'cgi'
 require 'set'
 

--- a/lib/rouge/string_scanner.rb
+++ b/lib/rouge/string_scanner.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+require 'strscan'
+
+module Rouge
+  class StringScanner < ::StringScanner
+    def initialize(str)
+      if ::StringScanner.method_defined?(:fixed_anchor?)
+        super str, fixed_anchor: true
+      else
+        super str
+      end
+    end
+  end
+end


### PR DESCRIPTION
The StringScanner class has had a longstanding bug where anchors in regular expressions were not properly handled. Rouge partly works around this for some anchors but not all (e.g. lookbehinds do not work properly in regular expressions):

https://github.com/rouge-ruby/rouge/blob/c56e7881bf6fbd2baa9d97643deffa657cb183e9/lib/rouge/regex_lexer.rb#L299-L304

The bug was originally reported by @jneen in 2012 (!) but due to a lack of a maintainer, it was not fixed until [version 1.02](https://github.com/ruby/strscan/blob/master/NEWS.md#102---2019-10-13) in October 2019. The first version of Ruby where the default standard library included the fix was v2.7.0. The bug and fix are discussed in more detail [here](https://github.com/ruby/strscan/pull/6).

Because at least one important library ([RDoc](https://github.com/ruby/strscan/issues/10)) depended on the buggy behaviour, when the fix was added in v1.02 it was hidden behind an initialisation option, `:fixed_anchors`, that defaults to `false`. The current version of Rouge (v3.17.0 at the time of writing) still uses the default behaviour. This PR enables the option where possible.

[The recommended way](https://github.com/ruby/strscan/issues/10#issuecomment-541366153) of checking for whether the initialiser can receive the option is to call `StringScanner.method_defined?(:fixed_anchors?)`. This PR takes that approach in the initialiser of a `Rouge::StringScanner` shim. While this approach has the advantage of avoiding changes to instances of instantiation through the Rouge codebase, it results in a lack of clarity. Later maintainers may not realise that `StringScanner` refers to `Rouge::StringScanner` rather than the class in the standard library.

This PR is submitted primarily for discussion. Rouge's test suite fails when using `fixed_anchors: true` indicating at least two lexers (`Lexers::Ada` and `Lexers::GHCCore`) depend on the broken behaviour. Other lexers may also be affected. As a result, it might make sense for this to be a change made as part of v4.0 of Rouge.

If/when `fixed_anchors` is enabled, this will fix #829.