### PR TITLE
Allow @ before REM in Batchfile lexer

### DIFF
--- a/lib/rouge/lexers/batchfile.rb
+++ b/lib/rouge/lexers/batchfile.rb
@@ -78,7 +78,7 @@ module Rouge
 
       state :basic do
         # Comments
-        rule %r/\brem\b.*$/i, Comment
+        rule %r/@?\brem\b.*$/i, Comment
         # Empty Labels
         rule %r/^::.*$/, Comment
 

--- a/spec/visual/samples/batchfile
+++ b/spec/visual/samples/batchfile
@@ -11,6 +11,7 @@ set /a num=0xff
 set /p "=qwerty." < nul
 echo %~dp0
 rem all okay
+@rem "sample"
 :: this is an empty label
 attrib.exe +r file.txt 2>nul
 for /f "tokens=1" %%a in ('echo hello %username% hi ^'') do echo %%~a


### PR DESCRIPTION
@ symbol tells the command interpreter to not show any prompts. Special casing it for `rem` so that using `@` also indicates a comment.

This syntax is used by Gradle for instance: https://github.com/gradle/gradle/blob/master/gradlew.bat