### PR TITLE
Fix identifier matching in Rego lexer

### DIFF
--- a/lib/rouge/lexers/rego.rb
+++ b/lib/rouge/lexers/rego.rb
@@ -9,36 +9,51 @@ module Rouge
             tag 'rego'
             filenames '*.rego'
 
+            def self.constants
+              @constants ||= Set.new %w(
+                true false null
+              )
+            end
+
+            def self.operators
+              @operators ||= Set.new %w(
+                as default else import not package some with
+              )
+            end
+
             state :basic do
               rule %r/\s+/, Text
               rule %r/#.*/, Comment::Single
-      
+
               rule %r/[\[\](){}|.,;!]/, Punctuation
-      
+
               rule %r/"[^"]*"/, Str::Double
-      
+
               rule %r/-?\d+\.\d+([eE][+-]?\d+)?/, Num::Float
               rule %r/-?\d+([eE][+-]?\d+)?/, Num
 
               rule %r/\\u[0-9a-fA-F]{4}/, Num::Hex
               rule %r/\\["\/bfnrt]/, Str::Escape
             end
-      
-            state :atoms do
-              rule %r/(true|false|null)/, Keyword::Constant
-              rule %r/[[:word:]]*/, Str::Symbol
-            end
-      
+
             state :operators do
               rule %r/(=|!=|>=|<=|>|<|\+|-|\*|%|\/|\||&|:=)/, Operator
-              rule %r/(default|not|package|import|as|with|else|some)/, Operator
               rule %r/[\/:?@^~]+/, Operator
             end
-      
+
             state :root do
               mixin :basic
               mixin :operators
-              mixin :atoms
+
+              rule %r/[[:word:]]+/ do |m|
+                if self.class.constants.include? m[0]
+                  token Keyword::Constant
+                elsif self.class.operators.include? m[0]
+                  token Operator::Word
+                else
+                  token Name
+                end
+              end
             end
         end
     end

--- a/spec/visual/samples/rego
+++ b/spec/visual/samples/rego
@@ -28,3 +28,10 @@ allow {
   input.path = ["finance", "salary", username]
   subordinates[input.user][_] == username
 }
+
+not obj.foo.bar.bar
+
+some_rule[msg] {
+  msg := "hey"
+}
+


### PR DESCRIPTION
The Rego lexer matches certain identifiers using `\b`. This will match identifiers that include `_`. This PR replaces these rules with a more robust generic regular expression. In addition, it changes the token used for variable names to `Name`.

It fixes #1547.