### PR TITLE
Drop support for Ruby < 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   Exclude:
     - "tasks/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -10,16 +10,13 @@ gem 'minitest', '>= 5.0'
 gem 'minitest-power_assert'
 gem 'power_assert', '~> 1.2'
 
-gem 'parallel', '~> 1.13.0' if RUBY_VERSION < '2.2.0'
 gem 'rubocop', '~> 0.49.1'
 
 # don't try to install redcarpet under jruby
-gem 'redcarpet', :platforms => :ruby
+gem 'redcarpet', platforms: :ruby
 
 # Profiling
-if RUBY_VERSION >= '2.3.0'
-  gem 'memory_profiler', :require => false
-end
+gem 'memory_profiler', require: false
 
 # Needed for a Rake task
 gem 'git'
@@ -32,11 +29,7 @@ group :development do
   gem 'github-markup'
 
   # for visual tests
-  if RUBY_VERSION < '2.2.0'
-    gem 'sinatra', '~> 1.4.8'
-  else
-    gem 'sinatra'
-  end
+  gem 'sinatra'
 
   # Ruby 3 no longer ships with a web server
   gem 'puma' if RUBY_VERSION >= '3'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake'
 
 gem 'minitest', '>= 5.0'
 gem 'minitest-power_assert'
-gem 'power_assert', '~> 1.2'
+gem 'power_assert', '~> 2.0.1'
 
 gem 'rubocop', '~> 0.49.1'
 

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.5'
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rouge-ruby/rouge/issues",
     "changelog_uri"     => "https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md",


### PR DESCRIPTION
With Ruby 2.4 being EOL, we should drop support for old versions to reduce Rouge gem maintenance effort. It also helps to reduce build runtime and avoid overrunning our monthly CI build time allotment.

Closes https://github.com/rouge-ruby/rouge/issues/1694