### PR TITLE
Fix erroneous brace matching rule in JavaScript lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -225,8 +225,6 @@ module Rouge
           groups Name::Label, Text, Punctuation
         end
 
-        rule %r/[{}]/, Punctuation
-
         mixin :expr_start
       end
 


### PR DESCRIPTION
The JavaScript lexer contains a bug in the `:statement` state. This state contains a rule for lexing braces but this rule prevents Rouge from ever leaving the `:object` state.

While this does not manifest itself in visible errors in most situations, it has the potential to cause subtle bugs and does not fit the mental model a user would have trying to understand how the
JavaScript lexer is implemented.

This PR fixes the problem by removing the rule.