### PR TITLE
Remove Dockerfile_ file glob from Docker lexer

### DIFF
--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Dockerfile syntax"
       tag 'docker'
       aliases 'dockerfile'
-      filenames 'Dockerfile', '*.Dockerfile', '*.docker', 'Dockerfile_*'
+      filenames 'Dockerfile', '*.Dockerfile', '*.docker'
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/spec/lexers/docker_spec.rb
+++ b/spec/lexers/docker_spec.rb
@@ -11,7 +11,6 @@ describe Rouge::Lexers::Docker do
       assert_guess :filename => 'Dockerfile'
       assert_guess :filename => 'docker.docker'
       assert_guess :filename => 'some.Dockerfile'
-      assert_guess :filename => 'Dockerfile_some_extension'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
In addition to adding the `*.Dockerfile` file glob, #1059 added a file glob for `Dockerfile_*` to address #1070. However, as noted by #1539, this causes issues for files that begin with `dockerfile_` but that are not Dockerfiles.

While I am the one that merged #1059, I now believe it was a mistake to add the `Dockerfile_*` file glob and it should be removed. This is a non-standard name and is not recognised by other lexing libraries (see [Pygments](https://github.com/pygments/pygments/blob/dd7a72a636be6423cfdec52d73e41dd92abcaa06/pygments/lexers/configs.py), [Chroma](https://github.com/alecthomas/chroma/blob/57c1bd941c39be8b5cebedb6b7c4bcedc7c801b7/lexers/d/docker.go), [Linguist](https://github.com/github/linguist/blob/a3627f3839334545ac3d21b264a4014a05aae4ea/lib/linguist/languages.yml#L1171-L1182)). I was not aware of this feature at the time but the correct fix for the issue that precipitated #1070 is to use a `.gitattributes` file as explained [here](https://docs.gitlab.com/ee/user/project/highlighting.html).

While this is technically a breaking change and should wait for the Rouge 4.0 release, I think it makes sense to characterise it as a bug that can be fixed as part of the next release of Rouge 3.0.

This fixes #1539.