### PR TITLE
Fix YAML key containing special characters

### DIFF
--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -175,7 +175,7 @@ module Rouge
 
       state :block_nodes do
         # implicit key
-        rule %r/((?:[\p{L}\p{Nl}\p{Nd}_][\p{L}\p{Nl}\p{Nd}\p{Blank}_-]*)?)(:)(?=\s|$)/ do |m|
+        rule %r/([^#,:?\[\]{}"'\n]+)(:)(?=\s|$)/ do |m|
           groups Name::Attribute, Punctuation::Indicator
           set_indent m[0], :implicit => true
         end

--- a/spec/lexers/digdag_spec.rb
+++ b/spec/lexers/digdag_spec.rb
@@ -21,7 +21,7 @@ describe Rouge::Lexers::Digdag do
 
     it 'recognizes one line comment on last line even when not terminated by a new line (#360)' do
       assert_tokens_equal "+step1:\n  echo> Hello!\n",
-        ["Literal.String", "+step1"],
+        ["Name.Attribute", "+step1"],
         ["Punctuation.Indicator", ":"],
         ["Text", "\n  "],
         ["Literal.String", "echo> Hello!"],

--- a/spec/visual/samples/yaml
+++ b/spec/visual/samples/yaml
@@ -353,3 +353,8 @@ Stack:
   语言: français
   référence: &réf_01
   alias: *λ-01
+
+# Scalars with special characters
+foo/bar: We are great
+foo.bar: Are we really?
+foo+bar: Maybe not


### PR DESCRIPTION
The regex is lifted from the `YamlLexer` class in `Pygments` library (see [more](https://github.com/pygments/pygments/blob/debda34e2d4f28d6d369cdafdcba4791702f63fc/pygments/lexers/data.py#L235)).

| Before | After |
| -- | -- |
| <img width="277" alt="Screen Shot 2021-01-20 at 9 47 46 pm" src="https://user-images.githubusercontent.com/756722/105164589-69397900-5b69-11eb-9e32-5781e4d45bbf.png"> | <img width="277" alt="Screen Shot 2021-01-20 at 9 48 22 pm" src="https://user-images.githubusercontent.com/756722/105164557-6048a780-5b69-11eb-895e-36326c9dbe20.png"> |

Closes #778