### PR TITLE
Improve support for sigils in Perl lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -110,9 +110,10 @@ module Rouge
 
         rule %r/(__(END|DATA)__)\b/, Comment::Preproc, :end_part
         rule %r/\$\^[ADEFHILMOPSTWX]/, Name::Variable::Global
-        rule %r/\$[\\"'\[\]&`+*.,;=%~?@$!<>(^\|\/-](?!\w)/, Name::Variable::Global
+        rule %r/\$[\\"'\[\]&`+*.,;=%~?@$!<>(^\|\/_-](?!\w)/, Name::Variable::Global
+        rule %r/[$@%&*][$@%&*#_]*(?=[a-z{\[;])/i, Name::Variable, :varname
+
         rule %r/[-+\/*%=<>&^\|!\\~]=?/, Operator
-        rule %r/[$@%#]+/, Name::Variable, :varname
 
         rule %r/0_?[0-7]+(_[0-7]+)*/, Num::Oct
         rule %r/0x[0-9A-Fa-f]+(_[0-9A-Fa-f]+)*/, Num::Hex
@@ -159,8 +160,9 @@ module Rouge
 
       state :varname do
         rule %r/\s+/, Text
-        rule %r/\{/, Punctuation, :pop! # hash syntax
-        rule %r/\)|,/, Punctuation, :pop! # arg specifier
+        rule %r/[{\[]/, Punctuation, :pop! # hash syntax
+        rule %r/[),]/, Punctuation, :pop! # arg specifier
+        rule %r/[;]/, Punctuation, :pop! # postfix
         mixin :name_common
       end
 

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -170,6 +170,28 @@ foo(
     => 1
 )
 
+# sigils
+${ $sref }
+@{ $aref }
+$#{ $aref }
+%{ $href }
+&{ $cref }
+*{ $gref }
+@$aref[ ... ]
+@$href{ ... }
+%$aref[ ... ]
+%$href{ ... }
+$sref->$*;  # same as  ${ $sref }
+$aref->@*;  # same as  @{ $aref }
+$aref->$#*; # same as $#{ $aref }
+$href->%*;  # same as  %{ $href }
+$cref->&*;  # same as  &{ $cref }
+$gref->**;  # same as  *{ $gref }
+$aref->@[ ... ];  # same as @$aref[ ... ]
+$href->@{ ... };  # same as @$href{ ... }
+$aref->%[ ... ];  # same as %$aref[ ... ]
+$href->%{ ... };  # same as %$href{ ... }
+
 __DATA__
 
 This is just some end text; everything after DATA can be accessed


### PR DESCRIPTION
Perl supports a variety of different sigils (`$`, `@`, `%`, etc). This PR improves support for some of the more unusual combinations of sigils.

It fixes #1619.