### PR TITLE
Rust: update lexer for the latest version of Rust

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -212,7 +212,8 @@ module Rouge
 
       state :has_literals do
         # constants
-        rule %r/\b(?:true|false|nil)\b/, Keyword::Constant
+        rule %r/\b(?:true|false)\b/, Keyword::Constant
+
         # characters/bytes
         rule %r(
           b?' (?: #{escapes} | [^\\] ) '

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -22,10 +22,13 @@ module Rouge
 
       def self.keywords
         @keywords ||= %w(
-          as assert async await break crate const continue copy do drop dyn else enum extern
-          fail false fn for if impl let log loop macro match mod move mut priv pub pure
-          ref return self Self static struct super true try trait type union unsafe use
-          where while yield box
+          as async await break const continue crate dyn else enum extern false
+          fn for if impl in let log loop match mod move mut pub ref return self
+          Self static struct super trait true type unsafe use where while
+          abstract become box do final macro
+          override priv typeof unsized virtual
+          yield try
+          union
         )
       end
 

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -284,7 +284,6 @@ mod test_literals {
     #[mach_int = 100u32];
     #[float = 1.0];
     #[mach_float = 1.0f32];
-    #[nil = ()];
     #[bool = true];
     mod m {
         #[legacy_exports]; }


### PR DESCRIPTION
# Language

Rust (version 1.48, the latest stable as of 10th December 2020)

# Description

Update the lexer to fit the latest version of Rust language.

## Remove constant `nil`

The word `nil` has no special meaning in the latest version of Rust.

## Update keyword list

The old keyword list seems to refer to pre-1.0 Rust, I don't know well about that though.

They are keywords in the latest version of Rust.

* `abstract`
* `become`
* `final`
* `in`
* `override`
* `typeof`
* `unsized`
* `virtual`

Removed:

They are *not* keywords in the latest version of Rust.

* `assert`
* `copy`
* `drop`
* `fail`
* `pure`

cf. https://doc.rust-lang.org/reference/keywords.html