### PR TITLE
Bugfix: Allow rust tuple indexing

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -100,6 +100,7 @@ module Rouge
 
         rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule %r/[.]\s*#{id}/, Name::Property
+        rule %r/[.]\s*\d+/, Num::Integer
         rule %r/(#{id})(::)/m do
           groups Name::Namespace, Punctuation
         end

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -100,7 +100,7 @@ module Rouge
 
         rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule %r/[.]\s*#{id}/, Name::Property
-        rule %r/[.]\s*\d+/, Num::Integer
+        rule %r/[.]\s*\d+/, Name::Property
         rule %r/(#{id})(::)/m do
           groups Name::Namespace, Punctuation
         end

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -100,7 +100,7 @@ module Rouge
 
         rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule %r/[.]\s*#{id}/, Name::Property
-        rule %r/[.]\s*\d+/, Name::Property
+        rule %r/[.]\s*\d+/, Name::Attribute
         rule %r/(#{id})(::)/m do
           groups Name::Namespace, Punctuation
         end

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -409,3 +409,8 @@ async fn learn_and_sing() {
     let song = learn_song().await;
     sing_song(song).await;
 }
+
+fn tuple_access() {
+    let t: (i32, i32) = (42, 13);
+    let f: t.0;
+}


### PR DESCRIPTION
`lorem.0` is now supported.

Fixes #958.