### PR TITLE
Support the 'a' keyword in SPARQL lexer

### DIFF
--- a/lib/rouge/lexers/sparql.rb
+++ b/lib/rouge/lexers/sparql.rb
@@ -35,12 +35,12 @@ module Rouge
       state :root do
         rule %r(\s+)m, Text::Whitespace
         rule %r(#.*), Comment::Single
-        
+
         rule %r("""), Str::Double, :string_double_literal
         rule %r("), Str::Double, :string_double
         rule %r('''), Str::Single, :string_single_literal
         rule %r('), Str::Single, :string_single
-       
+
         rule %r([$?]\w+), Name::Variable
         rule %r((\w*:)(\w+)?) do |m|
           token Name::Namespace, m[1]
@@ -49,7 +49,7 @@ module Rouge
         rule %r(<[^>]*>), Name::Namespace
         rule %r(true|false)i, Keyword::Constant
         rule %r/a\b/, Keyword
-        
+
         rule %r([A-Z]\w+\b)i do |m|
           if self.class.builtins.include? m[0].upcase
             token Name::Builtin
@@ -102,7 +102,7 @@ module Rouge
         end
         mixin :string_single_common
       end
-      
+
       state :string_single_literal do
         rule %r(''') do
           token Str::Single

--- a/lib/rouge/lexers/sparql.rb
+++ b/lib/rouge/lexers/sparql.rb
@@ -48,6 +48,7 @@ module Rouge
         end
         rule %r(<[^>]*>), Name::Namespace
         rule %r(true|false)i, Keyword::Constant
+        rule %r/a\b/, Keyword
         
         rule %r([A-Z]\w+\b)i do |m|
           if self.class.builtins.include? m[0].upcase

--- a/spec/visual/samples/sparql
+++ b/spec/visual/samples/sparql
@@ -52,3 +52,11 @@ false
 '''The librarian said, "Perhaps you would enjoy 'War and Peace'."'''
 """The librarian said, 'Perhaps you would enjoy "War and Peace".'"""
 "\u4444 and \U88888888"
+
+# `a` keyword
+PREFIX : <http://example.org/#>
+SELECT ?item ?itemLabel
+WHERE
+{
+    ?item a :Test .
+}


### PR DESCRIPTION
The case-sensitive keyword `a` is a valid keyword in SPARQL ([reference](https://www.w3.org/TR/sparql11-query/#sparqlGrammar)). At present, the SPARQL lexer does not recognise it as such. This PR fixes that error (the rule is similar to [the one](https://github.com/rouge-ruby/rouge/blob/bbdf8c8d2e241f37212bbc865a3c4e9c5dcbf522/lib/rouge/lexers/turtle.rb#L52) used in the Turtle lexer).

This fixes #1486.