### PR TITLE
Partially update Dart lexer with newer keywords and types

### DIFF
--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -5,25 +5,25 @@ module Rouge
   module Lexers
     class Dart < RegexLexer
       title "Dart"
-      desc "The Dart programming language (dartlang.com)"
+      desc "The Dart programming language (dart.dev)"
 
       tag 'dart'
       filenames '*.dart'
       mimetypes 'text/x-dart'
 
       keywords = %w(
-        as assert break case catch continue default do else finally for
-        if in is new rethrow return super switch this throw try while with
+        as assert await break case catch continue default do else finally for
+        if in is new rethrow return super switch this throw try while with yield
       )
 
       declarations = %w(
-        abstract dynamic const external extends factory final get implements
-        native operator set static typedef var
+        abstract async dynamic const covariant external extends factory final get
+        implements late native on operator required set static sync typedef var
       )
 
-      types = %w(bool double Dynamic enum int num Object Set String void)
+      types = %w(bool Comparable double Dynamic enum Function int List Map Never Null num Object Pattern Set String Symbol Type Uri void)
 
-      imports = %w(import export library part\s*of part source)
+      imports = %w(import deferred export library part\s*of part source)
 
       id = /[a-zA-Z_]\w*/
 
@@ -53,7 +53,7 @@ module Rouge
         rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
         rule %r/(?:#{types.join('|')})\b/, Keyword::Type
         rule %r/(?:true|false|null)\b/, Keyword::Constant
-        rule %r/(?:class|interface)\b/, Keyword::Declaration, :class
+        rule %r/(?:class|interface|mixin)\b/, Keyword::Declaration, :class
         rule %r/(?:#{imports.join('|')})\b/, Keyword::Namespace, :import
         rule %r/(\.)(#{id})/ do
           groups Operator, Name::Attribute


### PR DESCRIPTION
The Dart language has gone through a lot of changes since this lexer was last updated.

This change adds most of the new keywords and core built in types.

You can find more information on Dart's language tour: https://dart.dev/guides/language/language-tour