### PR TITLE
Extract f-string prefix as a separate token

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -115,7 +115,7 @@ module Rouge
         # TODO: not in python 3
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rfbu]{0,2})('''|"""|['"])/i do |m|
-          token Str
+          groups Str::Affix, Str
           current_string.register type: m[1].downcase, delim: m[2]
           push :generic_string
         end

--- a/lib/rouge/themes/base16.rb
+++ b/lib/rouge/themes/base16.rb
@@ -67,6 +67,7 @@ module Rouge
       style Keyword::Declaration, :fg => :base09
 
       style Literal::String, :fg => :base0B
+      style Literal::String::Affix, :fg => :base0E
       style Literal::String::Regex, :fg => :base0C
 
       style Literal::String::Interpol,

--- a/lib/rouge/themes/bw.rb
+++ b/lib/rouge/themes/bw.rb
@@ -26,6 +26,7 @@ module Rouge
       style Name::Tag,                   :bold => true
 
       style Literal::String,             :italic => true
+      style Literal::String::Affix,      :bold => true
       style Literal::String::Interpol,   :bold => true
       style Literal::String::Escape,     :bold => true
 

--- a/lib/rouge/themes/colorful.rb
+++ b/lib/rouge/themes/colorful.rb
@@ -37,6 +37,7 @@ module Rouge
       style Name::Decorator,             :fg => "#555", :bold => true
 
       style Literal::String,             :bg => "#fff0f0"
+      style Literal::String::Affix,      :fg => "#080", :bold => true
       style Literal::String::Char,       :fg => "#04D"
       style Literal::String::Doc,        :fg => "#D42"
       style Literal::String::Interpol,   :bg => "#eee"

--- a/lib/rouge/themes/github.rb
+++ b/lib/rouge/themes/github.rb
@@ -35,6 +35,7 @@ module Rouge
       style Literal::Number::Integer,         :fg => '#009999'
       style Literal::Number::Oct,             :fg => '#009999'
       style Literal::Number,                  :fg => '#009999'
+      style Literal::String::Affix,           :fg => '#000000', :bold => true
       style Literal::String::Backtick,        :fg => '#d14'
       style Literal::String::Char,            :fg => '#d14'
       style Literal::String::Doc,             :fg => '#d14'

--- a/lib/rouge/themes/gruvbox.rb
+++ b/lib/rouge/themes/gruvbox.rb
@@ -150,6 +150,8 @@ module Rouge
             Literal::String::Interpol,
             Literal::String::Regex, :fg => :green, :italic => true
 
+      style Literal::String::Affix, :fg => :red
+
       style Literal::String::Escape, :fg => :orange
 
       style Name::Namespace,

--- a/lib/rouge/themes/igor_pro.rb
+++ b/lib/rouge/themes/igor_pro.rb
@@ -15,6 +15,7 @@ module Rouge
       style Keyword::Reserved,                :fg => '#007575'
       style Keyword,                          :fg => '#0000FF'
       style Literal::String,                  :fg => '#009C00'
+      style Literal::String::Affix,           :fg => '#0000FF'
       style Name::Builtin,                    :fg => '#C34E00'
     end
   end

--- a/lib/rouge/themes/magritte.rb
+++ b/lib/rouge/themes/magritte.rb
@@ -62,6 +62,7 @@ module Rouge
             Literal::Date,                :fg => :forest, :bold => true
       style Literal::String::Symbol,      :fg => :forest
       style Literal::String,              :fg => :wine, :bold => true
+      style Literal::String::Affix,       :fg => :royal, :bold => true
       style Literal::String::Escape,
             Literal::String::Char,
             Literal::String::Interpol,    :fg => :purple, :bold => true

--- a/lib/rouge/themes/monokai.rb
+++ b/lib/rouge/themes/monokai.rb
@@ -59,6 +59,7 @@ module Rouge
             Literal::Number::Oct,
             Literal::Number,
             Literal::String::Escape,          :fg => :light_violet
+      style Literal::String::Affix,           :fg => :soft_cyan, :bold => true
       style Literal::String::Backtick,
             Literal::String::Char,
             Literal::String::Doc,

--- a/lib/rouge/themes/pastie.rb
+++ b/lib/rouge/themes/pastie.rb
@@ -36,6 +36,7 @@ module Rouge
       style Num,                       :fg => '#0000dd', :bold => true
 
       style Str,                       :fg => '#dd2200', :bg => '#fff0f0'
+      style Str::Affix,                :fg => '#008800', :bold => true
       style Str::Escape,               :fg => '#0044dd', :bg => '#fff0f0'
       style Str::Interpol,             :fg => '#3333bb', :bg => '#fff0f0'
       style Str::Other,                :fg => '#22bb22', :bg => '#f0fff0'

--- a/lib/rouge/themes/thankful_eyes.rb
+++ b/lib/rouge/themes/thankful_eyes.rb
@@ -59,6 +59,7 @@ module Rouge
             Literal::Date,
             Literal::String::Symbol, :fg => :pink_merengue, :bold => true
       style Literal::String, :fg => :dune, :bold => true
+      style Literal::String::Affix, :fg => :sandy, :bold => true
       style Literal::String::Escape,
             Literal::String::Char,
             Literal::String::Interpol, :fg => :backlit, :bold => true

--- a/lib/rouge/themes/tulip.rb
+++ b/lib/rouge/themes/tulip.rb
@@ -55,6 +55,7 @@ module Rouge
             Literal::Date,
             Literal::String::Symbol, :fg => :lpurple, :bold => true
       style Literal::String, :fg => :dune, :bold => true
+      style Literal::String::Affix, :fg => :yellow, :bold => true
       style Literal::String::Escape,
             Literal::String::Char,
             Literal::String::Interpol, :fg => :orange, :bold => true


### PR DESCRIPTION
The f-string prefix was extracted together with the text as one token. This makes syntax highlight less flexible.

This change will:
- Extract `f` prefix as `String::Affix` token, similar to how it is [done](https://github.com/pygments/pygments/blob/master/pygments/lexers/python.py#L135-L140) in `Pygments`.
- Add styles for `String::Affix` in all themes (mirror the style of `Keyword`)

This fixes #1634.

<details>
<summary>Before</summary>

```
[1] pry(main)> require './lib/rouge'
true
[2] pry(main)> lexer = Rouge::Lexers::Python.new
#<Rouge::Lexers::Python:0x00007fadc66979b0 @options={}, @debug=false>
[3] pry(main)> lexer.lex("foo = f\"test: {t}\"\n").to_a
[
    [0] [
        [0] <Token Name> < Rouge::Token,
        [1] "foo"
    ],
    [1] [
        [0] <Token Text> < Rouge::Token,
        [1] " "
    ],
    [2] [
        [0] <Token Operator> < Rouge::Token,
        [1] "="
    ],
    [3] [
        [0] <Token Text> < Rouge::Token,
        [1] " "
    ],
    [4] [
        [0] <Token Literal.String> < Rouge::Token::Tokens::Literal,
        [1] "f\"test: "
    ],
    [5] [
        [0] <Token Literal.String.Interpol> < Rouge::Token::Tokens::Literal::String,
        [1] "{"
    ],
    [6] [
        [0] <Token Name> < Rouge::Token,
        [1] "t"
    ],
    [7] [
        [0] <Token Literal.String.Interpol> < Rouge::Token::Tokens::Literal::String,
        [1] "}"
    ],
    [8] [
        [0] <Token Literal.String> < Rouge::Token::Tokens::Literal,
        [1] "\""
    ],
    [9] [
        [0] <Token Text> < Rouge::Token,
        [1] "\n"
    ]
]
```

</details>

<details>
<summary>After</summary>

```
[1] pry(main)> require './lib/rouge'
true
[2] pry(main)> lexer = Rouge::Lexers::Python.new
#<Rouge::Lexers::Python:0x00007fe355697bf8 @options={}, @debug=false>
[3] pry(main)> lexer.lex("foo = f\"test: {t}\"\n").to_a
[
    [ 0] [
        [0] <Token Name> < Rouge::Token,
        [1] "foo"
    ],
    [ 1] [
        [0] <Token Text> < Rouge::Token,
        [1] " "
    ],
    [ 2] [
        [0] <Token Operator> < Rouge::Token,
        [1] "="
    ],
    [ 3] [
        [0] <Token Text> < Rouge::Token,
        [1] " "
    ],
    [ 4] [
        [0] <Token Literal.String.Affix> < Rouge::Token::Tokens::Literal::String,
        [1] "f"
    ],
    [ 5] [
        [0] <Token Literal.String> < Rouge::Token::Tokens::Literal,
        [1] "\"test: "
    ],
    [ 6] [
        [0] <Token Literal.String.Interpol> < Rouge::Token::Tokens::Literal::String,
        [1] "{"
    ],
    [ 7] [
        [0] <Token Name> < Rouge::Token,
        [1] "t"
    ],
    [ 8] [
        [0] <Token Literal.String.Interpol> < Rouge::Token::Tokens::Literal::String,
        [1] "}"
    ],
    [ 9] [
        [0] <Token Literal.String> < Rouge::Token::Tokens::Literal,
        [1] "\""
    ],
    [10] [
        [0] <Token Text> < Rouge::Token,
        [1] "\n"
    ]
]
```

</details>

| Before (`base16-dark`) | After (`base16-dark`) |
| ---------------- | -------------- |
|<img width="336" alt="Screen Shot 2020-11-26 at 7 35 30 pm" src="https://user-images.githubusercontent.com/756722/100326955-b9d79e80-301e-11eb-9c2b-3b80a672b95e.png"> | <img width="336" alt="Screen Shot 2020-11-26 at 7 34 43 pm" src="https://user-images.githubusercontent.com/756722/100326969-be03bc00-301e-11eb-8131-417315d9b721.png"> |