### PR TITLE
Add new Matlab keywords (fixes #1589)

### DIFF
--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -13,8 +13,9 @@ module Rouge
 
       def self.keywords
         @keywords = Set.new %w(
-          break case catch classdef continue else elseif end for function
-          global if otherwise parfor persistent return spmd switch try while
+          arguments break case catch classdef continue else elseif end for
+          function global if import methods otherwise parfor persistent
+          properties return spmd switch try while
         )
       end
 


### PR DESCRIPTION
Newly introduced "keywords": `arguments, properties, methods, import`