### PR TITLE
Add support for labels to Kotlin lexer

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -78,6 +78,8 @@ module Rouge
         end
         rule class_name, Name::Class
         rule %r'(#{name})(?=\s*[({])', Name::Function
+        rule %r'(?<=return|continue|break|this|super)@(#{name})', Name::Decorator # label reference
+        rule %r'(#{name})@', Name::Decorator # label
         rule name, Name
       end
 

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -53,6 +53,9 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
+        rule %r'(return|continue|break|this|super)(@#{name})?' do
+          groups Keyword, Name::Decorator
+        end
         rule %r'\bfun\b', Keyword
         rule %r'\b(?:#{keywords.join('|')})\b', Keyword
         rule %r'^\s*\[.*?\]', Name::Attribute
@@ -78,7 +81,6 @@ module Rouge
         end
         rule class_name, Name::Class
         rule %r'(#{name})(?=\s*[({])', Name::Function
-        rule %r'(?<=return|continue|break|this|super)@(#{name})', Name::Decorator # label reference
         rule %r'(#{name})@', Name::Decorator # label
         rule name, Name
       end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -23,5 +23,13 @@ describe Rouge::Lexers::Kotlin do
     it 'recognizes one-line comments not followed by a newline (#797)' do
       assert_tokens_equal '// comment', ['Comment.Single', '// comment']
     end
+
+    it 'recognizes label' do
+      assert_tokens_equal 'label@', ["Name.Decorator", "label@"]
+    end
+
+    it 'recognizes label reference in break statement' do
+      assert_tokens_equal 'break@label', ["Keyword", "break"], ["Name.Decorator", "@label"]
+    end
   end
 end

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -172,4 +172,10 @@ fun anAnnotatedFunction() = {
 
 val (a, b) = pair
 
+loop@ for (i in 1..100) {
+    for (j in 1..100) {
+        if (...) break@loop
+    }
+}
+
 // comment at EOF (#797)


### PR DESCRIPTION
Hello,
I'm trying to add support for [labels](https://kotlinlang.org/docs/reference/grammar.html#label) to the Kotlin lexer. I managed to get it work for the label definition. Eg.
```kotlin
loop@ for (i in 1..100) {
```
but can't make it work for the rule for label reference. Eg.
```kotlin
if (...) break@loop 
```

I suspect the look behind group is the cause but I'm not really sure. I'd like to ask for help on this. .)

For reference how labels are used in Kotlin see the [Break and Continue Labels](https://kotlinlang.org/docs/reference/returns.html#break-and-continue-labels).