### PR TITLE
Disable text selection for prompts and line numbers

### DIFF
--- a/lib/rouge/demos/elixir
+++ b/lib/rouge/demos/elixir
@@ -1,1 +1,2 @@
-Enum.map([1,2,3], fn(x) -> x * 2 end)
+iex> Enum.map([1,2,3], fn(x) -> x * 2 end)
+[2, 4, 6]

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -19,6 +19,7 @@ module Rouge
       state :root do
         rule %r/\s+/m, Text
         rule %r/#.*$/, Comment::Single
+        rule %r{^(iex|\.{3})>\ }, Generic::Prompt
         rule %r{\b(case|cond|end|bc|lc|if|unless|try|loop|receive|fn|defmodule|
              defp?|defprotocol|defimpl|defrecord|defmacrop?|defdelegate|
              defexception|defguardp?|defstruct|exit|raise|throw|after|rescue|catch|else)\b(?![?!])|

--- a/lib/rouge/theme.rb
+++ b/lib/rouge/theme.rb
@@ -38,6 +38,7 @@ module Rouge
         yield "font-weight: bold" if self[:bold]
         yield "font-style: italic" if self[:italic]
         yield "text-decoration: underline" if self[:underline]
+        yield "user-select: none" if self[:unselectable]
 
         (self[:rules] || []).each(&b)
       end
@@ -88,11 +89,12 @@ module Rouge
     end
 
     class << self
+      include Token::Tokens
       def style(*tokens)
         style = tokens.last.is_a?(Hash) ? tokens.pop : {}
 
         tokens.each do |tok|
-          styles[tok] = style
+          styles[tok] = unselectable_tokens.include?(tok) ? {:unselectable => true}.merge!(style) : style
         end
       end
 
@@ -129,6 +131,10 @@ module Rouge
 
       def registry
         @registry ||= {}
+      end
+      
+      def unselectable_tokens
+        [Generic::Lineno, Generic::Prompt]
       end
     end
   end

--- a/spec/theme_spec.rb
+++ b/spec/theme_spec.rb
@@ -9,6 +9,8 @@ describe Rouge::Theme do
   class MyTheme < Rouge::CSSTheme
     style Literal::String, :fg => '#003366', :bold => true
     style Literal::String::Backtick, :fg => '#555555', :italic => true
+    style Generic::Lineno, :fg => '#003366', :unselectable => false
+    style Generic::Prompt, :fg => '#003366', :bold => true
   end
 
   let(:theme) { MyTheme.new }
@@ -49,4 +51,15 @@ describe Rouge::Theme do
     style = theme.style_for(Rouge::Token['Literal.String.Char'])
     assert { style == { :fg => '#003366', :bold => true } }
   end
+  
+  it 'provides default user selection behavior for prompts and line numbers' do
+    style = theme.style_for(Rouge::Token['Generic.Prompt'])
+    assert { style == { :fg => '#003366', :bold => true, :unselectable => true } }
+  end
+  
+  it 'overrides user selection behavior when specified explicitly' do
+    style = theme.style_for(Rouge::Token['Generic.Lineno'])
+    assert { style == { :fg => '#003366', :unselectable => false } }
+  end
+  
 end


### PR DESCRIPTION
This PR proposes a small change that prevents text selection for prompts and line numbers by default. This feature might be useful in a regular scenario of copy-pasting for examples containing interactive prompts. This behavior can be easily overridden if needed. 

<details>
  <summary>Screenshots</summary>

![elixir](https://user-images.githubusercontent.com/5345029/95221485-26dd6d80-0800-11eb-86d5-5ae9e9f5f8e2.png)
![console](https://user-images.githubusercontent.com/5345029/95221492-293fc780-0800-11eb-943e-a1019a53f50c.png)

</details>

Huge thanks for this awesome project and thank you in advance for your time, patience and help!