### PR TITLE
Fix YARD error when parsing LiveScript lexer

### DIFF
--- a/lib/rouge/lexers/livescript.rb
+++ b/lib/rouge/lexers/livescript.rb
@@ -196,7 +196,7 @@ module Rouge
         rule %r/[#][{]/, Str::Interpol, :interpolated_expression
         # without curly braces
         rule %r/(#)(#{id})/ do |m|
-          groups Str::Interpol, if self.class.builtins.include? m[2] then Name::Builtin else Name::Variable end
+          groups Str::Interpol, (self.class.builtins.include? m[2]) ? Name::Builtin : Name::Variable
         end
       end
 


### PR DESCRIPTION
A single line if-statement in the LiveScript lexer caused an error when YARD attempted to parse the code. Replacing it with a ternary statement fixed the problem. This is actually the code that is in the v3.20.0 gem.