### PR TITLE
Permit use of trailing comma in generics in TSX lexer

### DIFF
--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -14,6 +14,13 @@ module Rouge
 
       tag 'tsx'
       filenames '*.tsx'
+
+      prepend :element_name do
+        rule %r/(\w+)(,)/ do
+          groups Name::Other, Punctuation
+          pop! 3
+        end
+      end
     end
   end
 end

--- a/spec/visual/samples/tsx
+++ b/spec/visual/samples/tsx
@@ -81,3 +81,30 @@ ReactDOM.render(
   <LikeButton />,
   document.getElementById('example')
 );
+
+const withAuthRedirect = (route: string, redirectIfAuthed: boolean) => <P,>(
+  Page: NextComponentType<NextPageContext, {}, P>
+) => {
+  return class extends React.Component<P> {
+    static async getInitialProps(ctx: NextPageContext) {
+      const shouldContinue = await redirectBasedOnLogin(
+        ctx,
+        route,
+        redirectIfAuthed
+      );
+      if (!shouldContinue) {
+        return {};
+      }
+      if (Page.getInitialProps) {
+        return Page.getInitialProps(ctx);
+      }
+    }
+
+    render() {
+      return <Page {...this.props} />;
+    }
+  };
+};
+
+export const withLoginRedirect = withAuthRedirect('/login', false);
+export const withDashboardRedirect = withAuthRedirect('/dashboard', true);


### PR DESCRIPTION
When TypeScript is used with React, the syntax for generics (`<T>`) causes conflicts. The solution is to include a trailing comma (`<T,>`). This PR updates the TSX lexer to support this use of a trailing comma.

This fixes #1363.