### PR TITLE
Improve consistency of lexing of class-like names in C++ lexer

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -22,10 +22,10 @@ module Rouge
 
       def self.keywords
         @keywords ||= super + Set.new(%w(
-          asm auto catch const_cast delete dynamic_cast explicit export
-          friend mutable namespace new operator private protected public
-          reinterpret_cast restrict size_of static_cast template this throw
-          throws typeid typename using virtual final override
+          asm auto catch const_cast delete dynamic_cast explicit export friend
+          mutable namespace new operator private protected public
+          reinterpret_cast restrict size_of static_cast this throw throws
+          typeid typename using virtual final override
 
           alignas alignof constexpr decltype noexcept static_assert
           thread_local try
@@ -58,6 +58,7 @@ module Rouge
 
       prepend :statements do
         rule %r/(class|struct)\b/, Keyword, :classname
+        rule %r/template\b/, Keyword, :template
         rule %r/\d+(\.\d+)?(?:h|(?:min)|s|(?:ms)|(?:us)|(?:ns))/, Num::Other
         rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
         rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float
@@ -76,6 +77,12 @@ module Rouge
         rule %r/\s*(?=>)/m, Text, :pop!
         rule %r/[.]{3}/, Operator
         mixin :whitespace
+      end
+
+      state :template do
+        rule %r/>/, Punctuation, :pop!
+        rule %r/(class|struct|typename)\b/, Keyword, :classname
+        mixin :root
       end
     end
   end

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -57,7 +57,7 @@ module Rouge
       dq = /\d('?\d)*/
 
       prepend :statements do
-        rule %r/class\b/, Keyword, :classname
+        rule %r/(class|struct)\b/, Keyword, :classname
         rule %r/\d+(\.\d+)?(?:h|(?:min)|s|(?:ms)|(?:us)|(?:ns))/, Num::Other
         rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
         rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -81,7 +81,7 @@ module Rouge
 
       state :template do
         rule %r/>/, Punctuation, :pop!
-        rule %r/(class|struct|typename)\b/, Keyword, :classname
+        rule %r/typename\b/, Keyword, :classname
         mixin :root
       end
     end

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -78,6 +78,22 @@ double distance = [](double x, double y, double xx, double yy) -> double {
   return abs(x-xx) + abs(y-yy);
 };
 
+// templates
+namespace N
+{
+  template<class T>
+  class Y // template definition
+  {
+    void mf() { }
+  };
+}
+template class N::Y<char*>;
+template void N::Y<double>::mf();
+template struct Z<double>;
+template<typename T> concept C1 = sizeof(T) != sizeof(int);
+template<C1 T> struct S1 { };
+template<C1 T> using Ptr = T*;
+
 // variadic template
 template<class F, class... Args>
 void forward_args(F f, Args... args) {


### PR DESCRIPTION
Rouge's C++ lexer currently tokenises identifiers that come after the `class` keyword with the `Name::Class` token and identifiers that come after the `struct` keyword with the generic `Name` token. This is despite the fact that the only difference between a struct and a class in C++ is the default access specifier. Similarly, when used in a template definition, a typename is equivalent to a class but Rouge treats the identifiers that follow the `typename` and `class` keywords differently.

This PR addresses this problem. It treats `class` and `struct` as equivalent in all cases while treating `typename` as equivalent when used in a template definition.

It fixes #1484.