### PR TITLE
Pin power_assert to 1.2 series

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rake'
 
 gem 'minitest', '>= 5.0'
 gem 'minitest-power_assert'
+gem 'power_assert', '~> 1.2'
 
 gem 'parallel', '~> 1.13.0' if RUBY_VERSION < '2.2.0'
 gem 'rubocop', '~> 0.49.1'


### PR DESCRIPTION
`power_assert` recently released version 2.0 which caused some
    issues on older versions of Ruby. Pin to 1.2 for now until we
    deprecate support for older versions of Ruby.