### PR TITLE
Rust: add support for octal literals

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -179,6 +179,7 @@ module Rouge
         rule %r(
           ( 0b[10_]+
           | 0x[0-9a-fA-F_]+
+          | 0o[0-7]+
           | [0-9_]+
           ) (u#{size}?|i#{size})?
         )x, Num::Integer

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -16,7 +16,7 @@ fn h(a: i32) -> i32 {
   let b = (a / 4 + 1_000) * 2 - 3;
   let c = (a | 0b0100) & 0xF;
 
-  c ^ !b
+  c ^ !b ^ 0o707
 }
 
 fn main() {


### PR DESCRIPTION
# Langauge

Rust

# Description

Add support for octal literals like `0o123`.

cf. [Rust Reference: Integer Literals](https://doc.rust-lang.org/reference/tokens.html#integer-literals)

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/54318333/100875197-0c1a3300-34e9-11eb-8b80-c843db47a72f.png)

After:

![image](https://user-images.githubusercontent.com/54318333/100875207-0e7c8d00-34e9-11eb-8cee-2ddb8d6e77f6.png)
