### PR TITLE
Update C# lexer: new keywords and numeric literal syntax improvements

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -27,19 +27,19 @@ module Rouge
         static switch this throw true try typeof unchecked unsafe
         virtual void volatile while
         add alias async await get global partial remove set value where
-        yield nameof
-        ascending by descending equals from group in into join let on
-        orderby select
+        yield nameof notnull
+        ascending by descending equals from group in init into join let
+        on orderby select unmanaged when and not or with
       )
 
       keywords_type = %w(
-        bool byte char decimal double dynamic float int long object
-        sbyte short string uint ulong ushort var
+        bool byte char decimal double dynamic float int long nint nuint
+        object sbyte short string uint ulong ushort var
       )
 
       cpp_keywords = %w(
         if endif else elif define undef line error warning region
-        endregion pragma
+        endregion pragma nullable
       )
 
       state :whitespace do
@@ -88,7 +88,7 @@ module Rouge
           (e[+-][0-9]+)? # exponent
           [fldu]? # type
         )ix, Num
-        rule %r/\b(?:class|struct|interface)\b/, Keyword, :class
+        rule %r/\b(?:class|record|struct|interface)\b/, Keyword, :class
         rule %r/\b(?:namespace|using)\b/, Keyword, :namespace
         rule %r/^#[ \t]*(#{cpp_keywords.join('|')})\b.*?\n/,
           Comment::Preproc

--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -81,12 +81,13 @@ module Rouge
         rule %r/@"(""|[^"])*"/m, Str
         rule %r/"(\\.|.)*?["\n]/, Str
         rule %r/'(\\.|.)'/, Str::Char
-        rule %r/0x[0-9a-f]+[lu]?/i, Num
+        rule %r/0b[_01]+[lu]?/i, Num
+        rule %r/0x[_0-9a-f]+[lu]?/i, Num
         rule %r(
-          [0-9]
-          ([.][0-9]*)? # decimal
-          (e[+-][0-9]+)? # exponent
-          [fldu]? # type
+          [0-9](?:[_0-9]*[0-9])?
+          ([.][0-9](?:[_0-9]*[0-9])?)? # decimal
+          (e[+-]?[0-9](?:[_0-9]*[0-9])?)? # exponent
+          [fldum]? # type
         )ix, Num
         rule %r/\b(?:class|record|struct|interface)\b/, Keyword, :class
         rule %r/\b(?:namespace|using)\b/, Keyword, :namespace

--- a/spec/visual/samples/csharp
+++ b/spec/visual/samples/csharp
@@ -376,5 +376,31 @@ namespace Diva.Core {
                         var m = $"interpolation with nested strings: { @"Ooga\" } and { "booga\"" }".Length;
                 }
         }
-        
+
+        public static class Csharp7And8And9Tests
+        {
+                record NamedEntity(string Name);
+
+                record Person(string Name) : NamedEntity("Mr " + Name)
+                {
+                        public nint Age { get; init; }
+
+                        public static void WeaveSomeBobbins()
+                        {
+                                Person bob = new("Bob");
+                                var bobbin = bob with { Name = "Bobbin" };
+                                var birthdayBobbin = bobbin.OneYearOlder();
+                        }
+                }
+
+                static Person OneYearOlder<T>(this T person)
+                        where T : notnull, Person
+                {
+                        return person switch
+                        {
+                                Person p when p.Age is > 5 and < 10 => p with { Age = p.Age + 1 },
+                                _                                   => person,
+                        };
+                }
+        }
 }

--- a/spec/visual/samples/csharp
+++ b/spec/visual/samples/csharp
@@ -379,6 +379,12 @@ namespace Diva.Core {
 
         public static class Csharp7And8And9Tests
         {
+                const int BinaryConstant = 0b0100_1101;
+                const int HexadecimalConstant = 0x1245_78ab;
+
+                public const double AvogadroConstant = 6.022_140_857_747_474e23;
+                public const decimal GoldenRatio = 1.618_033_988_749_894_848_204_586_834_365_638_117_720_309_179M;
+
                 record NamedEntity(string Name);
 
                 record Person(string Name) : NamedEntity("Mr " + Name)


### PR DESCRIPTION
Those happened in C# language versions 6 through 9. I've mostly tested these additions visually (using `rackup`). Tests (`rake`) all pass. Here's a quick summary with links to official documentation:

### Added keywords

 * `and` ([pattern matching in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#pattern-matching-enhancements))
 * `init` ([init only setters and records in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#init-only-setters))
 * `unmanaged` ([new generic type constraint in C# 7](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#enhanced-generic-constraints))
 * `nint` ([native sized integers in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#performance-and-interop))
 * `nuint` ([native sized integers in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#performance-and-interop))
 * `not` ([pattern matching in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#pattern-matching-enhancements))
 * `notnull` ([nullable reference types in C# 8](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters#notnull-constraint))
 * `#nullable` ([nullable reference types in C# 8](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts))
 * `or` ([pattern matching in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#pattern-matching-enhancements))
 * `record` ([records in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#record-types))
 * `with` ([records in C# 9](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#record-types))
 * `when` ([exception filters in C# 6](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/when#when-in-a-catch-statement), [pattern matching in C# 7](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#pattern-matching))

### Numeric literal improvements ([documentation](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#numeric-literal-syntax-improvements))

 * add C# 7 binary literals, e.g. `0b0010`
 * add C# 7 digit separators in all numeric literals, e.g. `123_567_890`
 * add missing `M` type suffix designating `decimal`
 * make the exponent sign optional