### PR TITLE
Add support for nullish coalescing operator to TypeScript lexer

### DIFF
--- a/lib/rouge/lexers/typescript/common.rb
+++ b/lib/rouge/lexers/typescript/common.rb
@@ -33,6 +33,7 @@ module Rouge
       def self.extended(base)
         base.prepend :root do
           rule %r/[?][.]/, base::Punctuation
+          rule %r/[?]{2}/, base::Operator
         end
 
         base.prepend :statement do

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -206,4 +206,4 @@ const z = `Hello world`;
 
 // Nullish coalescing in template strings
 const content = `Value is ${value ?? 'not set'}`;
-const description = "Highlighting is broken now";
+const description = "Highlighting is not broken now";

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -203,3 +203,7 @@ declare module "foo" {
 const x = `Hello world ${a.b}`;
 const y = `Hello world ${a?.b}`;
 const z = `Hello world`;
+
+// Nullish coalescing in template strings
+const content = `Value is ${value ?? 'not set'}`;
+const description = "Highlighting is broken now";


### PR DESCRIPTION
An upcoming ECMAScript feature is the nullish coalescing operator, `??`. While it is not part of ECMAScript yet, it is [supported in TypeScript](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing). However, the current TypeScript lexer breaks when lexing it in template strings. This PR fixes this by adding a rule to match against this operator.

This fixes #1516.