### PR TITLE
JSX: Allow dashes in attribute names

### DIFF
--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -57,7 +57,7 @@ module Rouge
           push :interpol
           push :expr_start
         end
-        rule %r/\w+/, Name::Attribute
+        rule %r/\w[\w-]*/, Name::Attribute
         rule %r/=/, Punctuation
         rule %r/(["']).*?(\1)/, Str
       end

--- a/spec/lexers/jsx_spec.rb
+++ b/spec/lexers/jsx_spec.rb
@@ -15,5 +15,20 @@ describe Rouge::Lexers::JSX do
       assert_guess :mimetype => 'application/x-jsx'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'parse attribute with dashes' do
+      assert_tokens_equal '<button aria-label="hello"/>',
+        ['Punctuation', '<'],
+        ['Name.Tag', 'button'],
+        ['Text', ' '],
+        ['Name.Attribute', 'aria-label'],
+        ['Punctuation', '='],
+        ['Literal.String', '"hello"'],
+        ['Punctuation', '/>']
+    end
+  end
 end
 


### PR DESCRIPTION
Support attributes with names that contain dashes, e.g. ARIA attributes.