### PR TITLE
Fix Visual Test App on Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,8 @@ group :development do
   else
     gem 'sinatra'
   end
+
+  # Ruby 3 no longer ships with a web server
+  gem 'puma' if RUBY_VERSION.to_i >= 3
   gem 'shotgun'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,6 @@ group :development do
   end
 
   # Ruby 3 no longer ships with a web server
-  gem 'puma' if RUBY_VERSION.to_i >= 3
+  gem 'puma' if RUBY_VERSION >= '3'
   gem 'shotgun'
 end


### PR DESCRIPTION
Add puma as development dependency for Ruby 3.0, as  Ruby 3.0 no longer ships with a built-in web server.