### PR TITLE
Maint: Restrict empty-matching regexes

### DIFF
--- a/lib/rouge/lexers/elm.rb
+++ b/lib/rouge/lexers/elm.rb
@@ -78,13 +78,13 @@ module Rouge
         rule %r/"/, Str::Double, :pop!
       end
 
-      # Multiple line string with tripple double quotes, e.g. """ multi """
+      # Multiple line string with triple double quotes, e.g. """ multi """
       state :multiline_string do
-        rule %r/\s*"""/, Str, :pop!
-        rule %r/.*/, Str
-        rule %r/\s*/, Str
+        rule %r/\\"/, Str::Escape
+        rule %r/"""/, Str, :pop!
+        rule %r/[^"]+/, Str
+        rule %r/"/, Str
       end
-
     end
   end
 end

--- a/lib/rouge/lexers/ghc_core.rb
+++ b/lib/rouge/lexers/ghc_core.rb
@@ -27,8 +27,9 @@ module Rouge
         mixin :function
 
         # rest is Text
+        # TODO: this is really inefficient
         rule %r/\s/m, Text
-        rule %r/.*/, Text
+        rule %r/./, Text
       end
 
       state :expression do

--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -20,7 +20,7 @@ module Rouge
         end
 
         rule %r/\bfragment\b/, Keyword, :fragment_definition
-        
+
         rule %r/\bscalar\b/, Keyword, :value
 
         rule %r/\b(?:type|interface|enum)\b/, Keyword, :type_definition

--- a/lib/rouge/lexers/isbl.rb
+++ b/lib/rouge/lexers/isbl.rb
@@ -41,7 +41,7 @@ module Rouge
 
       state :dotted do
         mixin :whitespace
-        rule %r/[a-zа-яё_0-9]*/i do |m|
+        rule %r/[a-zа-яё_0-9]+/i do |m|
           name = m[0]
           if self.class.constants.include? name.downcase
             token Name::Builtin
@@ -56,7 +56,7 @@ module Rouge
 
       state :type do
         mixin :whitespace
-        rule %r/[a-zа-яё_0-9]*/i do |m|
+        rule %r/[a-zа-яё_0-9]+/i do |m|
           name = m[0]
           if self.class.interfaces.include? name.downcase
             token Keyword::Type

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -263,9 +263,10 @@ module Rouge
 
       # template strings
       state :template_string do
-        rule %r/\${/, Punctuation, :template_string_expr
+        rule %r/[$]{/, Punctuation, :template_string_expr
         rule %r/`/, Str::Double, :pop!
-        rule %r/(\\\\|\\[\$`]|[^\$`]|\$(?!{))*/, Str::Double
+        rule %r/\\[$`]/, Str::Escape
+        rule %r/[$]/, Str::Double
       end
 
       state :template_string_expr do

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -48,7 +48,7 @@ module Rouge
         rule %r/\\![btrnNf0\\"]/, Str::Escape
         rule %r/\\/, Str::Double
         rule %r/"/, Str::Double, :pop!
-        rule %r/[^\\"]*/m, Str::Double
+        rule %r/[^\\"]+/m, Str::Double
       end
     end
   end

--- a/lib/rouge/lexers/jsonnet.rb
+++ b/lib/rouge/lexers/jsonnet.rb
@@ -126,6 +126,7 @@ module Rouge
 
       state :string do
         rule %r/\\([\\\/bfnrt]|(u[0-9a-fA-F]{4}))/, Str::Escape
+        rule %r/\\./, Str::Escape
       end
 
       state :string_double do
@@ -137,15 +138,15 @@ module Rouge
 
       state :string_single do
         mixin :string
-        rule %r/\\'/, Str::Escape
         rule %r/'/, Str, :pop!
         rule %r/[^\\']+/, Str
       end
 
       state :string_block do
         mixin :string
-        rule %r/\|\|\|/, Str, :pop!
-        rule %r/.*/, Str
+        rule %r/[|][|][|]/, Str, :pop!
+        rule %r/[^|\\]+/, Str
+        rule %r/[|]/, Str
       end
     end
   end

--- a/lib/rouge/lexers/jsp.rb
+++ b/lib/rouge/lexers/jsp.rb
@@ -112,9 +112,8 @@ module Rouge
 
       state :jsp_interp_literal_start do
         rule %r/'/, Literal, :pop!
-        rule %r/[^']*/, Literal
+        rule %r/[^']+/, Literal
       end
-
     end
   end
 end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -130,9 +130,10 @@ module Rouge
       end
 
       state :comment do
-        rule %r'\s*/[*].*', Comment::Multiline, :comment
-        rule %r'.*[*]/', Comment::Multiline, :pop!
-        rule %r'.*', Comment::Multiline
+        rule %r'/[*]', Comment::Multiline, :comment
+        rule %r'[*]/', Comment::Multiline, :pop!
+        rule %r'[^/*]+', Comment::Multiline
+        rule %r'[/*]', Comment::Multiline
       end
     end
   end

--- a/lib/rouge/lexers/opentype_feature_file.rb
+++ b/lib/rouge/lexers/opentype_feature_file.rb
@@ -91,7 +91,6 @@ module Rouge
       state :strings do
         rule %r/"/, Str, :pop!
         rule %r/[^"%\n]+/, Str
-        rule %r/(\([a-z0-9_]+\))?[-#0 +]*([0-9]+|[*])?(\.([0-9]+|[*]))?/i, Str
       end
     end
   end

--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -118,7 +118,7 @@ module Rouge
       end
 
       state :bottom do
-        rule %r/.*\z/m, Comment::Multiline
+        rule %r/.+\z/m, Comment::Multiline
       end
     end
   end

--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -12,29 +12,29 @@ module Rouge
             state :basic do
               rule %r/\s+/, Text
               rule %r/#.*/, Comment::Single
-      
+
               rule %r/[\[\](){}|.,;!]/, Punctuation
-      
+
               rule %r/"[^"]*"/, Str::Double
-      
+
               rule %r/-?\d+\.\d+([eE][+-]?\d+)?/, Num::Float
               rule %r/-?\d+([eE][+-]?\d+)?/, Num
 
               rule %r/\\u[0-9a-fA-F]{4}/, Num::Hex
               rule %r/\\["\/bfnrt]/, Str::Escape
             end
-      
+
             state :atoms do
               rule %r/(true|false|null)/, Keyword::Constant
-              rule %r/[[:word:]]*/, Str::Symbol
+              rule %r/[[:word:]]+/, Str::Symbol
             end
-      
+
             state :operators do
               rule %r/(=|!=|>=|<=|>|<|\+|-|\*|%|\/|\||&|:=)/, Operator
               rule %r/(default|not|package|import|as|with|else|some)/, Operator
               rule %r/[\/:?@^~]+/, Operator
             end
-      
+
             state :root do
               mixin :basic
               mixin :operators

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -90,7 +90,7 @@ module Rouge
       end
 
       state :regex_flags do
-        rule %r/[mixounse]*/, Str::Regex, :pop!
+        rule %r/[mixounse]+/, Str::Regex, :pop!
       end
 
       # double-quoted string and symbol
@@ -267,7 +267,7 @@ module Rouge
       end
 
       state :test_heredoc do
-        rule %r/[^#\\\n]*$/ do |m|
+        rule %r/[^#\\\n]+$/ do |m|
           tolerant, heredoc_name = @heredoc_queue.first
           check = tolerant ? m[0].strip : m[0].rstrip
 

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -41,7 +41,7 @@ module Rouge
         end
 
 
-        rule(/.*?(?={[\/a-zA-Z0-9$#*"'])|.*/m) { delegate parent }
+        rule(/.+?(?={[\/a-zA-Z0-9$#*"'])/m) { delegate parent }
         rule(/.+/m) { delegate parent }
       end
 

--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -18,7 +18,6 @@ module Rouge
 
       state :whitespaces_and_comments do
         rule %r/\s+/m, Text::Whitespace
-        rule %r/$+/m, Text::Whitespace
         rule %r(//.*$), Comment::Single
         rule %r(/\*(.|\s)*?\*/)m, Comment::Multiline
       end

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -133,7 +133,7 @@ module Rouge
           raise "please pass `rule` a token to yield or a callback"
         end
 
-        matches_empty = re.match?('')
+        matches_empty = re =~ ''
 
         callback ||= case next_state
         when :pop!
@@ -177,10 +177,12 @@ module Rouge
 
       def context_sensitive?(re)
         source = re.source
-        return true if /[(][?]<?[!=]/.match?(source)
+        return true if source =~ /[(][?]<?[!=]/
 
         # anchors count as lookahead/behind
-        return true if /[$^]/.match?(source)
+        return true if source =~ /[$^]/
+
+        false
       end
 
       def close!

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -12,7 +12,7 @@ module Rouge
       end
 
       def to_s
-        "regex #{@re.inspect} matches empty string, but is not empty!"
+        "regex #{@re.inspect} matches empty string, but has no predicate!"
       end
     end
 


### PR DESCRIPTION
It is very common for a lexer developer to accidentally include a regex that matches the empty string, which can cause a number of issues. This patch restricts the use of empty-matching regexes in two ways:

* A regex that matches the empty string *must* have a predicate - either pushing a new state, `:pop!`, or a custom block. Otherwise it will infinite-loop.

* Any empty-matching regex that does not contain lookahead/lookbehind causes the state to be "closed" - no more rules can be added. This is because these regexes must serve as "default" rules, and it's guaranteed that the processing won't continue past them.