### PR TITLE
Add Lexer#with and Lexer.lookup_fancy

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -43,10 +43,10 @@ module Rouge
       # modify or provide additional options to the lexer.
       #
       # Please note: the lexer class might be nil!
-      def lookup_fancy(str, code=nil, additional_options={})
+      def lookup_fancy(str, code=nil, default_options={})
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
-          return [lexer_class, additional_options]
+          return [lexer_class, default_options]
         end
 
         name, opts = str ? str.split('?', 2) : [nil, '']
@@ -62,7 +62,7 @@ module Rouge
           [ k.to_s, val ]
         end
 
-        opts = additional_options.merge(Hash[opts])
+        opts = default_options.merge(Hash[opts])
 
         lexer_class = case name
         when 'guess', nil
@@ -91,8 +91,8 @@ module Rouge
       # This is used in the Redcarpet plugin as well as Rouge's own
       # markdown lexer for highlighting internal code blocks.
       #
-      def find_fancy(str, code=nil, additional_options={})
-        lexer_class, opts = lookup_fancy(str, code, additional_options)
+      def find_fancy(str, code=nil, default_options={})
+        lexer_class, opts = lookup_fancy(str, code, default_options)
 
         lexer_class && lexer_class.new(opts)
       end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -327,6 +327,8 @@ module Rouge
       @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
+    # Returns a new lexer with the given options set. Useful for e.g. setting
+    # debug flags post hoc, or providing global overrides for certain options
     def with(opts={})
       new_options = @options.dup
       opts.each { |k, v| new_options[k.to_s] = v }

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -38,28 +38,15 @@ module Rouge
         registry[name.to_s]
       end
 
-      # Find a lexer, with fancy shiny features.
+      # Same as ::find_fancy, except instead of returning an instantiated
+      # lexer, returns a pair of [lexer_class, options], so that you can
+      # modify or provide additional options to the lexer.
       #
-      # * The string you pass can include CGI-style options
-      #
-      #     Lexer.find_fancy('erb?parent=tex')
-      #
-      # * You can pass the special name 'guess' so we guess for you,
-      #   and you can pass a second argument of the code to guess by
-      #
-      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
-      #
-      #   If the code matches more than one lexer then Guesser::Ambiguous
-      #   is raised.
-      #
-      # This is used in the Redcarpet plugin as well as Rouge's own
-      # markdown lexer for highlighting internal code blocks.
-      #
-      def find_fancy(str, code=nil, additional_options={})
-
+      # Please note: the lexer class might be nil!
+      def lookup_fancy(str, code=nil, additional_options={})
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
-          return lexer_class && lexer_class.new(additional_options)
+          return [lexer_class, additional_options]
         end
 
         name, opts = str ? str.split('?', 2) : [nil, '']
@@ -83,6 +70,29 @@ module Rouge
         when String
           self.find(name)
         end
+
+        [lexer_class, opts]
+      end
+
+      # Find a lexer, with fancy shiny features.
+      #
+      # * The string you pass can include CGI-style options
+      #
+      #     Lexer.find_fancy('erb?parent=tex')
+      #
+      # * You can pass the special name 'guess' so we guess for you,
+      #   and you can pass a second argument of the code to guess by
+      #
+      #     Lexer.find_fancy('guess', "#!/bin/bash\necho Hello, world")
+      #
+      #   If the code matches more than one lexer then Guesser::Ambiguous
+      #   is raised.
+      #
+      # This is used in the Redcarpet plugin as well as Rouge's own
+      # markdown lexer for highlighting internal code blocks.
+      #
+      def find_fancy(str, code=nil, additional_options={})
+        lexer_class, opts = lookup_fancy(str, code, additional_options)
 
         lexer_class && lexer_class.new(opts)
       end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -317,6 +317,12 @@ module Rouge
       @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
+    def with(opts={})
+      new_options = @options.dup
+      opts.each { |k, v| new_options[k.to_s] = v }
+      self.class.new(new_options)
+    end
+
     def as_bool(val)
       case val
       when nil, false, 0, '0', 'false', 'off'

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -204,4 +204,16 @@ describe Rouge::Lexer do
     assert_equal false, option_lexer.new({bool_opt: 'false'}).instance_variable_get(:@bool_opt)
     assert_equal false, option_lexer.new({bool_opt: 'off'}).instance_variable_get(:@bool_opt)
   end
+
+  it 'extends options with #with' do
+    php = Rouge::Lexers::PHP.new
+
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+
+    inline_php = php.with(start_inline: true)
+    assert { inline_php.is_a?(Rouge::Lexers::PHP) }
+    assert { inline_php != php }
+    assert { php.instance_variable_get(:@start_inline) == :guess }
+    assert { inline_php.instance_variable_get(:@start_inline) == true }
+  end
 end


### PR DESCRIPTION
Rebase of #1188.

These are necessary for modifying the options of a lexer. Currently `Lexer.find_fancy` is a giant monolith, and there is no way to modify or default the lexer that is returned. `Lexer#with` allows for modifying the options after initialization, and `Lexer.lookup_fancy`, which returns the lexer class and an options hash, allows for directly manipulating the options before initialization.