### PR TITLE
Fix & selector in Sass/SCSS lexer

### DIFF
--- a/lib/rouge/lexers/sass/common.rb
+++ b/lib/rouge/lexers/sass/common.rb
@@ -29,6 +29,7 @@ module Rouge
         end
 
         rule %r/@#{id}/, Keyword, :selector
+        rule %r/&/, Keyword, :selector
 
         # $variable: assignment
         rule %r/([$]#{id})([ \t]*)(:)/ do

--- a/spec/visual/samples/sass
+++ b/spec/visual/samples/sass
@@ -157,7 +157,7 @@ body
       :padding 2px
       :border none
 
-#menu 
+#menu
   :clear both
   :text-align right
   :height 20px
@@ -167,7 +167,7 @@ body
     ul
       :margin 0 5px 0 0
       :padding 0
-      li 
+      li
         :list-style-type none
         :margin 0 5px
         :padding 5px 5px 0 5px
@@ -212,9 +212,9 @@ body
       :width 200px
       .box
         :margin-top 10px
-        p 
+        p
           :margin 0 1em auto 1em
-      .box.participants 
+      .box.participants
         img
           :float  left
           :margin 0 1em auto 1em
@@ -254,12 +254,12 @@ body
         :margin-top 0
 
 #content.contests
-  .container.information 
-    .column.right 
+  .container.information
+    .column.right
       .box
         :margin 1em 0
       .box.videos
-        .thumbnail img 
+        .thumbnail img
           :width         200px
           :height        150px
           :margin-bottom 5px
@@ -268,7 +268,7 @@ body
           :text-decoration none
         a:hover
           :text-decoration underline
-      .box.votes 
+      .box.votes
         a
           :display block
           :width  200px
@@ -285,7 +285,7 @@ body
           :text-indent -9999px
           :border-top 5px solid #a20013
 
-#content.contests 
+#content.contests
   .container.video
     .box.videos
       h2
@@ -296,13 +296,13 @@ body
         :border-top 5px solid #a20013
       table
         :width 100
-        td 
+        td
           :padding 1em
           :width 25
           :vertical-align top
           p
             :margin 0 0 5px 0
-          a:link, a:visited    
+          a:link, a:visited
             :color #93d700
             :text-decoration none
           a:hover
@@ -315,13 +315,13 @@ body
           :margin 0 10px 0 0
           :border 1px solid #6e000d
 
-#content 
-  .container.comments 
+#content
+  .container.comments
     .column
       :margin-top 15px
     .column.left
       :width 600px
-      .box 
+      .box
         ol
           :margin  0
           :padding 0
@@ -377,16 +377,16 @@ body
     :float right
 
 
-.clear 
+.clear
   :clear both
 
-.centered 
+.centered
   :text-align center
 
 img
   :border none
 
-button.short 
+button.short
   :width   60px
   :height  22px
   :padding 0 0 2px 0

--- a/spec/visual/samples/sass
+++ b/spec/visual/samples/sass
@@ -397,4 +397,12 @@ button.short
 table
   :border-collapse collapse
 
+body
+  &.open > button::after
+    color: red
+
+body
+  &::after
+    color: red
+
 // Comment at EOF (#797)

--- a/spec/visual/samples/scss
+++ b/spec/visual/samples/scss
@@ -66,13 +66,13 @@ body {
   }
 
   ul {
-    @include horizontal-list; 
+    @include horizontal-list;
     padding: 0 0 0 25px;
     li {
       @include incr(18px);
       padding: 0 20px 0 0;
       text-transform: uppercase;
-      a { 
+      a {
         color: #febf0f;
         text-decoration: none;
         width: 100px;
@@ -86,7 +86,7 @@ body {
         @include replace-text("header-timeline-text.jpg");
       }
     }
-  } 
+  }
 }
 
 #paging {
@@ -99,8 +99,8 @@ body {
     color: #908f8b;
     padding-right: 20px;
     text-transform: uppercase;
-    a { 
-      color: #f07b07; 
+    a {
+      color: #f07b07;
       text-decoration: none;
     }
   }
@@ -109,18 +109,18 @@ body {
     @include horizontal-list;
     li {
       padding: 3px 4px;
-      a { 
+      a {
         color: #4c4c4c;
         @include replace-text("thread-paging-inactive-bullet.jpg");
         width: 10px;
         height: 10px;
         display: block;
       }
-      &.active a { 
+      &.active a {
         color: #f17d06;
         background-image: image_@import "compass";
       }
-    } 
+    }
   }
 }
 
@@ -152,7 +152,7 @@ body {
 
     @for $i from 0 through 30 {
     &.position#{$i} {
-      left: ($i * -910px); 
+      left: ($i * -910px);
     }
   }
 }
@@ -163,7 +163,7 @@ body {
     width: 100%;
   }
 
-  #thread { 
+  #thread {
     padding: 0;
     width: 5000px;
     position: absolute;
@@ -278,15 +278,15 @@ body {
   }
 
   ul {
-    @include horizontal-list; 
+    @include horizontal-list;
 
     li {
       padding: 0 30px 0 0;
-      a { 
+      a {
         text-decoration: none;
-        color: #ef7a06; 
+        color: #ef7a06;
       }
-    } 
+    }
   }
 }
 

--- a/spec/visual/samples/scss
+++ b/spec/visual/samples/scss
@@ -290,4 +290,16 @@ body {
   }
 }
 
+body {
+  &.open > button::after {
+    color: red;
+  }
+}
+
+body {
+  &::after {
+    color: red;
+  }
+}
+
 // Comment at EOF (#797)


### PR DESCRIPTION
The `&` selector does not match correctly if it is combined with certain characters. This PR fixes the problem by adding a rule matching `&` to `:content_common`.

It fixes #841.