### PR TITLE
Rust: fix "await" highlight

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -99,6 +99,7 @@ module Rouge
         rule %r/[*\/!@~&+%^<>=\?-]|\.{2,3}/, Operator
 
         rule %r/([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
+        rule %r/[.]\s*await\b/, Keyword
         rule %r/[.]\s*#{id}/, Name::Property
         rule %r/[.]\s*\d+/, Name::Attribute
         rule %r/(#{id})(::)/m do


### PR DESCRIPTION
# Description

`await` is, currently, highlighted as `Name::Property`. It should be highlighted as `Keyword` as well as `async`.

# Screenshot

The source code below is borrowed from Rust's visual test (`spec/visual/samples/rust`).

## Before

Thankful-eyes theme:

![image](https://user-images.githubusercontent.com/54318333/93727457-39e42100-fbf6-11ea-9779-baf65a0b5f72.png)

GitHub theme:

![image](https://user-images.githubusercontent.com/54318333/93727462-3f416b80-fbf6-11ea-8f1f-7b178e968f85.png)

Because GitHub theme and some other themes don't highlight "Name::Property" segments, `await` is displayed as normal text.

## After

Thankful-eyes theme:

![image](https://user-images.githubusercontent.com/54318333/93727460-3cdf1180-fbf6-11ea-8080-c0a6e3c16d12.png)

GitHub theme:

![image](https://user-images.githubusercontent.com/54318333/93727467-41a3c580-fbf6-11ea-8af6-ce4b3b40d24c.png)

