### PR TITLE
Fix RuboCop grouped expression warning in Python lexer

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -210,7 +210,7 @@ module Rouge
           | [0-7]{1,3}
           )
         )x do
-          token (current_string.type?("r") ? Str : Str::Escape)
+          current_string.type?("r") ? token(Str) : token(Str::Escape)
           pop!
         end
 


### PR DESCRIPTION
The use of a ternary in code added to the Python lexer as part of the #1508 pull request results in a RuboCop warning concerning parentheses and grouped expressions. This PR fixes that warning.