### PR TITLE
Allow incorrect braces and brackets in JSON lexer

### DIFF
--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -23,6 +23,9 @@ module Rouge
 
         mixin :name
         mixin :value
+
+        # These characters may be invalid but syntax correctness is a non-goal
+        rule %r/[\]}]/, Punctuation
       end
 
       state :object do

--- a/spec/visual/samples/json
+++ b/spec/visual/samples/json
@@ -142,3 +142,7 @@ null
                \"ci_builds\".\"name\", \"ci_builds\".\"commit_id\")" }
 
 {"message":"\\\"retry_count\\\":0}\"}"}
+
+ "This is a test": "of missing opening brace"
+}
+

--- a/spec/visual/samples/json
+++ b/spec/visual/samples/json
@@ -143,6 +143,11 @@ null
 
 {"message":"\\\"retry_count\\\":0}\"}"}
 
- "This is a test": "of missing opening brace"
+ "This is a test": "of missing an opening brace"
 }
+
+ "This is a test": "of missing an opening bracket"
+]
+
+{"This is a correct": "JSON object"}
 


### PR DESCRIPTION
The JSON lexer will mark closing braces and brackets as an error if they do not have a matching opening brace/bracket. As checking syntactic correctness is a non-goal of Rouge, this PR instead adds a rule to the `:root` state to permits these characters.

This fixes #1467.