### PR TITLE
Move common rules to common module for TypeScript lexer

### DIFF
--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -18,17 +18,6 @@ module Rouge
       filenames '*.ts', '*.d.ts'
 
       mimetypes 'text/typescript'
-
-      prepend :root do
-        rule %r/[?][.]/, Punctuation
-      end
-
-      prepend :statement do
-        rule %r/(#{Javascript.id_regex})(\??)(\s*)(:)/ do
-          groups Name::Label, Punctuation, Text, Punctuation
-          push :expr_start
-        end
-      end
     end
   end
 end

--- a/lib/rouge/lexers/typescript/common.rb
+++ b/lib/rouge/lexers/typescript/common.rb
@@ -29,6 +29,19 @@ module Rouge
           Pick Partial Readonly Record
         )
       end
+
+      def self.extended(base)
+        base.prepend :root do
+          rule %r/[?][.]/, base::Punctuation
+        end
+
+        base.prepend :statement do
+          rule %r/(#{Javascript.id_regex})(\??)(\s*)(:)/ do
+            groups base::Name::Label, base::Punctuation, base::Text, base::Punctuation
+            push :expr_start
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Because the TSX lexer needs to inherit from both the TypeScript lexer and the JSX lexer (and because Ruby does not have multiple inheritance), most of the TypeScript lexer was extracted into a common module.

Some rules were not moved, though and this caused differences in the output from the TypeScript and TSX lexers that were not correct. This fixes that problem by adopting the same approach used with the ObjectiveC common module: using Ruby's `Module#extended` hook.