### PR TITLE
Fix escape sequences in Python's raw strings

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -186,9 +186,7 @@ module Rouge
           end
         end
 
-        rule %r/(?=\\)/ do |m|
-          push :generic_escape
-        end
+        rule %r/(?=\\)/, Str, :generic_escape
 
         rule %r/{/ do |m|
           if current_string.type? "f"

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -202,6 +202,7 @@ module Rouge
         rule %r(\\
           ( [\\abfnrtv"']
           | \n
+          | newline
           | N{[a-zA-Z][a-zA-Z ]+[a-zA-Z]}
           | u[a-fA-F0-9]{4}
           | U[a-fA-F0-9]{8}

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -47,6 +47,7 @@ def baz():
     '\UaaaaAF09'
     '\xaf\xAF\x09'
     '\007'
+    '.*\[p00t_(d\d{4})\].*' # This should include errors
 
 # escaped characters in raw strings
 def baz():
@@ -56,6 +57,7 @@ def baz():
     r'\UaaaaAF09'
     r'\xaf\xAF\x09'
     r'\007'
+    r'.*\[p00t_(d\d{4})\].*' # This should not include errors
 
 # line continuations
 apple.filter(x, y)

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -47,7 +47,7 @@ def baz():
     '\UaaaaAF09'
     '\xaf\xAF\x09'
     '\007'
-    '.*\[p00t_(d\d{4})\].*' # This should include errors
+    '.*\[p00t_(d\d{4})\].*' # There are no escape sequences in this string
 
 # escaped characters in raw strings
 def baz():
@@ -57,7 +57,7 @@ def baz():
     r'\UaaaaAF09'
     r'\xaf\xAF\x09'
     r'\007'
-    r'.*\[p00t_(d\d{4})\].*' # This should not include errors
+    r'.*\[p00t_(d\d{4})\].*'
 
 # line continuations
 apple.filter(x, y)


### PR DESCRIPTION
Version 3.18.0 of Rouge included a new mechanism for handling strings in the Python lexer. One of the consequences of that change was that raw strings would break if they included 'invalid' escape sequences. This is a mistake as raw strings do not have 'invalid' escape sequences.

This PR fixes that error by adding a special state for escape sequences with raw strings. A separate state is still necessary because `\` can be used in raw strings to prevent the particular string's delimiter from matching.

This fixes #1507.