### PR TITLE
Support template parameter packs in C++ lexer

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -75,25 +75,22 @@ module Rouge
         rule id, Name::Class, :pop!
 
         # template specification
-        rule %r/\s*(?=>)/m, Text, :pop!
         rule %r/[.]{3}/, Operator
+        rule %r/(?=>)/, Text, :pop!
         mixin :whitespace
       end
 
       state :template do
-        rule %r/>/, Punctuation, :pop!
-        rule %r/(typename)([ ,]?)/ do |m|
-          case m[2]
-          when " "
+        rule %r/[>;]/, Punctuation, :pop!
+        rule %r/(typename\b)(\s?)/ do |m|
+          if m[2].empty?
+            token Keyword
+          else
             groups Keyword, Text
             push :classname
-          when ","
-            groups Keyword, Punctuation
-          else
-            token Keyword
           end
         end
-        mixin :root
+        mixin :statements
       end
 
       state :case do

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -75,21 +75,15 @@ module Rouge
         rule id, Name::Class, :pop!
 
         # template specification
-        rule %r/[.]{3}/, Operator
-        rule %r/(?=>)/, Text, :pop!
         mixin :whitespace
+        rule %r/[.]{3}/, Operator
+        rule %r/,/, Punctuation, :pop!
+        rule(//) { pop! }
       end
 
       state :template do
         rule %r/[>;]/, Punctuation, :pop!
-        rule %r/(typename\b)(\s?)/ do |m|
-          if m[2].empty?
-            token Keyword
-          else
-            groups Keyword, Text
-            push :classname
-          end
-        end
+        rule %r/typename\b/, Keyword, :classname
         mixin :statements
       end
 

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -82,7 +82,17 @@ module Rouge
 
       state :template do
         rule %r/>/, Punctuation, :pop!
-        rule %r/typename\b/, Keyword, :classname
+        rule %r/(typename)([ ,]?)/ do |m|
+          case m[2]
+          when " "
+            groups Keyword, Text
+            push :classname
+          when ","
+            groups Keyword, Punctuation
+          else
+            token Keyword
+          end
+        end
         mixin :root
       end
 

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -94,6 +94,7 @@ template<typename T> concept C1 = sizeof(T) != sizeof(int);
 template<C1 T> struct S1 { };
 template<C1 T> using Ptr = T*;
 template <typename, typename...>
+template<class...> struct Tuple { };
 
 // variadic template
 template<class F, class... Args>

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -93,6 +93,7 @@ template struct Z<double>;
 template<typename T> concept C1 = sizeof(T) != sizeof(int);
 template<C1 T> struct S1 { };
 template<C1 T> using Ptr = T*;
+template <typename, typename...>
 
 // variadic template
 template<class F, class... Args>

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -95,6 +95,7 @@ template<C1 T> struct S1 { };
 template<C1 T> using Ptr = T*;
 template <typename, typename...>
 template<class...> struct Tuple { };
+template<typename ...Ts> void f(Ts...) {}
 
 // variadic template
 template<class F, class... Args>


### PR DESCRIPTION
Template parameters are more complicated than you could possibly imagine. This adds support for template parameter packs.

It fixes #1546.