### PR TITLE
docs: use `bundle config set path` instead of deprecated `--path`

### DIFF
--- a/docs/DevEnvironment.md
+++ b/docs/DevEnvironment.md
@@ -131,11 +131,11 @@ bundle config set path 'vendor'
 bundle install
 ```
 
-This first command tells Bundler to register the directory `vendor/` as the project-specific
-install location for dependencies, and the second command installs all dependencies.
-This has one drawback (explained below) but means the gems we
-use for Rouge are isolated from the other gems we may have installed on our
-system. This will be tremendously helpful in avoiding conflicts that arise
+This first command tells Bundler to register the directory `vendor/` as
+the project-specific install location for dependencies, and the second command
+installs all dependencies. This has one drawback (explained below) but means the
+gems we use for Rouge are isolated from the other gems we may have installed on
+our system. This will be tremendously helpful in avoiding conflicts that arise
 because of the use of incompatible versions of a gem.
 
 The one drawback is that we will need to tell Ruby every time we run our Rouge

--- a/docs/DevEnvironment.md
+++ b/docs/DevEnvironment.md
@@ -127,11 +127,13 @@ Rouge comes with a list of gems it depends upon called a _Gemfile_. Make sure
 you're at the top level of your clone of your repository and type:
 
 ```shell
-bundle install --path vendor
+bundle config set path 'vendor'
+bundle install
 ```
 
-This command tells Bundler to install the gems in the Gemfile into a directory
-called `vendor/`. This has one drawback (explained below) but means the gems we
+This first command tells Bundler to register the directory `vendor/` as the project-specific
+install location for dependencies, and the second command installs all dependencies.
+This has one drawback (explained below) but means the gems we
 use for Rouge are isolated from the other gems we may have installed on our
 system. This will be tremendously helpful in avoiding conflicts that arise
 because of the use of incompatible versions of a gem.


### PR DESCRIPTION
In particular, bundle says with `--path`:

```shell
$> bundle install --path vendor
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor'`, and stop using this flag
Fetching gem metadata from http://rubygems.org/.........

...
```