### PR TITLE
Fix lexing of jsl messages and nested block comments

### DIFF
--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -17,9 +17,7 @@ module Rouge
         rule %r'/[*].*', Comment::Multiline, :comment
 
         # messages
-        rule %r/(<<)(.*?)([(),;&|!=<>])/ do |m|
-          groups Operator, Name::Function, Punctuation
-        end
+        rule %r/<</, Operator, :message
 
         # covers built-in and custom functions
         rule %r/([a-z_][\w\s'%.\\]*)(\()/i do |m|
@@ -42,6 +40,13 @@ module Rouge
 
         rule %r/[-+*\/!%&<>\|=:]/, Operator
         rule %r/[\[\](){},;]/, Punctuation
+      end
+
+      state :message do
+        rule %r/\s+/m, Text::Whitespace
+        rule %r/[a-z_][\w\s'%.\\]*/i, Name::Function
+        rule %r/[(),;]/, Punctuation, :pop!
+        rule %r/[&|!=<>]/, Operator, :pop!
       end
 
       state :dq do

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -38,7 +38,7 @@ module Rouge
         end
         rule %r/"/, Str::Double, :dq
 
-        rule %r/[-+*\/!%&<>\|=:]/, Operator
+        rule %r/[-+*\/!%&<>\|=:`^]/, Operator
         rule %r/[\[\](){},;]/, Punctuation
       end
 

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -17,7 +17,7 @@ module Rouge
         rule %r(/\*.*?\*/)m, Comment::Multiline
 
         # messages
-        rule %r/(<<)(.*?)(\(|;)/ do |m|
+        rule %r/(<<)(.*?)([(),;&|!=<>])/ do |m|
           groups Operator, Name::Function, Punctuation
         end
 

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -24,9 +24,9 @@ module Rouge
           groups Keyword, Punctuation
         end
 
-        rule %r/\b[+-]?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+|\.)(?:e[+-]?[0-9]+)?i?\b/i, Num
-
         rule %r/\d{2}(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\d{2}(\d{2})?(:\d{2}:\d{2}(:\d{2}(\.\d*)?)?)?/i, Literal::Date
+
+        rule %r/-?(?:[0-9]+(?:[.][0-9]+)?|[.][0-9]*)(?:e[+-]?[0-9]+)?i?/i, Num
 
         rule %r/::[a-z_][\w\s'%.\\]*/i, Name::Variable
         rule %r/:\w+/, Name

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -14,7 +14,7 @@ module Rouge
         rule %r/\s+/m, Text::Whitespace
 
         rule %r(//.*?$), Comment::Single
-        rule %r(/\*.*?\*/)m, Comment::Multiline
+        rule %r'/[*].*', Comment::Multiline, :comment
 
         # messages
         rule %r/(<<)(.*?)([(),;&|!=<>])/ do |m|
@@ -49,6 +49,13 @@ module Rouge
         rule %r/\\/, Str::Double
         rule %r/"/, Str::Double, :pop!
         rule %r/[^\\"]+/m, Str::Double
+      end
+
+      state :comment do
+        rule %r'/[*]', Comment::Multiline, :comment
+        rule %r'[*]/', Comment::Multiline, :pop!
+        rule %r'[^/*]+', Comment::Multiline
+        rule %r'[/*]', Comment::Multiline
       end
     end
   end

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -20,5 +20,7 @@ date = 01jan00;
 dateTime = 12dec1999:12:30:00.45;
 
 New Window( "Rouge Test",
-    Text Box( "Syntax highlighting is great!" )
+    tb = Text Box( "Syntax highlighting is great!" )
 );
+
+If(tb << Get Text != "", "I'm still formatted correctly!");

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -5,6 +5,14 @@ dt << Distribution( Column( :age ), Histograms Only( 1 ) );
     Multi-line comment
 */
 
+/*
+    Nested
+    /*
+        Comments
+    */
+    Work
+*/
+
 escapeSequence = "This is an \!b escaped sequence";
 escapeQuote = "This is a \!" quotation mark";
 escapeStr = "\[This is """"""" an escaped string]\"

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -24,6 +24,7 @@ a name with spaces = 5;
 
 scientificNotation = 5e9;
 decimal = 1.234;
+missing = .;
 date = 01jan00;
 dateTime = 12dec1999:12:30:00.45;
 


### PR DESCRIPTION
Some small fixes for the JSL lexer
* Cover more cases of messages e.g.`<<Some Message` where they aren't terminated with `()` or `;` 
* Add support for nested block comments
* Add missing operators `` ` `` (transpose) and `^` (exponentiation)
* Parse decimals starting with `.` as Nums
    * `.` by itself is `missing` and is considered a number as well