### PR TITLE
Fix character escaping in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -188,12 +188,14 @@ module Rouge
         mixin :string_intp
         rule %r/\\[\\tnrabefluLUE"$@]/, Str::Escape
         rule %r/\\0\d{2}/, Str::Escape
+        rule %r/\\o\{\d+\}/, Str::Escape
         rule %r/\\x\h{2}/, Str::Escape
-        rule %r/\\x\{\h{4}\}/, Str::Escape
+        rule %r/\\x\{\h+\}/, Str::Escape
         rule %r/\\c./, Str::Escape
         rule %r/\\N\{[^\}]+\}/, Str::Escape
         rule %r/[^\\"]+?/, Str::Double
         rule %r/"/, Punctuation, :pop!
+        rule %r/\\/, Str::Escape
       end
 
       state :bq do

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -186,7 +186,12 @@ module Rouge
 
       state :dq do
         mixin :string_intp
-        rule %r/\\[\\tnr"$@]/, Str::Escape
+        rule %r/\\[\\tnrabefluLUE"$@]/, Str::Escape
+        rule %r/\\0\d{2}/, Str::Escape
+        rule %r/\\x\h{2}/, Str::Escape
+        rule %r/\\x\{\h{4}\}/, Str::Escape
+        rule %r/\\c./, Str::Escape
+        rule %r/\\N\{[^\}]+\}/, Str::Escape
         rule %r/[^\\"]+?/, Str::Double
         rule %r/"/, Punctuation, :pop!
       end

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -178,14 +178,15 @@ module Rouge
       end
 
       state :sq do
-        rule %r/\\[']/, Str::Escape
+        rule %r/\\[\\']/, Str::Escape
         rule %r/[^\\']+/, Str::Single
         rule %r/'/, Punctuation, :pop!
+        rule %r/\\/, Str::Single
       end
 
       state :dq do
         mixin :string_intp
-        rule %r/\\[\\tnr"]/, Str::Escape
+        rule %r/\\[\\tnr"$@]/, Str::Escape
         rule %r/[^\\"]+?/, Str::Double
         rule %r/"/, Punctuation, :pop!
       end

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -60,7 +60,13 @@ $s =~ y/[]|/()&/; # "backward" compatible
 
 
 # quoted strings
+my $a = 'foo';
+my $a = 'foo\'s bar';
+my $a = 'foo\bar';
+my $a = 'foo\\bar';
 my $a = "foo";
+my $a = "foo \" bar";
+my $a = "foo\bar";
 
 print "a: ";
 print $a, " - ";

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -67,6 +67,7 @@ my $a = 'foo\\bar';
 my $a = "foo";
 my $a = "foo \" bar";
 my $a = "foo\bar";
+my $a = "foo \057 \x7f \x{263a} \cC \N{GREEK SMALL LETTER SIGMA} bar";
 
 print "a: ";
 print $a, " - ";

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -68,6 +68,7 @@ my $a = "foo";
 my $a = "foo \" bar";
 my $a = "foo\bar";
 my $a = "foo \057 \x7f \x{263a} \cC \N{GREEK SMALL LETTER SIGMA} bar";
+my $a = "invalid escape \w";
 
 print "a: ";
 print $a, " - ";


### PR DESCRIPTION
In single-quoted strings, the Perl lexer currently tokenises `\` as an error if it is followed by any character other than a `'`. This is a bug. Perl accepts the use of `\` in single-quoted strings.

In the course of fixing this, errors in the handling of character escaping in double-quoted strings was also addressed. In that case, `$` and `@` are also valid characters to escape. The use of `\` can still produce `Error` tokens in double-quoted strings if followed by another character.

This fixes #1163.