### PR TITLE
Fix Ruby 2.7 keyword parameter deprecation warning

### DIFF
--- a/lib/rouge/formatter.rb
+++ b/lib/rouge/formatter.rb
@@ -42,8 +42,8 @@ module Rouge
     end
 
     # Format a token stream.  Delegates to {#format}.
-    def self.format(tokens, *a, &b)
-      new(*a).format(tokens, &b)
+    def self.format(tokens, *args, **kwargs, &b)
+      new(*args, **kwargs).format(tokens, &b)
     end
 
     def initialize(opts={})


### PR DESCRIPTION
This fixes the warning:

```
lib/rouge/formatter.rb:46: warning: Using the last argument as
keyword parameters is deprecated; maybe ** should be added to the call
```

More details:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/