### PR TITLE
Change the way common methods are mixed in to TypeScript-based lexers

### DIFF
--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -7,7 +7,7 @@ module Rouge
     load_lexer 'typescript/common.rb'
 
     class TSX < JSX
-      include TypescriptCommon
+      extend TypescriptCommon
 
       title 'TypeScript'
       desc 'tsx'

--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -7,7 +7,7 @@ module Rouge
     load_lexer 'typescript/common.rb'
 
     class Typescript < Javascript
-      include TypescriptCommon
+      extend TypescriptCommon
 
       title "TypeScript"
       desc "TypeScript, a superset of JavaScript"

--- a/lib/rouge/lexers/typescript/common.rb
+++ b/lib/rouge/lexers/typescript/common.rb
@@ -4,27 +4,27 @@
 module Rouge
   module Lexers
     module TypescriptCommon
-      def self.keywords
+      def keywords
         @keywords ||= super + Set.new(%w(
           is namespace static private protected public
           implements readonly
         ))
       end
 
-      def self.declarations
+      def declarations
         @declarations ||= super + Set.new(%w(
           type abstract
         ))
       end
 
-      def self.reserved
+      def reserved
         @reserved ||= super + Set.new(%w(
           string any void number namespace module
           declare default interface keyof
         ))
       end
 
-      def self.builtins
+      def builtins
         @builtins ||= super + %w(
           Pick Partial Readonly Record
         )


### PR DESCRIPTION
Sometimes it makes sense for a Rouge lexer to inherit methods from more than one class. Ruby does not have multiple class inheritance and so the idiomatic solution in Rouge is to extract the methods that should be shared into a common module that can be mixed in to the relevant lexers.

A Ruby module can be mixed in via either calling `include` or `extend`. If the module is mixed in via `include`, then the methods are added as instance methods of the mixing class. If the module is mixed in via `extend`, the methods are added to the singleton class of the mixing class. Given the way Rouge is architected, it is more correct for the common module to be extended (not doing so can cause issues with overloading methods).

This PR updates the TypeScript and TSX lexers to mix in the `TypescriptCommon` module by calling `extend` rather than `include`.