### PR TITLE
Treat bats tests as shell scripts

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -11,13 +11,13 @@ module Rouge
       aliases 'bash', 'zsh', 'ksh', 'sh'
       filenames '*.sh', '*.bash', '*.zsh', '*.ksh', '.bashrc', '.zshrc',
                 '.kshrc', '.profile', 'APKBUILD', 'PKGBUILD', '*.ebuild',
-                '*.eclass', '*.exheres-0', '*.exlib'
+                '*.eclass', '*.exheres-0', '*.exlib', '*.bats'
 
       mimetypes 'application/x-sh', 'application/x-shellscript', 'text/x-sh',
                 'text/x-shellscript'
 
       def self.detect?(text)
-        return true if text.shebang?(/(ba|z|k)?sh/)
+        return true if text.shebang?(/(ba|z|k)?sh|bats/)
       end
 
       KEYWORDS = %w(

--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -47,6 +47,7 @@ describe Rouge::Lexers::Shell do
       assert_guess :filename => 'foo.eclass'
       assert_guess :filename => 'foo.exheres-0'
       assert_guess :filename => 'foo.exlib'
+      assert_guess :filename => 'foo.bats'
       deny_guess   :filename => 'foo'
     end
 
@@ -62,6 +63,7 @@ describe Rouge::Lexers::Shell do
       assert_guess :source => '   #!   /bin/bash'
       assert_guess :source => '#!/usr/bin/env bash'
       assert_guess :source => '#!/usr/bin/env bash -i'
+      assert_guess :source => '#!/usr/bin/env bats'
       deny_guess   :source => '#!/bin/smash'
       # not sure why you would do this, but hey, whatevs
       deny_guess   :source => '#!/bin/bash/python'


### PR DESCRIPTION
Adds support for .bats files as shell scripts. I just wanted GitLab to make [Bats](https://github.com/sstephenson/bats) tests look pretty by default :)
