### PR TITLE
Remove reference to @pyrmont as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,7 @@ Rouge uses [Semantic Versioning 2.0.0][sv2].
 
 Rouge is largely the result of the hard work of unpaid volunteers. It was
 originally developed by Jeanine Adkisson (@jneen) and is currently maintained by
-Jeanine Adkisson, Drew Blessing (@dblessing), Michael Camilleri (@pyrmont) and
-Goro Fuji (@gfx).
+Jeanine Adkisson, Drew Blessing (@dblessing) and Goro Fuji (@gfx).
 
 ## License
 


### PR DESCRIPTION
As discussed previously amongst the maintainers, I am stepping down from my position as a maintainer. I've removed myself as the assignee from open issues and PRs and this PR removes the reference to me from the README.