### PR TITLE
Fix Crystal floor division becoming regex literals

### DIFF
--- a/lib/rouge/lexers/crystal.rb
+++ b/lib/rouge/lexers/crystal.rb
@@ -212,7 +212,7 @@ module Rouge
 
         rule %r/[a-zA-Z_]\w*[?!]/, Name, :expr_start
         rule %r/[a-zA-Z_]\w*/, Name, :method_call
-        rule %r/\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
+        rule %r/\*\*|\/\/|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
         rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
         rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }

--- a/lib/rouge/lexers/crystal.rb
+++ b/lib/rouge/lexers/crystal.rb
@@ -212,7 +212,7 @@ module Rouge
 
         rule %r/[a-zA-Z_]\w*[?!]/, Name, :expr_start
         rule %r/[a-zA-Z_]\w*/, Name, :method_call
-        rule %r/\*\*|\/\/|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
+        rule %r/\*\*|\/\/|>=|<=|<=>|<<?|>>?|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
         rule %r/[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
         rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }


### PR DESCRIPTION
Currently, the [crystal floor division operator](https://crystal-lang.org/reference/syntax_and_semantics/operators.html#multiplicative) `//` is not lexed properly when `:root` is the topmost thing on the stack (default state). It becomes a regular division followed by a regex literal. This literal will span multiple lines until met by another `/`, which can make large parts of a file become seemingly unformatted. 

This change adds `//` as an operator next to `**`, as they seem similar. This shouldn't affect actual regex literals or empty regex literals (which are also `//`) though I haven't tested it much with real-code examples