### PR TITLE
Feature: Add Dockerfile as an alias for the docker lexer.

### DIFF
--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Docker"
       desc "Dockerfile syntax"
       tag 'docker'
-      aliases 'dockerfile', "Dockerfile"
+      aliases 'dockerfile', 'Dockerfile'
       filenames 'Dockerfile', '*.Dockerfile', '*.docker'
       mimetypes 'text/x-dockerfile-config'
 

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Docker"
       desc "Dockerfile syntax"
       tag 'docker'
-      aliases 'dockerfile'
+      aliases 'dockerfile', "Dockerfile"
       filenames 'Dockerfile', '*.Dockerfile', '*.docker'
       mimetypes 'text/x-dockerfile-config'
 


### PR DESCRIPTION
This allows users use:

\`\`\`Dockerfile

When specifying a filetype in their markdown.