### PR TITLE
powershell: more robust handling of data structure literals

### DIFF
--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -52,6 +52,16 @@ $my_hash = @{
     thing = "table"
 }
 
+$my_complex_hash = @{
+  # comment
+  foo = {
+    if ($var1 -eq $var2)
+    {
+        return $true
+    }
+  }
+}
+
 $my_array = @("my" "array")
 
 ###########################


### PR DESCRIPTION
fixes #1579

The problem was that the hash table state was a huge special case and was not tested on larger tables with comments and code in them at all. I factored out a more generic `:expr` state that should be able to handle most of these.

I also reduced the overall level of highlighting - this is one of the lexers that suffered from over-highlighting, where too many things were emphasized with the colours. Pulling back a little allows the really important stuff to come through a bit better.