### PR TITLE
Speed improvement when formatting HTML

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -33,7 +33,9 @@ module Rouge
         '&' => '&amp;',
         '<' => '&lt;',
         '>' => '&gt;',
-      }
+      }.freeze
+
+      ESCAPE_REGEX = /[&<>]/.freeze
 
     private
       # A performance-oriented helper method to escape `&`, `<` and `>` for the rendered
@@ -41,15 +43,19 @@ module Rouge
       #
       # `String#gsub` will always return a new string instance irrespective of whether
       # a substitution occurs. This method however invokes `String#gsub` only if
-      # a substitution is imminent.
+      # a substitution is imminent. Where possible it will perform the substitution in-place
+      # using gsub!
       #
       # Returns either the given `value` argument string as is or a new string with the
       # special characters replaced with their escaped counterparts.
       def escape_special_html_chars(value)
-        escape_regex = /[&<>]/
-        return value unless value =~ escape_regex
+        if value.frozen?
+          return value unless value =~ ESCAPE_REGEX
 
-        value.gsub(escape_regex, TABLE_FOR_ESCAPE_HTML)
+          value.gsub(ESCAPE_REGEX, TABLE_FOR_ESCAPE_HTML)
+        else
+          value.gsub!(ESCAPE_REGEX, TABLE_FOR_ESCAPE_HTML) || value
+        end
       end
     end
   end


### PR DESCRIPTION
A slight performance improvement when formatting HTML. This will further reduce the number of new strings being created, and also prevents the regex being instantiated multiple times.

Briefly benchmarked this by adding 50,000 extra tests and the gain is marginal but there:

### Original
```
Finished in 18.505466s, 57.2263 runs/s, 2827.1107 assertions/s.
1059 runs, 52317 assertions, 0 failures, 0 errors, 0 skips
```

### This PR
```
Finished in 17.132288s, 61.8131 runs/s, 3053.7077 assertions/s.
1059 runs, 52317 assertions, 0 failures, 0 errors, 0 skips
```

I do however have a question about the safety of using `gsub!` to replace the tokens in the existing string here. I am assuming that the strings would already have been duplicated from the original user input by this point (having gone through a lexer). I'd like to clarify this with someone more experienced :smile: 