### PR TITLE
Fix warnings and small mistakes in several lexers

### DIFF
--- a/lib/rouge/lexers/ada.rb
+++ b/lib/rouge/lexers/ada.rb
@@ -155,7 +155,7 @@ module Rouge
         end
 
         # Flag word-like things that don't match the ID pattern.
-        rule %r{\b(\p{Pc}|[[alpha]])\p{Word}*}, Error
+        rule %r{\b(\p{Pc}|[[:alpha:]])\p{Word}*}, Error
       end
     end
   end

--- a/lib/rouge/lexers/clean.rb
+++ b/lib/rouge/lexers/clean.rb
@@ -79,7 +79,7 @@ module Rouge
 
         rule %r/code(\s+inline)?\s*{/, Comment::Preproc, :abc
 
-        rule %r/_*[a-z][\w_`]*/ do |m|
+        rule %r/_*[a-z][\w`]*/ do |m|
           if self.class.keywords.include?(m[0])
             token Keyword
           else
@@ -87,7 +87,7 @@ module Rouge
           end
         end
 
-        rule %r/_*[A-Z][\w_`]*/ do |m|
+        rule %r/_*[A-Z][\w`]*/ do |m|
           if m[0]=='True' || m[0]=='False'
             token Keyword::Constant
           else
@@ -95,7 +95,7 @@ module Rouge
           end
         end
 
-        rule %r/[^\w_\s`]/, Punctuation
+        rule %r/[^\w\s`]/, Punctuation
         rule %r/_\b/, Punctuation
       end
 
@@ -136,7 +136,7 @@ module Rouge
 
         rule %r/}/, Comment::Preproc, :pop!
         rule %r/\.\w*/, Keyword, :abc_rest_of_line
-        rule %r/[\w_]+/, Name::Builtin, :abc_rest_of_line
+        rule %r/[\w]+/, Name::Builtin, :abc_rest_of_line
       end
 
       state :abc_rest_of_line do

--- a/lib/rouge/lexers/ecl.rb
+++ b/lib/rouge/lexers/ecl.rb
@@ -114,8 +114,8 @@ module Rouge
         mixin :single_quote
 
         rule %r(\b(?i:(and|not|or|in))\b), Operator::Word
-        rule %r([:=|>|<|<>|/|\\|\+|-|=]), Operator
-        rule %r([\[\]{}();,\&,\.,\%]), Punctuation
+        rule %r(:=|>|<>|<|/|\\|\+|-|=), Operator
+        rule %r([\[\]{}();,\&\.\%]), Punctuation
 
         rule %r(\b(?i:(beginc\+\+.*?endc\+\+)))m, Str::Single
         rule %r(\b(?i:(embed.*?endembed)))m, Str::Single

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -28,7 +28,7 @@ module Rouge
       end
 
       def self.builtins
-        builtins = %w(
+        %w(
           Color8 ColorN abs acos asin assert atan atan2 bytes2var ceil char
           clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst
           ease exp floor fmod fposmod funcref hash inst2dict instance_from_id

--- a/lib/rouge/lexers/ghc_cmm.rb
+++ b/lib/rouge/lexers/ghc_cmm.rb
@@ -22,11 +22,11 @@ module Rouge
       ws = %r(\s|//.*?\n|/[*](?:[^*]|(?:[*][^/]))*[*]+/)mx
 
       # Make sure that this is not a preprocessor macro, e.g. `#if` or `#define`.
-      id = %r((?!#[a-zA-Z])[\w#\$%_']+)
+      id = %r((?!#[a-zA-Z])[\w#\$%']+)
 
       complex_id = %r(
-        (?:[\w#$%_']|\(\)|\(,\)|\[\]|[0-9])*
-        (?:[\w#$%_']+)
+        (?:[\w#$%']|\(\)|\(,\)|\[\]|[0-9])*
+        (?:[\w#$%']+)
       )mx
 
       state :root do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -24,7 +24,7 @@ module Rouge
         while yield
       )
 
-      name_chars = %r'[-_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
+      name_chars = %r'[-\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
 
       class_name = %r'`?[\p{Lu}]#{name_chars}`?'
       name = %r'`?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}]#{name_chars}`?'

--- a/lib/rouge/lexers/objective_c/common.rb
+++ b/lib/rouge/lexers/objective_c/common.rb
@@ -4,8 +4,6 @@
 module Rouge
   module Lexers
     module ObjectiveCCommon
-      id = /[a-z$_][a-z0-9$_]*/i
-
       def at_keywords
         @at_keywords ||= %w(
           selector private protected public encode synchronized try

--- a/lib/rouge/lexers/solidity.rb
+++ b/lib/rouge/lexers/solidity.rb
@@ -11,7 +11,7 @@ module Rouge
 
       # optional comment or whitespace
       ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
-      id = /[a-zA-Z$_][\w$_]*/
+      id = /[a-zA-Z$_][\w$]*/
 
       def self.detect?(text)
         return true if text.start_with? 'pragma solidity'

--- a/lib/rouge/lexers/sql.rb
+++ b/lib/rouge/lexers/sql.rb
@@ -115,7 +115,7 @@ module Rouge
         rule %r/"/, Name::Variable, :double_string
         rule %r/`/, Name::Variable, :backtick
 
-        rule %r/\w[\w\d]*/ do |m|
+        rule %r/[[:alpha:]][\w]*/ do |m|
           if self.class.keywords_type.include? m[0].upcase
             token Name::Builtin
           elsif self.class.keywords.include? m[0].upcase

--- a/lib/rouge/lexers/yang.rb
+++ b/lib/rouge/lexers/yang.rb
@@ -10,7 +10,7 @@ module Rouge
       filenames '*.yang'
       mimetypes 'application/yang'
 
-      id = /[\w_-]+(?=[^\w\-\:])\b/
+      id = /[\w-]+(?=[^\w\-\:])\b/
 
       #Keywords from RFC7950 ; oriented at BNF style
       def self.top_stmts_keywords


### PR DESCRIPTION
When running tests for a gem that depends on `rouge` I've noticed that there are a bunch of relatively easy to fix warnings popping up during the test execution.

I've split into separate commits each warning / fix per file required and added an explanation on each commit message of what was the problem.

When evaluating each regular expression issue, I've used Ruby 2.0.0 Regexp documentation as base.

----

To reproduce the warnings above, I've run specs with `-W2` option enabled:

```ruby
RUBYOPT='-W2' rake check:specs
```