### PR TITLE
Add Byebug as development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'yard'
 
 group :development do
   gem 'pry'
+  gem 'byebug'
 
   # docs
   gem 'github-markup'


### PR DESCRIPTION
Minitest power assert requires byebug. Apparently this needs to
be explicitly defined in older versions of Ruby. Newer versions
don't need to have a problem with it.