### PR TITLE
Do not read ::class as opening a 'class'

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -66,7 +66,7 @@ module Rouge
         rule %r'/[*].*', Comment::Multiline, :comment # multiline block comment
         rule %r'\n', Text
         rule %r'(::)(class)' do
-          groups Operator, Name
+          groups Operator, Keyword
         end
         rule %r'::|!!|\?[:.]', Operator
         rule %r"(\.\.)", Operator

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -65,6 +65,9 @@ module Rouge
         rule %r'/[*].*[*]/', Comment::Multiline # single line block comment
         rule %r'/[*].*', Comment::Multiline, :comment # multiline block comment
         rule %r'\n', Text
+        rule %r'(::)(class)' do
+          groups Operator, Name
+        end
         rule %r'::|!!|\?[:.]', Operator
         rule %r"(\.\.)", Operator
         # Number literals


### PR DESCRIPTION
Explicitly find 'class' after the '::' operator and render as name. Prevents pushing a :class. Fixes #1571

I figured that this works. But please tell me if that is not the best way to do so :)