### PR TITLE
Add alias `graphviz` for `dot`

### DIFF
--- a/lib/rouge/lexers/dot.rb
+++ b/lib/rouge/lexers/dot.rb
@@ -8,6 +8,7 @@ module Rouge
       desc "graph description language"
 
       tag 'dot'
+      aliases 'graphviz'
       filenames '*.dot'
       mimetypes 'text/vnd.graphviz'
 


### PR DESCRIPTION
Name of this graph visualization software is Graphviz — see https://graphviz.org/ and its MIME type is `text/vnd.graphviz`
So we should add alias.