### PR TITLE
Fix handling of square parentheses in velocity lexer

### DIFF
--- a/lib/rouge/lexers/velocity.rb
+++ b/lib/rouge/lexers/velocity.rb
@@ -63,7 +63,7 @@ module Rouge
         rule %r/0[xX][0-9a-fA-F]+[Ll]?/, Num::Hex
         rule %r/\b[0-9]+\b/, Num::Integer
         rule %r/(true|false|null)\b/, Keyword::Constant
-        rule %r/[(\[]/, Punctuation, :push!
+        rule %r/[(\[]/, Punctuation, :push
         rule %r/[)\]}]/, Punctuation, :pop!
       end
     end

--- a/spec/visual/samples/velocity
+++ b/spec/visual/samples/velocity
@@ -20,6 +20,7 @@
 </table>
 #end
 #set( $monkey.Say = ["Not", $my, "fault", 10, false, null] ) ## ArrayList
+#set( $result = $foo($bar[$baz]) )
 ${mudSlinger}
 ${customer.Address}
 ${purchase.getTotal(true)}


### PR DESCRIPTION
### Summary
Bugfix for using `[` within nested parentheses for velocity lexer.

### Details
I was seeing the following error message: `unknown state: :push!` when using a line similar to this in a .vm file.
`#set( $result = $foo($bar[$baz]) )`

This is being highlighted by `velocity.rb`

Looks like this is a result of this rule using `push!` instead of `push`: https://github.com/rouge-ruby/rouge/blob/128abf0240444be05dd60dfddc690a33ab2fdafc/lib/rouge/lexers/velocity.rb#L66

### Testing
I have added the line above to `spec/visual/samples/velocity`.
I have confirmed that with no change this causes a `unknown state: :push!` error message.
After applying my change I have confirmed that this case no longer appears. 

### Issue link
Raised an issue to track this here: https://github.com/rouge-ruby/rouge/issues/1604. This commit fixes #1604.

### Further work
I have identified that a similar issue **MAY** be present in `ceylon.rb`
https://github.com/rouge-ruby/rouge/blob/1af45d51bffebbf4a4e4c5c0576c13810c8759b0/lib/rouge/lexers/ceylon.rb#L90

I have not amended this, as I don't have the full context on this lexer. 