### PR TITLE
Revert empty patterns in Ruby lexer

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -90,7 +90,7 @@ module Rouge
       end
 
       state :regex_flags do
-        rule %r/[mixounse]+/, Str::Regex, :pop!
+        rule %r/[mixounse]*/, Str::Regex, :pop!
       end
 
       # double-quoted string and symbol

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -267,7 +267,7 @@ module Rouge
       end
 
       state :test_heredoc do
-        rule %r/[^#\\\n]+$/ do |m|
+        rule %r/[^#\\\n]*$/ do |m|
           tolerant, heredoc_name = @heredoc_queue.first
           check = tolerant ? m[0].strip : m[0].rstrip
 


### PR DESCRIPTION
The maintenance changes in #1548 resulted in updates to two rules in the Ruby lexer, one regarding regular expression flags and the other regarding heredoc strings. However, these patterns should not have been changed. The change in #1548 was to prevent rules that matched an empty string _unless_ they contained a 'predicate' of some sort. Both rules in the Ruby lexer contained such a predicate and so should not have been changed. This PR fixes that error.

This fixes #1618.