### PR TITLE
Avoid catastrophic backtracing in regex

### DIFF
--- a/lib/rouge/lexers/factor.rb
+++ b/lib/rouge/lexers/factor.rb
@@ -243,8 +243,8 @@ module Rouge
         end
 
         # strings
-        rule %r/"""[^"].*?[^"]"""/, Str
-        rule %r/"(\\.|[^\\])*?"/, Str
+        rule %r/"(?:\\\\|\\"|[^"])*"/, Str
+        rule %r/\S+"\s+(?:\\\\|\\"|[^"])*"/, Str
         rule %r/(CHAR:)(\s+)(\\[\\abfnrstv]*|\S)(?=\s)/, Str::Char
 
         # comments

--- a/lib/rouge/lexers/factor.rb
+++ b/lib/rouge/lexers/factor.rb
@@ -243,7 +243,7 @@ module Rouge
         end
 
         # strings
-        rule %r/"""\s+.*?\s+"""/, Str
+        rule %r/"""[^"].*?[^"]"""/, Str
         rule %r/"(\\.|[^\\])*?"/, Str
         rule %r/(CHAR:)(\s+)(\\[\\abfnrstv]*|\S)(?=\s)/, Str::Char
 

--- a/lib/rouge/lexers/ghc_core.rb
+++ b/lib/rouge/lexers/ghc_core.rb
@@ -17,7 +17,7 @@ module Rouge
         rule %r/^=====.*=====$/, Generic::Heading
         # timestamps
         rule %r/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ UTC$/, Comment::Single
-        rule %r/^Result size of .+\s*.*}/, Comment::Multiline
+        rule %r/^Result size of .+\n.+{[^}]*}/, Comment::Multiline
         rule %r/--.*$/, Comment::Single
 
         rule %r/\[/, Comment::Special, :annotation


### PR DESCRIPTION
@tancnle This PR attempts to fix some regex that could cause catastrophic backtracing, could you take a look?

## For the `ghc_core` lexer:

- <img width="755" alt="Screen Shot 2021-03-10 at 15 57 39" src="https://user-images.githubusercontent.com/36979740/110595228-1d966980-81c1-11eb-93f7-d12ecc11c393.png">

- <img width="755" alt="Screen Shot 2021-03-10 at 15 58 13" src="https://user-images.githubusercontent.com/36979740/110595251-22f3b400-81c1-11eb-8020-471ea56c4377.png">

## For the `factor` lexer:

- <img width="755" alt="Screen Shot 2021-03-10 at 16 09 54" src="https://user-images.githubusercontent.com/36979740/110595274-2be48580-81c1-11eb-82f3-d48039acc697.png">

- <img width="755" alt="Screen Shot 2021-03-10 at 16 09 39" src="https://user-images.githubusercontent.com/36979740/110595299-33a42a00-81c1-11eb-9b02-9cc2988cb0ae.png">
