### PR TITLE
Fix incorrect predicate usage in PowerShell lexer

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -201,7 +201,7 @@ module Rouge
         rule %r/(?:#{KEYWORDS})\b(?![-.])/i, Keyword::Reserved
 
         rule %r/-{1,2}\w+/, Name::Tag
-        
+
         rule %r/(\.)?([-\w]+)(\[)/ do |m|
           groups Operator, Name::Function, Punctuation
           push :bracket
@@ -209,12 +209,12 @@ module Rouge
 
         rule %r/([\/\\~\w][-.:\/\\~\w]*)(\n)?/ do |m|
           groups Name::Function, Text::Whitespace
-          push :parameters unless m[2]
+          push :parameters
         end
 
         rule %r/(\.)?([-\w]+)(?:(\()|(\n))?/ do |m|
           groups Operator, Name::Function, Punctuation, Text::Whitespace
-          push :parameters unless m[3]
+          push :parameters unless m[3].nil?
         end
 
         rule %r/[-+*\/%=!.&|]/, Operator

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -188,6 +188,9 @@ Function Get-IPv4Scopes
 
 } #end function
 
+Write-Output "Updating: $($file.FullName)"
+# $content = Get-Content $file.FullName
+
 # Without Error
 $gitUserName = "$($userAdObject.Properties['sn']), $($userAdObject.Properties['givenName'])"
 


### PR DESCRIPTION
The PowerShell lexer includes rules that use the existence of a `nil` value in a regular expression to decide whether to push new states onto the stack. The predicates for these rules were written incorrectly. This PR removes one of the predicates (which wasn't necessary) and uses `Object#nil?` in the other to match correctly.

This fixes #1535.