### PR TITLE
Allow empty prefix in Turtle lexer

### DIFF
--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -53,7 +53,7 @@ module Rouge
 
         rule %r/\s+/, Text::Whitespace
 
-        rule %r/[^:;<>#\@"\(\).\[\]\{\} ]+:/, Name::Namespace
+        rule %r/[^:;<>#\@"\(\).\[\]\{\} ]*:/, Name::Namespace
         rule %r/[^:;<>#\@"\(\).\[\]\{\} ]+/, Name
       end
     end

--- a/spec/visual/samples/turtle
+++ b/spec/visual/samples/turtle
@@ -58,3 +58,9 @@
 
 	<https://data.cssz.cz/resource/dataset/zanikle-duchody/id2> a adms:Identifier ;
 	skos:notation "https://data.cssz.cz/dataset/zanikle-duchody"^^<http://purl.org/spar/datacite/url> .
+
+@prefix : <http://example.org/#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+: a :AdditionalTest ;
+  rdfs:comment ":-)"^^: .

--- a/spec/visual/samples/turtle
+++ b/spec/visual/samples/turtle
@@ -52,7 +52,7 @@
 	dcterms:modified "2015-09-06T23:59:12"^^xsd:dateTime ;
 	owl:versionInfo "5.0" ;
 	adms:versionNotes "Lepší než předtim"@cs, "This version is better"@en .
-	
+
 	<https://data.cssz.cz/resource/dataset/zanikle-duchody/id1> a adms:Identifier ;
 	skos:notation "https://data.cssz.cz/dataset/pocet-zaniklych-duchodu-v-ceske-republice"^^<http://purl.org/spar/datacite/url> .
 


### PR DESCRIPTION
An empty prefix (`:` as distinct from `<prefix>:`) is permitted in Terse RDF Triple Language. However, the current lexer requires at least one character before the `:`. This PR removes that requirement.

It fixes #1485.