### PR TITLE
Support fat comma in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -142,7 +142,7 @@ module Rouge
 
       state :fat_comma do
         rule %r/\w+/, Str
-        rule %r/\s*/, Text
+        rule %r/\s+/, Text
         rule %r/=>/, Operator, :pop!
       end
 

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -99,6 +99,9 @@ module Rouge
           re_tok, :balanced_regex
 
         rule %r/\s+/, Text
+
+        rule(/(?=[a-z_]\w*\s+=>)/i) { push :fat_comma }
+
         rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
         rule %r/((__(DIE|WARN)__)|(DATA|STD(IN|OUT|ERR)))\b/,
           Name::Builtin::Pseudo
@@ -135,6 +138,12 @@ module Rouge
           Operator
         rule %r/[()\[\]:;,<>\/?{}]/, Punctuation
         rule(/(?=\w)/) { push :name }
+      end
+
+      state :fat_comma do
+        rule %r/\w+/, Str
+        rule %r/\s+/, Text
+        rule %r/=>/, Operator, :pop!
       end
 
       state :format do

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -100,7 +100,7 @@ module Rouge
 
         rule %r/\s+/, Text
 
-        rule(/(?=[a-z_]\w*(\s*#.*)*\s*=>)/i) { push :fat_comma }
+        rule(/(?=[a-z_]\w*(\s*#.*\n)*\s*=>)/i) { push :fat_comma }
 
         rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
         rule %r/((__(DIE|WARN)__)|(DATA|STD(IN|OUT|ERR)))\b/,

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -140,16 +140,16 @@ module Rouge
         rule(/(?=\w)/) { push :name }
       end
 
+      state :format do
+        rule %r/\.\n/, Str::Interpol, :pop!
+        rule %r/.*?\n/, Str::Interpol
+      end
+
       state :fat_comma do
         rule %r/#.*/, Comment::Single
         rule %r/\w+/, Str
         rule %r/\s+/, Text
         rule %r/=>/, Operator, :pop!
-      end
-
-      state :format do
-        rule %r/\.\n/, Str::Interpol, :pop!
-        rule %r/.*?\n/, Str::Interpol
       end
 
       state :name_common do

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -65,7 +65,7 @@ module Rouge
       end
 
       state :root do
-        rule %r/#.*?$/, Comment::Single
+        rule %r/#.*/, Comment::Single
         rule %r/^=[a-zA-Z0-9]+\s+.*?\n=cut/m, Comment::Multiline
         rule %r/(?:#{keywords.join('|')})\b/, Keyword
 
@@ -100,7 +100,7 @@ module Rouge
 
         rule %r/\s+/, Text
 
-        rule(/(?=[a-z_]\w*\s*=>)/i) { push :fat_comma }
+        rule(/(?=[a-z_]\w*(\s*#.*)*\s*=>)/i) { push :fat_comma }
 
         rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
         rule %r/((__(DIE|WARN)__)|(DATA|STD(IN|OUT|ERR)))\b/,
@@ -141,6 +141,7 @@ module Rouge
       end
 
       state :fat_comma do
+        rule %r/#.*/, Comment::Single
         rule %r/\w+/, Str
         rule %r/\s+/, Text
         rule %r/=>/, Operator, :pop!

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -100,7 +100,7 @@ module Rouge
 
         rule %r/\s+/, Text
 
-        rule(/(?=[a-z_]\w*\s+=>)/i) { push :fat_comma }
+        rule(/(?=[a-z_]\w*\s*=>)/i) { push :fat_comma }
 
         rule %r/(?:#{builtins.join('|')})\b/, Name::Builtin
         rule %r/((__(DIE|WARN)__)|(DATA|STD(IN|OUT|ERR)))\b/,
@@ -142,7 +142,7 @@ module Rouge
 
       state :fat_comma do
         rule %r/\w+/, Str
-        rule %r/\s+/, Text
+        rule %r/\s*/, Text
         rule %r/=>/, Operator, :pop!
       end
 

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -164,6 +164,11 @@ sub __END__but_not_really { 1 }
 use constant EMPTY_SPACE => '&nbsp;';
 my %h = ( FOO => 23 );
 $text = format_text({FOO => 23, BAR => 30});
+foo(
+  sub # comment
+      # second comment
+    => 1
+)
 
 __DATA__
 

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -160,6 +160,11 @@ my $addOperation = $totalNumber + $myOtherVar;
 
 sub __END__but_not_really { 1 }
 
+# fat commas
+use constant EMPTY_SPACE => '&nbsp;';
+my %h = ( FOO => 23 );
+$text = format_text({FOO => 23, BAR => 30});
+
 __DATA__
 
 This is just some end text; everything after DATA can be accessed


### PR DESCRIPTION
The `=>` operator (sometimes called the 'fat comma') is an operator in Perl that causes the identifier to the immediate left of the fat comma to be treated as if it were a string. See additional explanation in the answers to [this StackOverflow question](https://stackoverflow.com/q/4093895/308909).

This fixes #1164.