### PR TITLE
Fix reasonml comments

### DIFF
--- a/lib/rouge/lexers/reasonml.rb
+++ b/lib/rouge/lexers/reasonml.rb
@@ -24,7 +24,8 @@ module Rouge
         rule %r/#{@@upper_id}(?=\s*[.])/, Name::Namespace, :dotted
         rule %r/`#{@@id}/, Name::Tag
         rule @@upper_id, Name::Class
-        rule %r/[\/][*](?![\/])/, Comment, :comment
+        rule %r(//.*), Comment::Single
+        rule %r(/\*), Comment::Multiline, :comment
         rule @@id do |m|
           match = m[0]
           if self.class.keywords.include? match
@@ -55,10 +56,10 @@ module Rouge
       end
 
       state :comment do
-        rule %r|[^/*)]+|, Comment
-        rule %r|[/][*]|, Comment, :push
-        rule %r|[*][/]|, Comment, :pop!
-        rule %r|[*/]|, Comment
+        rule %r([^/\*]+), Comment::Multiline
+        rule %r(/\*), Comment::Multiline, :comment
+        rule %r(\*/), Comment::Multiline, :pop!
+        rule %r([*/]), Comment::Multiline
       end
     end
   end

--- a/lib/rouge/lexers/reasonml.rb
+++ b/lib/rouge/lexers/reasonml.rb
@@ -56,7 +56,7 @@ module Rouge
       end
 
       state :comment do
-        rule %r([^/\*]+), Comment::Multiline
+        rule %r([^/*]+), Comment::Multiline
         rule %r(/\*), Comment::Multiline, :comment
         rule %r(\*/), Comment::Multiline, :pop!
         rule %r([*/]), Comment::Multiline

--- a/spec/visual/samples/reasonml
+++ b/spec/visual/samples/reasonml
@@ -45,7 +45,8 @@ let ignore: 'a => unit = _ => ();
 /* comment ****/
 /* comment *****/
 
-// Another single line comment
+// A single line comment
+
 let testingNotQuiteEndOfLineComments = [
   "Item 1" /* Comment For First Item */,
   "Item 2" /* Comment For Second Item */,

--- a/spec/visual/samples/reasonml
+++ b/spec/visual/samples/reasonml
@@ -1,3 +1,5 @@
+let x = 6 // This is single line comment
+
 let c: char = 'A'; /* comment with link https://example and - = */
 
 let respond_no_content = reqd => {
@@ -43,6 +45,7 @@ let ignore: 'a => unit = _ => ();
 /* comment ****/
 /* comment *****/
 
+// Another single line comment
 let testingNotQuiteEndOfLineComments = [
   "Item 1" /* Comment For First Item */,
   "Item 2" /* Comment For Second Item */,


### PR DESCRIPTION
This PR contains:
- Fix multiline comments (Issue with paren)
![image](https://user-images.githubusercontent.com/13261088/100758083-5bd2fe80-3404-11eb-8e2f-b64c65d0e98e.png)
- Add support for single line comments