### PR TITLE
Add a lexer for emails

### DIFF
--- a/lib/rouge/demos/email
+++ b/lib/rouge/demos/email
@@ -1,0 +1,11 @@
+From: Me <me@example.com>
+To: You <you@example.com>
+Date: Tue, 21 Jul 2020 15:14:03 +0000
+Subject: A very important message
+
+> Please investigate.  Thank you.
+
+I have investigated.
+
+-- 
+This message is highly confidential and will self-destruct.

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -30,6 +30,7 @@ module Rouge
       end
 
       state :root do
+        rule %r/\n/, Text
         rule %r/^>.*/, Comment
         rule %r/.*/, Text
       end

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Email < RegexLexer
+      tag 'email'
+      aliases 'eml', 'mail'
+      filenames '*.eml', '*.mail'
+      mimetypes 'message/rfc822'
+
+      title "Email"
+      desc "An email message"
+
+      def self.detect?(text)
+        return true if text.start_with?('From: ')
+      end
+
+      state :root do
+        rule %r/^(From|To|Cc|Bcc):\s/, Keyword, :address
+        rule %r/^Date:\s/, Keyword, :date
+        rule %r/^Subject:\s/, Keyword, :subject
+        rule %r/\n/m, Text::Whitespace
+        rule %r/^>.*/, Comment
+        rule %r/^--\s\n/m, Comment::Doc, :signature
+        rule %r/.*/, Text
+      end
+
+      state :address do
+        rule %r/[^\n]+\n/m, Name, :pop!
+      end
+
+      state :date do
+        rule %r/[^\n]+\n/m, Literal::Date, :pop!
+      end
+
+      state :subject do
+        rule %r/[^\n]+\n/m, Name::Label, :pop!
+      end
+
+      state :signature do
+        rule %r/.*/m, Comment::Doc
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -5,63 +5,32 @@ module Rouge
   module Lexers
     class Email < RegexLexer
       tag 'email'
-      aliases 'eml', 'mail'
-      filenames '*.eml', '*.mail'
+      aliases 'eml', 'e-mail'
+      filenames '*.eml'
       mimetypes 'message/rfc822'
 
       title "Email"
       desc "An email message"
 
-      def self.detect?(text)
-        return true if text.start_with?('From: ')
-      end
-
       start do
-        push :header
+        push :fields
       end
 
-      state :header do
-        rule %r/^(From|To|Cc|Bcc):\s/, Keyword, :address
-        rule %r/^Date:\s/, Keyword, :date
-        rule %r/^Subject:\s/, Keyword, :subject
-        rule %r/^[A-Z][A-Za-z0-9-]+:\s/, Keyword, :other_header
-        rule %r/\n/, Text::Whitespace, :pop!
+      state :fields do
+        rule %r/[:]/, Operator, :field_body
+        rule %r/[^\n\r:]+/, Name::Tag
+        rule %r/[\n\r]/, Name::Tag
+      end
+
+      state :field_body do
+        rule(/(\r?\n){2}/) { token Text; pop!(2) }
+        rule %r/\r?\n(?![ \v\t\f])/, Text, :pop!
+        rule %r/[^\n\r]+/, Name::Attribute
+        rule %r/[\n\r]/, Name::Attribute
       end
 
       state :root do
-        rule %r/\n/, Text::Whitespace
-        rule %r/^>.*$/, Comment
-        rule %r/^--\s\n/, Comment::Doc, :signature
-        rule %r/.*$/, Text
-      end
-
-      state :header_line_and_continuation do
-        rule %r/\n(?=[^ \t])/, Text::Whitespace, :pop!
-        rule %r/\n/, Text::Whitespace
-      end
-
-      state :address do
-        mixin :header_line_and_continuation
-        rule %r/.*$/, Name
-      end
-
-      state :date do
-        mixin :header_line_and_continuation
-        rule %r/.*$/, Literal::Date
-      end
-
-      state :subject do
-        mixin :header_line_and_continuation
-        rule %r/.*$/, Name::Label
-      end
-
-      state :other_header do
-        mixin :header_line_and_continuation
-        rule %r/.*$/, Literal::String
-      end
-
-      state :signature do
-        rule %r/.*/m, Comment::Doc
+        rule %r/.*/m, Text
       end
     end
   end

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -25,19 +25,19 @@ module Rouge
         rule %r/^Date:\s/, Keyword, :date
         rule %r/^Subject:\s/, Keyword, :subject
         rule %r/^[A-Z][A-Za-z0-9-]+:\s/, Keyword, :other_header
-        rule %r/\n/m, Text::Whitespace, :pop!
+        rule %r/\n/, Text::Whitespace, :pop!
       end
 
       state :root do
-        rule %r/\n/m, Text::Whitespace
+        rule %r/\n/, Text::Whitespace
         rule %r/^>.*$/, Comment
-        rule %r/^--\s\n/m, Comment::Doc, :signature
+        rule %r/^--\s\n/, Comment::Doc, :signature
         rule %r/.*$/, Text
       end
 
       state :header_line_and_continuation do
-        rule %r/\n(?=[^ \t])/m, Text::Whitespace, :pop!
-        rule %r/\n/m, Text::Whitespace
+        rule %r/\n(?=[^ \t])/, Text::Whitespace, :pop!
+        rule %r/\n/, Text::Whitespace
       end
 
       state :address do

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -30,7 +30,8 @@ module Rouge
       end
 
       state :root do
-        rule %r/.*/m, Text
+        rule %r/^>.*/, Comment
+        rule %r/.*/, Text
       end
     end
   end

--- a/spec/lexers/email_spec.rb
+++ b/spec/lexers/email_spec.rb
@@ -9,15 +9,10 @@ describe Rouge::Lexers::Email do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.eml'
-      assert_guess :filename => 'foo.mail'
     end
 
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'message/rfc822'
-    end
-
-    it 'guesses by source' do
-      assert_guess :source => 'From: Me <me@example.com>'
     end
   end
 end

--- a/spec/lexers/email_spec.rb
+++ b/spec/lexers/email_spec.rb
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Email do
+  let(:subject) { Rouge::Lexers::Email.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.eml'
+      assert_guess :filename => 'foo.mail'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'message/rfc822'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => 'From: Me <me@example.com>'
+    end
+  end
+end

--- a/spec/visual/samples/email
+++ b/spec/visual/samples/email
@@ -1,0 +1,11 @@
+From: Me <me@example.com>
+To: You <you@example.com>
+Date: Tue, 21 Jul 2020 15:14:03 +0000
+Subject: A very important message
+
+> Please investigate.  Thank you.
+
+I have investigated.
+
+-- 
+This message is highly confidential and will self-destruct.

--- a/spec/visual/samples/email
+++ b/spec/visual/samples/email
@@ -1,11 +1,23 @@
 From: Me <me@example.com>
 To: You <you@example.com>
+Cc: Somebody <somebody@example.com>,
+ And One More <andonemore@example.com>
+Bcc: Secret Person <secretperson@email.com>
+X-Spam-Status: Definitely not spam
 Date: Tue, 21 Jul 2020 15:14:03 +0000
 Subject: A very important message
+ that continues onto the next line.
 
+Greetings and salutations.
+
+>> A second-level quotation.
+>
 > Please investigate.  Thank you.
 
 I have investigated.
+
+Note: This header-like like shouldn't be highlighted
+ since it's part of the body text.
 
 -- 
 This message is highly confidential and will self-destruct.

--- a/spec/visual/samples/email
+++ b/spec/visual/samples/email
@@ -16,8 +16,8 @@ Greetings and salutations.
 
 I have investigated.
 
-Note: This header-like like shouldn't be highlighted
- since it's part of the body text.
+Note: A space-stuffed line starting with > is not a quote.
+ > like this.
 
--- 
+--
 This message is highly confidential and will self-destruct.

--- a/spec/visual/samples/email
+++ b/spec/visual/samples/email
@@ -5,7 +5,7 @@ Cc: Somebody <somebody@example.com>,
 Bcc: Secret Person <secretperson@email.com>
 X-Spam-Status: Definitely not spam
 Date: Tue, 21 Jul 2020 15:14:03 +0000
-Subject: A very important message
+Subject: RE: A very important message
  that continues onto the next line.
 
 Greetings and salutations.


### PR DESCRIPTION
This adds a lexer that highlights email headers (From, To, Cc, Bcc, Date, Subject), quoted text, unquoted text, and signatures.

Email isn't a programming language, but nevertheless I think it could be useful for Rouge to highlight email messages — for example, GitLab uses Rouge to highlight code blocks in Markdown, and my team sometimes copy-pastes emails into GitLab comments surrounded by triple-backtick code fences; this highlighter would make those emails easier to read.