### PR TITLE
Support using grave character to escape characters in PowerShell lexer

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -165,6 +165,7 @@ module Rouge
       end
 
       state :parameters do
+        rule %r/`./m, Str::Escape
         rule %r/\s*?\n/, Text::Whitespace, :pop!
         rule %r/[;(){}\]]/, Punctuation, :pop!
         rule %r/[|=]/, Operator, :pop!

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -95,7 +95,7 @@ process {
 }
 
 ###########################
-# Control structures 
+# Control structures
 ###########################
 
 if ($var1 -eq $var2)
@@ -114,15 +114,15 @@ Foreach ($Thing in $Things ) {
 }
 
 ###########################
-# Classes 
+# Classes
 ###########################
 
 class Child : Parent, Relatives {
     [int] hidden $var = 8
-    
+
     Child ([string]$a, [string]$b, [int]$capacity) {
         $this.var = $a
-    } 
+    }
 
     [string]toString() {
         return "A string"

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -194,5 +194,8 @@ Write-Output "Updating: $($file.FullName)"
 # Without Error
 $gitUserName = "$($userAdObject.Properties['sn']), $($userAdObject.Properties['givenName'])"
 
-# With Error
+# Grave escaping
 $gitExeString = "$gitExeFolder\git.exe" &("$gitExeString") config --add --global user.name `"$gitUserName`"
+hildItem -Include *.txt `
+    -Recurse
+Write-Output `$hello

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -196,6 +196,6 @@ $gitUserName = "$($userAdObject.Properties['sn']), $($userAdObject.Properties['g
 
 # Grave escaping
 $gitExeString = "$gitExeFolder\git.exe" &("$gitExeString") config --add --global user.name `"$gitUserName`"
-hildItem -Include *.txt `
+Get-ChildItem -Include *.txt `
     -Recurse
 Write-Output `$hello


### PR DESCRIPTION
The `` ` `` character escapes characters in PowerShell statements. This PR adds support for it to the `:paramaters` state. It fixes #1542.