### PR TITLE
Fix errors from new empty regex requirements

### DIFF
--- a/lib/rouge/lexers/apex.rb
+++ b/lib/rouge/lexers/apex.rb
@@ -57,17 +57,19 @@ module Rouge
         rule %r/import\b/, Keyword::Namespace, :import
 
         rule %r/([@$.]?)(#{id})([:(]?)/io do |m|
-          if self.class.keywords.include? m[0].downcase
+          lowercased = m[0].downcase
+          uppercased = m[0].upcase
+          if self.class.keywords.include? lowercased
             token Keyword
-          elsif self.class.soql.include? m[0].upcase
+          elsif self.class.soql.include? uppercased
             token Keyword
-          elsif self.class.declarations.include? m[0].downcase
+          elsif self.class.declarations.include? lowercased
             token Keyword::Declaration
-          elsif self.class.types.include? m[0].downcase
+          elsif self.class.types.include? lowercased
             token Keyword::Type
-          elsif self.class.constants.include? m[0].downcase
+          elsif self.class.constants.include? lowercased
             token Keyword::Constant
-          elsif m[0].downcase == 'package'
+          elsif lowercased == 'package'
             token Keyword::Namespace
           elsif m[1] == "@"
             token Name::Decorator

--- a/lib/rouge/lexers/email.rb
+++ b/lib/rouge/lexers/email.rb
@@ -32,7 +32,7 @@ module Rouge
       state :root do
         rule %r/\n/, Text
         rule %r/^>.*/, Comment
-        rule %r/.*/, Text
+        rule %r/.+/, Text
       end
     end
   end

--- a/lib/rouge/lexers/j.rb
+++ b/lib/rouge/lexers/j.rb
@@ -217,12 +217,12 @@ module Rouge
 
       state :note do
         mixin :delimiter
-        rule %r/.*\n?/, Comment::Multiline
+        rule %r/.+\n?/, Comment::Multiline
       end
 
       state :noun do
         mixin :delimiter
-        rule %r/.*\n?/, Str::Heredoc
+        rule %r/.+\n?/, Str::Heredoc
       end
 
       state :code do


### PR DESCRIPTION
Merging #1548 caused some errors in lexers that had been added after the PR was originally submitted.

This commit also reduces the number of times uppercasing and lowercasing is required in the Apex lexer.