### PR TITLE
Support quoting structs/tables in Janet lexer

### DIFF
--- a/lib/rouge/lexers/janet.rb
+++ b/lib/rouge/lexers/janet.rb
@@ -143,20 +143,19 @@ module Rouge
 
         rule %r/\(/, Punctuation, :function
 
-        rule %r/(')([\(\[])/ do
+        rule %r/(')([\(\[\{])/ do
           groups Operator, Punctuation
           push :quote
         end
 
-        rule %r/(~)([\(\[])/ do
+        rule %r/(~)([\(\[\{])/ do
           groups Operator, Punctuation
           push :quasiquote
         end
 
         rule %r/[\#~,';\|]/, Operator
 
-        rule %r/@?[({\[]/, Punctuation, :push
-        rule %r/[)}\]]/, Punctuation, :pop!
+        rule %r/@?[(){}\[\]]/, Punctuation
 
         rule symbol, Name
       end
@@ -169,6 +168,8 @@ module Rouge
       end
 
       state :function do
+        rule %r/[\)]/, Punctuation, :pop!
+
         rule symbol do |m|
           case m[0]
           when "quote"
@@ -187,8 +188,9 @@ module Rouge
       end
 
       state :quote do
-        rule %r/[\(\[]/, Punctuation, :push
-        rule symbol, Str::Symbol
+        rule %r/[\(\[\{]/, Punctuation, :push
+        rule %r/[\)\]\}]/, Punctuation, :pop!
+        rule symbol, Str::Escape
         mixin :root
       end
 
@@ -199,7 +201,6 @@ module Rouge
         end
         rule %r/(\()(\s*)(unquote)(\s+)(\()/ do
           groups Punctuation, Text, Keyword, Text, Punctuation
-          push :root
           push :function
         end
 

--- a/lib/rouge/lexers/janet.rb
+++ b/lib/rouge/lexers/janet.rb
@@ -143,12 +143,12 @@ module Rouge
 
         rule %r/\(/, Punctuation, :function
 
-        rule %r/(')(@?[\(\[\{])/ do
+        rule %r/(')(@?[(\[{])/ do
           groups Operator, Punctuation
           push :quote
         end
 
-        rule %r/(~)(@?[\(\[\{])/ do
+        rule %r/(~)(@?[(\[{])/ do
           groups Operator, Punctuation
           push :quasiquote
         end
@@ -188,8 +188,8 @@ module Rouge
       end
 
       state :quote do
-        rule %r/[\(\[\{]/, Punctuation, :push
-        rule %r/[\)\]\}]/, Punctuation, :pop!
+        rule %r/[(\[{]/, Punctuation, :push
+        rule %r/[)\]}]/, Punctuation, :pop!
         rule symbol, Str::Escape
         mixin :root
       end

--- a/lib/rouge/lexers/janet.rb
+++ b/lib/rouge/lexers/janet.rb
@@ -114,7 +114,7 @@ module Rouge
         end
       end
 
-      punctuation = %r/[_!@$%^&*+=~<>.?\/-]/o
+      punctuation = %r/[_!$%^&*+=~<>.?\/-]/o
       symbol = %r/([[:alpha:]]|#{punctuation})([[:word:]]|#{punctuation}|:)*/o
 
       state :root do
@@ -143,12 +143,12 @@ module Rouge
 
         rule %r/\(/, Punctuation, :function
 
-        rule %r/(')([\(\[\{])/ do
+        rule %r/(')(@?[\(\[\{])/ do
           groups Operator, Punctuation
           push :quote
         end
 
-        rule %r/(~)([\(\[\{])/ do
+        rule %r/(~)(@?[\(\[\{])/ do
           groups Operator, Punctuation
           push :quasiquote
         end

--- a/spec/visual/samples/janet
+++ b/spec/visual/samples/janet
@@ -130,6 +130,7 @@ Yet another buffer
 (def name 'myfunction)
 (def args '[x y z])
 (defn body '[(print x) (print y) (print z)])
+'{:foo (print "bar")}
 
 # Quasiquotes
 ~x

--- a/spec/visual/samples/janet
+++ b/spec/visual/samples/janet
@@ -131,6 +131,7 @@ Yet another buffer
 (def args '[x y z])
 (defn body '[(print x) (print y) (print z)])
 '{:foo (print "bar")}
+'@(print 1 2 3)
 
 # Quasiquotes
 ~x


### PR DESCRIPTION
This fixes two errors in the Janet lexer:

1. The rule in `:root` for closing parentheses, brackets and braces would cause an error if the symbol was unmatched as it would try to `pop()` from the bottom-most state. To fix this, the rule in `:root` should not `pop()` at all. Rather, there should be rules in the other states.

2. Quoting and quasi-quoting works with structs (marked by `{`). This adds support for that.