### PR TITLE
Update J lexer for J9.02

### DIFF
--- a/lib/rouge/lexers/j.rb
+++ b/lib/rouge/lexers/j.rb
@@ -253,22 +253,8 @@ module Rouge
           token Keyword
           goto :dd_noun
         end
-        rule %r/[acdmv](?!\w)|\*/ do
-          token Keyword
-          goto :dd_ctrl
-        end
-        # `)aNB.`, as well as `)b`, is invalid.
-        rule %r/.N?/ do
-          token Error
-          goto :dd_ctrl
-        end
-        rule(/$/) { pop! }
-      end
-
-      state :dd_ctrl do
-        rule %r/[ \t\r]+/, Text
-        rule %r/NB\.(?![.:]).*/, Comment::Single
-        rule(/$/) { pop! }
+        rule %r/[acdmv](?![\w.:])|\*(?![.:])/, Keyword
+        rule(//) { pop! }
       end
 
       state :dd_noun do

--- a/lib/rouge/lexers/j.rb
+++ b/lib/rouge/lexers/j.rb
@@ -93,7 +93,16 @@ module Rouge
           token Punctuation
           push :dd if m[1]
         end
+
         rule %r/\}\}(?![.:])/, Punctuation
+
+        rule %r/(\{)(\})(?![.:])/ do
+          groups Name::Function, Operator
+        end
+
+        rule %r/(\})(\{)(?![.:])/ do
+          groups Operator, Name::Function
+        end
 
         rule %r/^([ \t]*)(:)([ \t\r]*\n)/ do
           groups Text, Punctuation, Text

--- a/lib/rouge/lexers/j.rb
+++ b/lib/rouge/lexers/j.rb
@@ -93,7 +93,7 @@ module Rouge
         # https://code.jsoftware.com/wiki/Vocabulary/DirectDefinition
         rule %r/\{\{(\))?(?![.:])/ do |m|
           token Punctuation
-          push :dd if m[1]
+          push(m[1] ? :dd : :dd_expr)
         end
 
         rule %r/\}\}(?![.:])/, Punctuation
@@ -261,8 +261,11 @@ module Rouge
           token Keyword
           goto :dd_noun
         end
-        rule %r/[acdmv](?![\w.:])|\*(?![.:])/, Keyword
-        rule(//) { pop! }
+        rule %r/[acdmv](?![\w.:])|\*(?![.:])/ do
+          token Keyword
+          goto :dd_expr
+        end
+        rule(//) { goto :dd_expr }
       end
 
       state :dd_noun do
@@ -277,6 +280,11 @@ module Rouge
       state :dd_noun_m do
         rule %r/[^\}].*\n*/, Str::Heredoc
         rule %r/^\}\}/, Punctuation, :pop!
+      end
+
+      state :dd_expr do
+        rule %r/\}\}(?![.:])/, Punctuation, :pop!
+        mixin :expr
       end
     end
   end

--- a/spec/lexers/j_spec.rb
+++ b/spec/lexers/j_spec.rb
@@ -261,6 +261,15 @@ describe Rouge::Lexers::J do
           ['Name.Function', '{{.']
         assert_tokens_equal '}}:',
           ['Operator', '}'], ['Name.Function', '}:']
+        assert_tokens_equal '}{{',
+          ['Operator', '}'], ['Name.Function', '{{']
+        assert_tokens_equal '{}}',
+          ['Name.Function', '{'], ['Operator', '}}']
+        assert_tokens_equal '} {{ {}}}',
+          ['Operator', '}'], ['Text', ' '],
+          ['Punctuation', '{{'], ['Text', ' '],
+          ['Name.Function', '{'], ['Operator', '}'],
+          ['Punctuation', '}}']
       end
 
       it 'recognizes control information' do

--- a/spec/lexers/j_spec.rb
+++ b/spec/lexers/j_spec.rb
@@ -268,18 +268,18 @@ describe Rouge::Lexers::J do
           assert_tokens_equal "{{)#{c}",
             ['Punctuation', '{{)'], ['Keyword', c]
         end
-        assert_tokens_equal '{{)b',
-          ['Punctuation', '{{)'], ['Error', 'b']
-        assert_tokens_equal '{{)a bc',
-          ['Punctuation', '{{)'], ['Keyword', 'a'], ['Text', ' '],
-          ['Error', 'bc']
-        assert_tokens_equal '{{)aNB.',
-          ['Punctuation', '{{)'], ['Error', 'aNB.']
-        assert_tokens_equal '{{)a NB.',
-          ['Punctuation', '{{)'], ['Keyword', 'a'], ['Text', ' '],
-          ['Comment.Single', 'NB.']
         assert_tokens_equal '{{).',
           ['Punctuation', '{{'], ['Error', ').']
+        assert_tokens_equal '{{)abc',
+          ['Punctuation', '{{)'], ['Name', 'abc']
+        assert_tokens_equal '{{)a bc',
+          ['Punctuation', '{{)'], ['Keyword', 'a'], ['Text', ' '],
+          ['Name', 'bc']
+        assert_tokens_equal '{{)a}}',
+          ['Punctuation', '{{)'], ['Keyword', 'a'], ['Punctuation', '}}']
+        assert_tokens_equal '{{)a NB.}}',
+          ['Punctuation', '{{)'], ['Keyword', 'a'], ['Text', ' '],
+          ['Comment.Single', 'NB.}}']
       end
 
       it 'recognizes nouns' do

--- a/spec/lexers/j_spec.rb
+++ b/spec/lexers/j_spec.rb
@@ -313,6 +313,13 @@ describe Rouge::Lexers::J do
           ['Error', '}}'], ['Name.Builtin.Pseudo', 'm'],
           ['Punctuation', "'"]
       end
+
+      it 'does not highlight explicit definitions inside {{ }}' do
+        assert_tokens_equal '{{3 :0 y}}',
+          ['Punctuation', '{{'], ['Literal.Number', '3'], ['Text', ' '],
+          ['Operator', ':'], ['Literal.Number', '0'], ['Text', ' '],
+          ['Name.Builtin.Pseudo', 'y'], ['Punctuation', '}}']
+      end
     end
   end
 end

--- a/spec/visual/samples/j
+++ b/spec/visual/samples/j
@@ -107,10 +107,13 @@ line}}
 string
   }}
 }}
+3 : '{{x + y}}~y NB. invalid'
 
 NB. Delimiters / primitives
 {{ }} {{. }}:
 {{)a b
-{{)aNB.
-{{)NB.
-{{)a NB. b
+{{)ab
+{{)a.
+{{)NB.}}
+{{)a NB.
+{{)}}

--- a/spec/visual/samples/j
+++ b/spec/visual/samples/j
@@ -111,9 +111,9 @@ string
 
 NB. Delimiters / primitives
 {{ }} {{. }}:
+{}} }{{
 {{)a b
 {{)ab
-{{)a.
-{{)NB.}}
-{{)a NB.
+{{)v.
+{{)a NB.}}
 {{)}}

--- a/spec/visual/samples/j
+++ b/spec/visual/samples/j
@@ -108,6 +108,7 @@ string
   }}
 }}
 3 : '{{x + y}}~y NB. invalid'
+{{3 : 0 y}}
 
 NB. Delimiters / primitives
 {{ }} {{. }}:

--- a/spec/visual/samples/j
+++ b/spec/visual/samples/j
@@ -90,3 +90,27 @@ the right noun
 )
 the left noun
 )
+
+NB. Direct definitions
+{{)a
+  f=. {{x + y}}
+  f&u
+}}
+{{)*
+  *y
+:
+  x | y
+}}
+{{)nsingle line string}}
+{{)n multiple
+line}}
+string
+  }}
+}}
+
+NB. Delimiters / primitives
+{{ }} {{. }}:
+{{)a b
+{{)aNB.
+{{)NB.
+{{)a NB. b


### PR DESCRIPTION
There was [J9.02 release](https://code.jsoftware.com/wiki/System/ReleaseNotes/J902) with a new feature: [Direct Definition](https://code.jsoftware.com/wiki/Vocabulary/DirectDefinition).
This PR adds support for Direct Definition.