### PR TITLE
V4: remove the warning for Lexer#lex with an options hash

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -486,25 +486,10 @@ module Rouge
     # @option opts :continue
     #   Continue the lex from the previous state (i.e. don't call #reset!)
     #
-    # @note The use of :continue => true has been deprecated. A warning is
-    #       issued if run with `$VERBOSE` set to true.
-    #
-    # @note The use of arbitrary `opts` has never been supported, but we
-    #       previously ignored them with no error. We now warn unconditionally.
-    def lex(string, opts=nil, &b)
-      if opts
-        if (opts.keys - [:continue]).size > 0
-          # improper use of options hash
-          warn('Improper use of Lexer#lex - this method does not receive options.' +
-               ' This will become an error in a future version.')
-        end
-
-        if opts[:continue]
-          warn '`lex :continue => true` is deprecated, please use #continue_lex instead'
-          return continue_lex(string, &b)
-        end
-      end
-
+    # @note The use of :continue => true has been deprecated.
+    #       A warning was issued in v3, and support for any
+    #       option hash was removed in v4.0.0.
+    def lex(string, &b)
       return enum_for(:lex, string) unless block_given?
 
       Lexer.assert_utf8!(string)

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -31,18 +31,6 @@ describe Rouge::Formatters::HTML do
     end
   end
 
-  describe 'format using lexer instance called with options' do
-    let(:text) { %(<meta name="description" content="foo">\n<script>alert("bar")</script>) }
-    let(:subject) { Rouge::Formatters::HTML.new }
-    let(:tokens) { Rouge::Lexers::HTML.new.lex text, {} }
-    let(:output) { subject.format(tokens) }
-
-    it 'should format token stream' do
-      assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
-<span class="nt">&lt;script&gt;</span><span class="nx">alert</span><span class="p">(</span><span class="dl">"</span><span class="s2">bar</span><span class="dl">"</span><span class="p">)</span><span class="nt">&lt;/script&gt;</span>' }
-    end
-  end
-
   describe 'tableized line numbers' do
     let(:options) { { :line_numbers => true } }
 


### PR DESCRIPTION
Thus ends the saga of #1175, #1176, #1186, and #1187. As of Rouge v4.0.0, passing an options hash to `Lexer#lex` will result in an error. The `#continue_lex` and `#with` methods should be used instead.