### PR TITLE
Add support for long options to Batchfile lexer

### DIFF
--- a/lib/rouge/lexers/batchfile.rb
+++ b/lib/rouge/lexers/batchfile.rb
@@ -79,6 +79,7 @@ module Rouge
       state :basic do
         # Comments
         rule %r/@?\brem\b.*$/i, Comment
+
         # Empty Labels
         rule %r/^::.*$/, Comment
 
@@ -105,7 +106,7 @@ module Rouge
           end
         end
 
-        rule %r/([\/\-+][a-z]+)\s*/i, Name::Attribute
+        rule %r/((?:[\/\+]|--?)[a-z]+)\s*/i, Name::Attribute
 
         mixin :expansions
 

--- a/spec/visual/samples/batchfile
+++ b/spec/visual/samples/batchfile
@@ -35,3 +35,4 @@ echo ^Hello
 echo Bye
 goto :eof
 :a
+streamlink --http-header "User-Agent: test" "https://example.com/master.m3u8" best -o output.ts


### PR DESCRIPTION
The Batchfile lexer does not support 'long options' (i.e. options that begin with `--`). This PR adds support for that.

It fixes #1599.