### PR TITLE
js: add a special case for safe navigation

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -162,6 +162,10 @@ module Rouge
           push :template_string
         end
 
+        # special case for the safe navigation operator ?.
+        # so that we don't start detecting a ternary expr
+        rule %r/[?][.]/, Punctuation
+
         rule %r/[?]/ do
           token Punctuation
           push :ternary

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -229,6 +229,8 @@ function* range(from, to)
   1 + 2
 }`;
 
+var notATernary = `${obj?.prop}`;
+
 @(function(thing) { return thing; })
 class Person {
   @deprecate


### PR DESCRIPTION
Fixes #1591

Previously, the example `${obj?.prop}` would result in a runaway string
literal, since the ? would start a ternary expression, and we would lose
the stack state that would cause the second ` to terminate the literal.
It is possible the handling of ? needs more care in modern javascript.