### PR TITLE
Simplify JSX and TSX lexers

### DIFF
--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -6,7 +6,7 @@ module Rouge
 
     class JSX < Javascript
       title 'JSX'
-      desc 'React JSX (https://facebook.github.io/react/)'
+      desc 'An XML-like syntax extension to JavaScript (facebook.github.io/jsx/)'
       tag 'jsx'
       aliases 'jsx', 'react'
       filenames '*.jsx'

--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -13,7 +13,7 @@ module Rouge
 
       mimetypes 'text/x-jsx', 'application/x-jsx'
 
-      start { @html = HTML.new(options) }
+      start { @html = HTML.new(options); push :expr_start }
 
       prepend :expr_start do
         mixin :tag

--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -14,6 +14,13 @@ module Rouge
 
       tag 'tsx'
       filenames '*.tsx'
+
+      prepend :element_name do
+        rule %r/(\w+)(,)/ do
+          groups Name::Other, Punctuation
+          pop! 3
+        end
+      end
     end
   end
 end

--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -14,13 +14,6 @@ module Rouge
 
       tag 'tsx'
       filenames '*.tsx'
-
-      prepend :element_name do
-        rule %r/(\w+)(,)/ do
-          groups Name::Other, Punctuation
-          pop! 3
-        end
-      end
     end
   end
 end

--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -9,8 +9,8 @@ module Rouge
     class TSX < JSX
       extend TypescriptCommon
 
-      title 'TypeScript'
-      desc 'tsx'
+      title 'TSX'
+      desc 'TypeScript-compatible JSX (www.typescriptlang.org/docs/handbook/jsx.html)'
 
       tag 'tsx'
       filenames '*.tsx'

--- a/spec/visual/samples/jsx
+++ b/spec/visual/samples/jsx
@@ -1,8 +1,6 @@
 var myDivElement = <div className="foo" />;
 ReactDOM.render(myDivElement, document.getElementById('example'));
 
-
-
 var MyComponent = React.createClass({/*...*/});
 var myElement = <MyComponent someProperty={true} />;
 ReactDOM.render(myElement, document.getElementById('example'));

--- a/spec/visual/samples/jsx
+++ b/spec/visual/samples/jsx
@@ -48,15 +48,6 @@ var content = (
   </Nav>
 );
 
-var App = (
-  <Form>
-    <FormRow>
-      <FormLabel />
-      <FormInput />
-    </FormRow>
-  </Form>
-);
-
 var thing = <A b={function() { var c = <D e={true}>&quot;</D>; }()}/>
 
 class LikeButton extends React.Component {

--- a/spec/visual/samples/jsx
+++ b/spec/visual/samples/jsx
@@ -1,3 +1,7 @@
+<header className="App-header">
+  Hello React!
+</header>
+
 var myDivElement = <div className="foo" />;
 ReactDOM.render(myDivElement, document.getElementById('example'));
 

--- a/spec/visual/samples/tsx
+++ b/spec/visual/samples/tsx
@@ -81,3 +81,30 @@ ReactDOM.render(
   <LikeButton />,
   document.getElementById('example')
 );
+
+const withAuthRedirect = (route: string, redirectIfAuthed: boolean) => <P,>(
+  Page: NextComponentType<NextPageContext, {}, P>
+) => {
+  return class extends React.Component<P> {
+    static async getInitialProps(ctx: NextPageContext) {
+      const shouldContinue = await redirectBasedOnLogin(
+        ctx,
+        route,
+        redirectIfAuthed
+      );
+      if (!shouldContinue) {
+        return {};
+      }
+      if (Page.getInitialProps) {
+        return Page.getInitialProps(ctx);
+      }
+    }
+
+    render() {
+      return <Page {...this.props} />;
+    }
+  };
+};
+
+export const withLoginRedirect = withAuthRedirect('/login', false);
+export const withDashboardRedirect = withAuthRedirect('/dashboard', true);

--- a/spec/visual/samples/tsx
+++ b/spec/visual/samples/tsx
@@ -81,30 +81,3 @@ ReactDOM.render(
   <LikeButton />,
   document.getElementById('example')
 );
-
-const withAuthRedirect = (route: string, redirectIfAuthed: boolean) => <P,>(
-  Page: NextComponentType<NextPageContext, {}, P>
-) => {
-  return class extends React.Component<P> {
-    static async getInitialProps(ctx: NextPageContext) {
-      const shouldContinue = await redirectBasedOnLogin(
-        ctx,
-        route,
-        redirectIfAuthed
-      );
-      if (!shouldContinue) {
-        return {};
-      }
-      if (Page.getInitialProps) {
-        return Page.getInitialProps(ctx);
-      }
-    }
-
-    render() {
-      return <Page {...this.props} />;
-    }
-  };
-};
-
-export const withLoginRedirect = withAuthRedirect('/login', false);
-export const withDashboardRedirect = withAuthRedirect('/dashboard', true);


### PR DESCRIPTION
The JSX lexer is implemented with an embedded version of itself that is used for lexing interpolated text. This is not the manner in which other lexers handle interpolation and so makes maintenance difficult as patterns developed in other lexers for handling interpolation cannot be brought across. It also makes subclassing the lexer difficult (a practical concern because the TSX lexer subclasses the JSX lexer).

To fix this, this PR rewrites the JSX lexer. By using two interpolation states, it obviates the need for an embedded version.

~In the course of implementation, it was discovered that the JavaScript lexer contains a bug in the `:statement` state. This state contains a rule for lexing braces but this rule causes the `:object` state to never be closed. The bug was discovered in the implementation of the rewrite because braces are used to begin and end interpolation.~

~Having a simplified implementation of the JSX lexer makes it straightforward to implement a more robust TSX lexer. The PR includes a version of the TSX lexer that fixes a bug where generics that are expressed in the form `<T,>` would not be lexed correctly.~

This fixes #1517.