### PR TITLE
add a :content option to http

### DIFF
--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -8,16 +8,22 @@ module Rouge
       title "HTTP"
       desc 'http requests and responses'
 
+      option :content, "the language for the content (default: auto-detect)"
+
       def self.http_methods
         @http_methods ||= %w(GET POST PUT DELETE HEAD OPTIONS TRACE PATCH)
       end
 
       def content_lexer
+        @content_lexer ||= (lexer_option(:content) || guess_content_lexer)
+      end
+
+      def guess_content_lexer
         return Lexers::PlainText unless @content_type
 
-        @content_lexer ||= Lexer.guess_by_mimetype(@content_type)
+        Lexer.guess_by_mimetype(@content_type)
       rescue Lexer::AmbiguousGuess
-        @content_lexer = Lexers::PlainText
+        Lexers::PlainText
       end
 
       start { @content_type = 'text/plain' }


### PR DESCRIPTION
This allows overriding of the auto-detected lexer for the content, resolving this comment: https://github.com/rouge-ruby/rouge/issues/1028#issuecomment-698879041

~~~
``` http?content=jsonc
HTTP/1.1 200 OK
Content-Type: application/json

{
  // Now this comment will be supported!
  "foo": "bar"
}
```
~~~