### PR TITLE
Support ? in PowerShell lexer

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -218,6 +218,7 @@ module Rouge
           push :parameters unless m[3].nil?
         end
 
+        rule %r/\?/, Name::Function, :parameters
         rule %r/[-+*\/%=!.&|]/, Operator
         rule %r/@\{/, Punctuation, :hasht
         rule %r/@\(/, Punctuation, :array

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -199,3 +199,6 @@ $gitExeString = "$gitExeFolder\git.exe" &("$gitExeString") config --add --global
 Get-ChildItem -Include *.txt `
     -Recurse
 Write-Output `$hello
+
+# Where-Object alias
+Get-process | ? {$_.workingset -gt 25000*1024}


### PR DESCRIPTION
The `?` symbol is an alias for the `Where-Object`. This PR adds support for it to the PowerShell lexer.

It closes #1557.