### PR TITLE
ruby: treat % like /: no space after method call = infix

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -374,7 +374,7 @@ module Rouge
       end
 
       state :method_call do
-        rule %r(/) do
+        rule %r(/|%) do
           token Operator
           goto :expr_start
         end

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -269,6 +269,14 @@ a.()
 %r( hash mark: # )
 %w( ! $ % # )
 
+# this is modulo
+board[i/w][i%w] == 'O'
+puts [[x%w].reverse]
+
+# this is a method that takes a list
+def x(s) puts x end
+x %w].]
+
 ##################################################################
 # HEREDOCS
 <<-CONTENT.strip_heredoc


### PR DESCRIPTION
This is consistent with what I've tested locally with `ruby -e ...`

Fixes #1562 

Thanks @0x7ffc for the report!