### PR TITLE
Diff lexer - add extra check for catching duplicate lines

### DIFF
--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -14,7 +14,7 @@ module Rouge
       def self.detect?(text)
         return true if text.start_with?('Index: ')
         return true if text =~ %r(\Adiff[^\n]*?\ba/[^\n]*\bb/)
-        return true if text =~ /(---|[+][+][+]).*?\n(---|[+][+][+])/
+        return true if text =~ /---.*?\n[+][+][+]/ || text =~ /[+][+][+].*?\n---/
       end
 
       state :root do

--- a/spec/lexers/diff_spec.rb
+++ b/spec/lexers/diff_spec.rb
@@ -46,5 +46,17 @@ index d228e4b..560b687 100644
  load load_dir.join('rouge/lexers/text.rb')
       source
     end
+
+    it 'does not detect invalid diff-like sources' do
+      deny_guess :source => <<-source
+---4
+---2
+      source
+
+      deny_guess :source => <<-source
++++4
++++2
+      source
+    end
   end
 end


### PR DESCRIPTION
As described in #1531, the Diff lexer was catching lines that started with either --- or +++ however that includes two consecutive --- lines, or two +++ lines.

This extra checks considers just the two combos, either ---/+++ or +++/---.

Hoping I'm not missing anything and we can't _actually_ have diff types that have two consecutive `---` or `+++` lines.