### PR TITLE
Add *.cshtml file glob to HTML lexer

### DIFF
--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -7,7 +7,7 @@ module Rouge
       title "HTML"
       desc "HTML, the markup language of the web"
       tag 'html'
-      filenames '*.htm', '*.html', '*.xhtml'
+      filenames '*.htm', '*.html', '*.xhtml', '*.cshtml'
       mimetypes 'text/html', 'application/xhtml+xml'
 
       def self.detect?(text)

--- a/spec/lexers/html_spec.rb
+++ b/spec/lexers/html_spec.rb
@@ -65,6 +65,7 @@ describe Rouge::Lexers::HTML do
       assert_guess :filename => 'foo.html'
       assert_guess :filename => 'foo.htm'
       assert_guess :filename => 'foo.xhtml'
+      assert_guess :filename => 'foo.cshtml'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
'Razor syntax' is a feature of ASP.NET web programming. By convention, files that use this syntax, use the `.cshtml` extension. While Rouge does not properly support Razor syntax, discussion in #873 indicates that the HTML lexer would be preferable to these files being lexed as plaintext.

This PR adds the file glob and a test. It fixes #873.