### PR TITLE
Ensure word break exists after keywords in Kotlin lexer

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -53,7 +53,7 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
-        rule %r'(return|continue|break|this|super)(@#{name})?' do
+        rule %r'(return|continue|break|this|super)(@#{name})?\b' do
           groups Keyword, Name::Decorator
         end
         rule %r'\bfun\b', Keyword

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -155,15 +155,19 @@ fun <T, V> genericFunction() {
 }
 
 fun String.extensionFunction() {
-   return
+    return
 }
 
 fun `String`.`backTickedExtensionFunction`() {
-   return
+    return
 }
 
 fun <T, V : Comparable> String.genericExtensionFunction() {
-   return
+    return
+}
+
+fun foo(supersedingStuff: List<String>): List<String> {
+    return supersedingStuff.map { it }
 }
 
 inline fun <reified T> membersOf() = T::class.members


### PR DESCRIPTION
Rouge currently will match identifiers that begin with certain keywords (such as `super`). This is because of a change in #1496 that added a rule to support labels. That change should have ensured that the rule ended with a `\b` to ensure that identifiers that begin with the listed keywords are followed by a word break. This PR fixes that mistake.

It fixes #1608.