### PR TITLE
Bugfix: support rust float delimiters

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -167,7 +167,7 @@ module Rouge
         flt = /f32|f64/
 
         rule %r(
-          [0-9]+
+          [0-9_]+
           (#{dot}  #{exp}? #{flt}?
           |#{dot}? #{exp}  #{flt}?
           |#{dot}? #{exp}? #{flt}

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -400,6 +400,10 @@ fn int_literals_delimiter() {
     let red_color = 0xff_60_60;
 }
 
+fn float_literals_delimiter() {
+    let billion = 1000_000_000.0;
+}
+
 // Some hidden lines by starting with hash
 # extern crate core;
 # use core::str;


### PR DESCRIPTION
1_000.0 is a valid float.