### PR TITLE
[cpp] fix cpp binary literal digit separator

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -63,7 +63,7 @@ module Rouge
         rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
         rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float
         rule %r/0x\h('?\h)*[lu]*/i, Num::Hex
-        rule %r/0b[01]+(?:'[01]+)*/, Num::Bin
+        rule %r/0b[01]+('[01]+)*/, Num::Bin
         rule %r/0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule %r/#{dq}[lu]*/i, Num::Integer
         rule %r/\bnullptr\b/, Name::Builtin

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -63,7 +63,7 @@ module Rouge
         rule %r((#{dq}[.]#{dq}?|[.]#{dq})(e[+-]?#{dq}[lu]*)?)i, Num::Float
         rule %r(#{dq}e[+-]?#{dq}[lu]*)i, Num::Float
         rule %r/0x\h('?\h)*[lu]*/i, Num::Hex
-        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
+        rule %r/0b[01]+(?:'[01]+)*/, Num::Bin
         rule %r/0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule %r/#{dq}[lu]*/i, Num::Integer
         rule %r/\bnullptr\b/, Name::Builtin

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -1,6 +1,6 @@
-int quote_delims = 100'000'000
-int float_delims = 100.00'00
-int hex_delims = 0xFF'Fa12
+int quote_delims = 100'000'000;
+int float_delims = 100.00'00;
+int hex_delims = 0xFF'Fa12;
 int bin_delims = 0b10'1000;
 
 // string literal with encoding-prefix

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -1,8 +1,7 @@
 int quote_delims = 100'000'000
 int float_delims = 100.00'00
 int hex_delims = 0xFF'Fa12
-
-int binary = 0b10'1000;
+int bin_delims = 0b10'1000;
 
 // string literal with encoding-prefix
 char str1[] = u8"UTF-8 string";

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -2,7 +2,7 @@ int quote_delims = 100'000'000
 int float_delims = 100.00'00
 int hex_delims = 0xFF'Fa12
 
-int binary = 0b1000;
+int binary = 0b10'1000;
 
 // string literal with encoding-prefix
 char str1[] = u8"UTF-8 string";


### PR DESCRIPTION
This fixes an issue with digit separators (') in binary literals in C++. Separator character is ' not _.