### PR TITLE
apex: fix invalid use of String#casecmp

### DIFF
--- a/lib/rouge/lexers/apex.rb
+++ b/lib/rouge/lexers/apex.rb
@@ -49,7 +49,7 @@ module Rouge
 
       state :root do
         rule %r/\s+/m, Text
-        
+
         rule %r(//.*?$), Comment::Single
         rule %r(/\*.*?\*/)m, Comment::Multiline
 
@@ -67,7 +67,7 @@ module Rouge
             token Keyword::Type
           elsif self.class.constants.include? m[0].downcase
             token Keyword::Constant
-          elsif 'package'.casecmp m[0]
+          elsif m[0].downcase == 'package'
             token Keyword::Namespace
           elsif m[1] == "@"
             token Name::Decorator


### PR DESCRIPTION
In ruby, this always returns a number, which... is always truthy. Yes,
even 0 is truthy in Ruby. (Also casecmp is 0 when they're equal, so it
would have needed negation...? idk.) This seems like the original intent
of the code, and makes the highlighting look wayyyy better. We were
mismatching colours on parentheses ><