### PR TITLE
used 'Enumerator#with_index' to detect lineno.

### DIFF
--- a/lib/rouge/formatters/html_line_highlighter.rb
+++ b/lib/rouge/formatters/html_line_highlighter.rb
@@ -13,9 +13,7 @@ module Rouge
       end
 
       def stream(tokens)
-        lineno = 0
-        token_lines(tokens) do |tokens_in_line|
-          lineno += 1
+        token_lines(tokens).with_index(1) do |tokens_in_line, lineno|
           line = %(#{@delegate.format(tokens_in_line)}\n)
           line = %(<span class="#{@highlight_line_class}">#{line}</span>) if @highlight_lines.include? lineno
           yield line

--- a/lib/rouge/formatters/html_line_highlighter.rb
+++ b/lib/rouge/formatters/html_line_highlighter.rb
@@ -13,8 +13,8 @@ module Rouge
       end
 
       def stream(tokens)
-        token_lines(tokens).with_index(1) do |tokens_in_line, lineno|
-          line = %(#{@delegate.format(tokens_in_line)}\n)
+        token_lines(tokens).with_index(1) do |line_tokens, lineno|
+          line = %(#{@delegate.format(line_tokens)}\n)
           line = %(<span class="#{@highlight_line_class}">#{line}</span>) if @highlight_lines.include? lineno
           yield line
         end

--- a/lib/rouge/formatters/html_line_table.rb
+++ b/lib/rouge/formatters/html_line_table.rb
@@ -32,10 +32,8 @@ module Rouge
       end
 
       def stream(tokens, &b)
-        lineno = @start_line - 1
         buffer = [%(<table class="#@table_class"><tbody>)]
-        token_lines(tokens) do |line_tokens|
-          lineno += 1
+        token_lines(tokens).with_index(@start_line) do |line_tokens, lineno|
           buffer << %(<tr id="#{sprintf @line_id, lineno}" class="#@line_class">)
           buffer << %(<td class="#@gutter_class gl" )
           buffer << %(style="-moz-user-select: none;-ms-user-select: none;)

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -11,9 +11,8 @@ module Rouge
       end
 
       def stream(tokens, &b)
-        lineno = 0
-        token_lines(tokens) do |line_tokens|
-          yield %(<#{@tag_name} class="#{sprintf @class_format, lineno += 1}">)
+        token_lines(tokens).with_index(1) do |line_tokens, lineno|
+          yield %(<#{@tag_name} class="#{sprintf @class_format, lineno}">)
           @formatter.stream(line_tokens) {|formatted| yield formatted }
           yield %(\n</#{@tag_name}>)
         end


### PR DESCRIPTION
used 'Enumerator#with_index' to detect lineno.

before: Defined a variable called lineno to count up for each loop.
after: Fixed it.' Enumerator#with_index'.

Rouge::Formatters is often referenced by developers when creating Custom Formatters, so I think it should be written in a better Ruby way.

and fix block scope variable name.(Adjusted variable names to match those used in other files.)