### PR TITLE
Fix single line block comments and scoped variables and functions in JSL lexer

### DIFF
--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -14,8 +14,7 @@ module Rouge
         rule %r/\s+/m, Text::Whitespace
 
         rule %r(//.*?$), Comment::Single
-        rule %r'/[*].*[*]/', Comment::Multiline # single line block comment
-        rule %r'/[*].*', Comment::Multiline, :comment # multiline block comment
+        rule %r'/[*].*?', Comment::Multiline, :comment # multiline block comment
 
         # messages
         rule %r/<</, Operator, :message

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -14,7 +14,8 @@ module Rouge
         rule %r/\s+/m, Text::Whitespace
 
         rule %r(//.*?$), Comment::Single
-        rule %r'/[*].*', Comment::Multiline, :comment
+        rule %r'/[*].*[*]/', Comment::Multiline # single line block comment
+        rule %r'/[*].*', Comment::Multiline, :comment # multiline block comment
 
         # messages
         rule %r/<</, Operator, :message

--- a/lib/rouge/lexers/jsl.rb
+++ b/lib/rouge/lexers/jsl.rb
@@ -21,18 +21,17 @@ module Rouge
         rule %r/<</, Operator, :message
 
         # covers built-in and custom functions
-        rule %r/([a-z_][\w\s'%.\\]*)(\()/i do |m|
-          groups Keyword, Punctuation
+        rule %r/(::|:)?([a-z_][\w\s'%.\\]*)(\()/i do |m|
+          groups Punctuation, Keyword, Punctuation
         end
 
         rule %r/\d{2}(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\d{2}(\d{2})?(:\d{2}:\d{2}(:\d{2}(\.\d*)?)?)?/i, Literal::Date
 
         rule %r/-?(?:[0-9]+(?:[.][0-9]+)?|[.][0-9]*)(?:e[+-]?[0-9]+)?i?/i, Num
 
-        rule %r/::[a-z_][\w\s'%.\\]*/i, Name::Variable
-        rule %r/:\w+/, Name
-        rule %r/[a-z_][\w\s'%.\\]*/i, Name::Variable
-        rule %r/"(?:\\!"|[^"])*?"n/m, Name::Variable
+        rule %r/(::|:)?([a-z_][\w\s'%.\\]*|"(?:\\!"|[^"])*?"n)/i do |m|
+          groups Punctuation, Name::Variable
+        end
 
         rule %r/(")(\\\[)(.*?)(\]\\)(")/m do
           groups Str::Double, Str::Escape, Str::Double, Str::Escape, Str::Double  # escaped string

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -4,7 +4,7 @@ dt << Distribution( Column( :age ), Histograms Only( 1 ) );
 /*
     Multi-line comment
 */
-
+/* Single line block comment */
 /*
     Nested
     /*
@@ -36,3 +36,7 @@ New Window( "Rouge Test",
 );
 
 If(tb << Get Text != "", "I'm still formatted correctly!");
+
+New Namespace("rouge");
+rouge:scoped.func = function({x, y}, x + y);
+rouge:scoped.func(1, 2);

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -18,7 +18,8 @@ escapeQuote = "This is a \!" quotation mark";
 escapeStr = "\[This is """"""" an escaped string]\"
 
 list = List( 1, 3, 5 );
-alsoAList = {7,9,11};index = 1::10::2;
+alsoAList = {7,9,11};
+index = 1::10::2;
 a name with spaces = 5;
 "a-name!with\!"special\characters"n = 5;
 ::globalVar = 1;

--- a/spec/visual/samples/jsl
+++ b/spec/visual/samples/jsl
@@ -18,9 +18,11 @@ escapeQuote = "This is a \!" quotation mark";
 escapeStr = "\[This is """"""" an escaped string]\"
 
 list = List( 1, 3, 5 );
-alsoAList = {7,9,11};
+alsoAList = {7,9,11};index = 1::10::2;
 a name with spaces = 5;
 "a-name!with\!"special\characters"n = 5;
+::globalVar = 1;
+here:scopedVar = 2;
 
 scientificNotation = 5e9;
 decimal = 1.234;


### PR DESCRIPTION
This PR has the following fixes for the JSL lexer:
* Single line block comments no longer comment out the rest of the file
* Scoped variables/functions get lexed correctly e.g. `namespace:my_var`
