### PR TITLE
Detect CommonJS (.cjs) files

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -15,7 +15,7 @@ module Rouge
 
       tag 'javascript'
       aliases 'js'
-      filenames '*.js', '*.mjs'
+      filenames '*.cjs', '*.js', '*.mjs'
       mimetypes 'application/javascript', 'application/x-javascript',
                 'text/javascript', 'text/x-javascript'
 

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -17,7 +17,9 @@ describe Rouge::Lexers::Javascript do
     include Support::Guessing
 
     it 'guesses by filename' do
+      assert_guess :filename => 'foo.cjs'
       assert_guess :filename => 'foo.js'
+      assert_guess :filename => 'foo.mjs'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
In Node.js, JavaScript file names can end in [`.cjs`](https://nodejs.org/api/esm.html#esm_enabling).