### PR TITLE
Fix nesting of raw and verbatim tags in Jinja/Twig lexers

### DIFF
--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -41,7 +41,7 @@ module Rouge
         rule %r/##.*/, Comment
 
         # Raw and verbatim
-        rule %r/({%)(\s*)(raw|verbatim)(\s*)(%})/ do |m|
+        rule %r/({%-?)(\s*)(raw|verbatim)(\s*)(-?%})/ do |m|
           groups Comment::Preproc, Text, Keyword, Text, Comment::Preproc
           case m[3]
           when "raw"
@@ -148,7 +148,7 @@ module Rouge
       end
 
       state :raw do
-        rule %r/({%)(\s*)(endraw)(\s*)(%})/ do
+        rule %r/({%-?)(\s*)(endraw)(\s*)(-?%})/ do
           groups Comment::Preproc, Text, Keyword, Text, Comment::Preproc
           pop!
         end
@@ -157,7 +157,7 @@ module Rouge
       end
 
       state :verbatim do
-        rule %r/({%)(\s*)(endverbatim)(\s*)(%})/ do
+        rule %r/({%-?)(\s*)(endverbatim)(\s*)(-?%})/ do
           groups Comment::Preproc, Text, Keyword, Text, Comment::Preproc
           pop!
         end

--- a/lib/rouge/lexers/twig.rb
+++ b/lib/rouge/lexers/twig.rb
@@ -17,10 +17,10 @@ module Rouge
 
       def self.keywords
         @@keywords ||= %w(as do extends flush from import include use else starts
-                          ends with without autoescape endautoescape block endblock
-                          embed endembed filter endfilter for endfor if endif
-                          macro endmacro sandbox endsandbox set endset
-                          spaceless endspaceless verbatim endverbatim)
+                          ends with without autoescape endautoescape block
+                          endblock embed endembed filter endfilter for endfor
+                          if endif macro endmacro sandbox endsandbox set endset
+                          spaceless endspaceless)
       end
 
       def self.tests


### PR DESCRIPTION
The current Jinja lexer ends a `raw` or `verbatim` block when the lexer encounters either `endraw` or `endverbatim`. This behaviour is incorrect. The block should only end with a matching tag.

This fixes #1166.