### PR TITLE
Fix template string lexing in JavaScript lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -272,7 +272,8 @@ module Rouge
         rule %r/[$]{/, Punctuation, :template_string_expr
         rule %r/`/, Str::Double, :pop!
         rule %r/\\[$`]/, Str::Escape
-        rule %r/[$]/, Str::Double
+        rule %r/[^$`\\]+/, Str::Double
+        rule %r/[\\$]/, Str::Double
       end
 
       state :template_string_expr do


### PR DESCRIPTION
The changes made in #1548 to avoid empty regular expression patterns, broke the template string rules in the JavaScript lexer (and lexers such as the TypeScript lexer that inherit from it). This PR adds the rules necessary to fix this lexing.

It fixes #1616.