### PR TITLE
Allow Unicode in Python identifiers

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -67,8 +67,8 @@ module Rouge
         )
       end
 
-      identifier =        /[a-z_][a-z0-9_]*/i
-      dotted_identifier = /[a-z_.][a-z0-9_.]*/i
+      identifier =        /[[:alpha:]_][[:alpha:][:digit:]_]*/i
+      dotted_identifier = /[[:alpha:]_.][[:alpha:][:digit:]_.]*/i
 
       def current_string
         @string_register ||= StringRegister.new

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -67,8 +67,8 @@ module Rouge
         )
       end
 
-      identifier =        /[[:alpha:]_][[:alpha:][:digit:]_]*/i
-      dotted_identifier = /[[:alpha:]_.][[:alpha:][:digit:]_.]*/i
+      identifier =        /[[:alpha:]_][[:alnum:]_]*/
+      dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
 
       def current_string
         @string_register ||= StringRegister.new

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -150,3 +150,8 @@ x @= y
 f'{hello} world {int(x) + 1}'
 f'{{ {4*10} }}'
 f'result: {value:{width}.{precision}}'
+
+# Unicode identifiers
+α = 10
+def coöperative(б):
+    return f"{б} is Russian"


### PR DESCRIPTION
- Allow unicode in Python identifiers instead of only ascii. The official specification is located [here](https://docs.python.org/3/reference/lexical_analysis.html#identifiers).

I've used #1414 as inspiration.

----

Note that this solution is not 100% correct, as [this](https://stackoverflow.com/a/54059733) answer on StackOverflow explains. I do however believe it is an improvement over the current situation: in almost all cases it will be correct, except for a few very rare cases. It didn't seem worth it to complicate the lexer a bunch for those few cases.