### PR TITLE
Add explicit support for scope resolution operator in C++ lexer

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -68,6 +68,7 @@ module Rouge
         rule %r/#{dq}[lu]*/i, Num::Integer
         rule %r/\bnullptr\b/, Name::Builtin
         rule %r/(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
+        rule %r/::/, Operator
       end
 
       state :classname do
@@ -83,6 +84,11 @@ module Rouge
         rule %r/>/, Punctuation, :pop!
         rule %r/typename\b/, Keyword, :classname
         mixin :root
+      end
+
+      state :case do
+        rule %r/:(?!:)/, Punctuation, :pop!
+        mixin :statements
       end
     end
   end

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -60,7 +60,7 @@ decltype(a->x) ax = a->x;
 
 // strongly typed enums
 enum class Day {
-  Mon, Tue, Wed, Thur, Fri, Sat, Sun
+    Mon, Tue, Wed, Thur, Fri, Sat, Sun
 };
 Day today = Day::Mon;
 
@@ -81,11 +81,11 @@ double distance = [](double x, double y, double xx, double yy) -> double {
 // templates
 namespace N
 {
-  template<class T>
-  class Y // template definition
-  {
-    void mf() { }
-  };
+    template<class T>
+    class Y // template definition
+    {
+        void mf() { }
+    };
 }
 template class N::Y<char*>;
 template void N::Y<double>::mf();
@@ -97,22 +97,22 @@ template<C1 T> using Ptr = T*;
 // variadic template
 template<class F, class... Args>
 void forward_args(F f, Args... args) {
-  f(std::forward<Args>(args)...);
+    f(std::forward<Args>(args)...);
 }
 
 // namespace
 namespace printing {
-  inline namespace latest {
-    using std::cout;
-    void print() {
-      cout << "Latest print\n";
-    }
-  }
-  namespace old {
-    void print() {
-      ::printf("Old print\n");
-    }
-  }
+    inline namespace latest {
+        using std::cout;
+        void print() {
+            cout << "Latest print\n";
+        }
+     }
+     namespace old {
+          void print() {
+              ::printf("Old print\n");
+          }
+     }
 }
 printing::print();
 printing::latest::print();
@@ -125,47 +125,47 @@ oldPrint::print();
 [[deprecated("useless")]] void doNothing() {}
 
 namespace std {
-  class thread {
-  public:
-    // types:
-    class id;
-    typedef void *native_handle_type;
+    class thread {
+    public:
+        // types:
+        class id;
+        typedef void *native_handle_type;
 
-    // construct/copy/destroy:
-    thread() noexcept;
-    template <class F, class ...Args> explicit thread(F&& f, Args&&... args);
-    ~thread();
-    thread(const thread&) = delete;
-    thread(thread&&) noexcept;
-    thread& operator=(const thread&) = delete;
-    thread& operator=(thread&&) noexcept;
+        // construct/copy/destroy:
+        thread() noexcept;
+        template <class F, class ...Args> explicit thread(F&& f, Args&&... args);
+        ~thread();
+        thread(const thread&) = delete;
+        thread(thread&&) noexcept;
+        thread& operator=(const thread&) = delete;
+        thread& operator=(thread&&) noexcept;
 
-    // members:
-    void swap(thread&) noexcept;
-    bool joinable() const noexcept;
-    void join();
-    void detach();
-    id get_id() const noexcept;
-    native_handle_type native_handle();
+        // members:
+        void swap(thread&) noexcept;
+        bool joinable() const noexcept;
+        void join();
+        void detach();
+        id get_id() const noexcept;
+        native_handle_type native_handle();
 
-    // static members:
-    static unsigned hardware_concurrency() noexcept;
-  };
+        // static members:
+        static unsigned hardware_concurrency() noexcept;
+    };
 }
 
 // try-block
 try {
-  throw std::runtime_error("Runtime error!");
+    throw std::runtime_error("Runtime error!");
 } catch (std::exception& e) {
-  std::cerr << e.what() << std::endl;
+    std::cerr << e.what() << std::endl;
 }
 
 constexpr int factorial(int n) {
-  return n > 0 ? n * factorial(n - 1) : 1;
+    return n > 0 ? n * factorial(n - 1) : 1;
 }
 
 /* foo */ #if 0
- this is commented
+    this is commented
 #endif
 
 /* it shouldn't hang */        /* trying to lex this */
@@ -190,22 +190,22 @@ constexpr int factorial(int n) {
 class Base
 {
 public:
-  Base () = default;
-  virtual ~Base () = default;
+    Base () = default;
+    virtual ~Base () = default;
 
-  virtual void foo () = 0;
+    virtual void foo () = 0;
 };
 
 class Derived final : public Base
 {
 public:
-  Derived () = default;
-  virtual ~Derived () = default;
+    Derived () = default;
+    virtual ~Derived () = default;
 
-  virtual void foo () override
-  {
-     auto a = 1 + 2;
-  }
+    virtual void foo () override
+    {
+        auto a = 1 + 2;
+    }
 };
 
 #define foo bar
@@ -213,31 +213,36 @@ public:
 
 class Highlighter : public QSyntaxHighlighter
 {
-   class InnerClass {}
+    class InnerClass {}
 
-   Q_OBJECT
+    Q_OBJECT
 
 public:
-   Highlighter(QTextDocument *parent = 0);
+    Highlighter(QTextDocument *parent = 0);
 
 protected:
-   void highlightBlock(const QString &text);
+    void highlightBlock(const QString &text);
 
 private:
-   struct HighlightingRule
-   {
-       QRegExp pattern;
-       QTextCharFormat format;
-   };
-   QVector<HighlightingRule> highlightingRules;
+    struct HighlightingRule
+    {
+        QRegExp pattern;
+        QTextCharFormat format;
+    };
+    QVector<HighlightingRule> highlightingRules;
 
-   QRegExp commentStartExpression;
-   QRegExp commentEndExpression;
+    QRegExp commentStartExpression;
+    QRegExp commentEndExpression;
 
-   QTextCharFormat keywordFormat;
-   QTextCharFormat classFormat;
-   QTextCharFormat singleLineCommentFormat;
-   QTextCharFormat multiLineCommentFormat;
-   QTextCharFormat quotationFormat;
-   QTextCharFormat functionFormat;
+    QTextCharFormat keywordFormat;
+    QTextCharFormat classFormat;
+    QTextCharFormat singleLineCommentFormat;
+    QTextCharFormat multiLineCommentFormat;
+    QTextCharFormat quotationFormat;
+    QTextCharFormat functionFormat;
 };
+
+switch (foo) {
+    case Foo::kBar:
+        break;
+}


### PR DESCRIPTION
The C++ lexer inherits the majority of its rules from the C lexer. While this approach reduces duplication, it can cause issues where assumptions that are correct in C, cause issues in C++.

One such issue occurs when the scope resolution operator, `::`, is used in a `case` statement. The C lexer contains a rule that treats colons in a `case` statement as representing the 'end' of that state. While the assumption that a colon would not otherwise occur in a `case` statement is correct in C, that is not the case in C++. The scope resolution operator uses two colons and it can occur within a `case` statement.

This PR creates a new `:case` state in the C++ lexer that uses a negative lookahead to avoid matching a scope resolution operator. A rule matching the scope resolution operator is also prepended to the `:statements` state. This fixes #1506.