### PR TITLE
Use qualified method name for calls to Kernel#load

### DIFF
--- a/bin/rougify
+++ b/bin/rougify
@@ -3,8 +3,8 @@
 
 require 'pathname'
 ROOT_DIR = Pathname.new(__FILE__).dirname.parent
-load ROOT_DIR.join('lib/rouge.rb')
-load ROOT_DIR.join('lib/rouge/cli.rb')
+Kernel::load ROOT_DIR.join('lib/rouge.rb')
+Kernel::load ROOT_DIR.join('lib/rouge/cli.rb')
 Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include? 'PIPE'
 
 begin

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -12,7 +12,7 @@ module Rouge
 
   class << self
     def reload!
-      Object.send :remove_const, :Rouge
+      Object::send :remove_const, :Rouge
       Kernel::load __FILE__
     end
 

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -13,7 +13,7 @@ module Rouge
   class << self
     def reload!
       Object.send :remove_const, :Rouge
-      load __FILE__
+      Kernel::load __FILE__
     end
 
     # Highlight some text with a given lexer and formatter.
@@ -40,7 +40,7 @@ module Rouge
     #
     # @api private
     def load_file(path)
-      load File.join(LIB_DIR, "rouge/#{path}.rb")
+      Kernel::load File.join(LIB_DIR, "rouge/#{path}.rb")
     end
 
     # Load the lexers in the `lib/rouge/lexers` directory.

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -511,7 +511,7 @@ module Rouge
     def self.load_lexer(relpath)
       return if @_loaded_lexers.key?(relpath)
       @_loaded_lexers[relpath] = true
-      load File.join(BASE_DIR, relpath)
+      Kernel::load File.join(BASE_DIR, relpath)
     end
   end
 end

--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -13,7 +13,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load File.join(Lexers::BASE_DIR, 'apache/keywords.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'apache/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -19,7 +19,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load File.join(Lexers::BASE_DIR, 'gherkin/keywords.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'gherkin/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/isbl.rb
+++ b/lib/rouge/lexers/isbl.rb
@@ -10,7 +10,7 @@ module Rouge
       filenames '*.isbl'
 
       def self.builtins
-        load File.join(Lexers::BASE_DIR, 'isbl/builtins.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'isbl/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -36,7 +36,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load File.join(Lexers::BASE_DIR, 'lasso/keywords.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'lasso/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -25,7 +25,7 @@ module Rouge
       end
 
       def self.builtins
-        load File.join(Lexers::BASE_DIR, 'lua/builtins.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'lua/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -56,7 +56,7 @@ module Rouge
 
       # The list of built-in symbols comes from a wolfram server and is created automatically by rake
       def self.builtins
-        load File.join(Lexers::BASE_DIR, 'mathematica/builtins.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'mathematica/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -20,7 +20,7 @@ module Rouge
 
       # self-modifying method that loads the builtins file
       def self.builtins
-        load File.join(Lexers::BASE_DIR, 'matlab/builtins.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'matlab/builtins.rb')
         builtins
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -29,7 +29,7 @@ module Rouge
       end
 
       def self.builtins
-        load File.join(Lexers::BASE_DIR, 'php/builtins.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'php/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/sqf.rb
+++ b/lib/rouge/lexers/sqf.rb
@@ -55,7 +55,7 @@ module Rouge
       end
 
       def self.commands
-        load File.join(Lexers::BASE_DIR, "sqf/commands.rb")
+        Kernel::load File.join(Lexers::BASE_DIR, "sqf/commands.rb")
         @commands = self.commands
       end
 

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -14,7 +14,7 @@ module Rouge
       mimetypes 'text/x-vim'
 
       def self.keywords
-        load File.join(Lexers::BASE_DIR, 'viml/keywords.rb')
+        Kernel::load File.join(Lexers::BASE_DIR, 'viml/keywords.rb')
         self.keywords
       end
 

--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -18,8 +18,7 @@ class VisualTestApp < Sinatra::Application
   DEMOS = ROOT.join('lib/rouge/demos')
 
   def reload_source!
-    Object.send :remove_const, :Rouge
-    load ROUGE_LIB
+    Rouge.reload!
   end
 
   def query_string


### PR DESCRIPTION
Rouge loads various components of the library using `Kernel#load`. In certain situations, this can cause issues where `load` is redefined at the global level. To ensure maximum compatibility with other libraries, this PR replaces all calls of `load` with qualified calls to `Kernel::load`.