### PR TITLE
maint: `rougify server`

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -10,14 +10,21 @@ module Rouge
   # cache value in a constant since `__dir__` allocates a new string
   # on every call.
   LIB_DIR = __dir__.freeze
+  RELOADABLE_CONSTANTS = []
+  RELOADABLE_FILES = []
 
   LOAD_LOCK = Monitor.new
   ROOT = File.dirname(LIB_DIR)
 
   class << self
     def reload!
+      consts = RELOADABLE_CONSTANTS
+      files = RELOADABLE_FILES
+
       Object::send :remove_const, :Rouge
+      consts.each { |c| Object::send :remove_const, c }
       Kernel::load __FILE__
+      files.each { |f| Kernel::load f }
     end
 
     # Highlight some text with a given lexer and formatter.

--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -74,7 +74,7 @@ module Rouge
         when '-h', '--help', 'help', '-help'
           return Help.parse(argv)
         when '--require', '-r'
-          require argv.shift
+          require_file argv.shift
         else
           break
         end
@@ -85,6 +85,13 @@ module Rouge
 
       argv.unshift(head) if head
       Highlight.parse(argv)
+    end
+
+    def self.require_file(file)
+      toplevel = Object.constants
+      require file
+      RELOADABLE_CONSTANTS.concat(Set.new(Object.constants) - toplevel)
+      RELOADABLE_FILES << file
     end
 
     def initialize(options={})

--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -355,6 +355,7 @@ module Rouge
 
     class Debug < Highlight
       def self.desc
+        "highlight code with debug features"
       end
 
       def self.doc

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -34,4 +34,7 @@ Gem::Specification.new do |s|
     "documentation_uri" => "https://rouge-ruby.github.io/docs/",
     "source_code_uri"   => "https://github.com/rouge-ruby/rouge"
   }
+
+  # for running the development server
+  s.add_development_dependency 'sinatra'
 end

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -13,7 +13,18 @@ Gem::Specification.new do |s|
     for pygments.
   desc
   s.homepage = "http://rouge.jneen.net/"
-  s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
+  s.files = Dir[
+    'Gemfile',
+    'LICENSE',
+    'rouge.gemspec',
+    'lib/**/*.rb',
+    'lib/**/*.yml',
+    'bin/rougify',
+    'lib/rouge/demos/*',
+    'spec/visual/templates/*.erb',
+    'spec/visual/samples/*',
+    'spec/visual/*.rb'
+  ]
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
   s.required_ruby_version = '>= 2.0'

--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
-require 'rubygems'
-require 'bundler'
-Bundler.require(:default, :development)
+require 'rack'
+require 'sinatra'
 
 # stdlib
 require 'pathname'


### PR DESCRIPTION
For version 4, I want to improve the development experience for "plug-in" authors - those who may want to publish their own Rouge lexers for languages possibly too obscure to include in Rouge base. The first step I want to take here is to expose the development server through the `rougify` command. This involves shipping the files necessary to run the server with the gem, and adding sinatra/rack as a development dependency.

I've also modified the behaviour of the reloading feature, so that we can add extra files/constants to be removed and reloaded. This will allow plugin devs to run, for example,

```
rougify -r my_cool_lexer.rb server
```

and have their file seamlessly reloaded.