### PR TITLE
Add Kos lexer

### DIFF
--- a/lib/rouge/demos/kos
+++ b/lib/rouge/demos/kos
@@ -1,0 +1,17 @@
+import base.*
+import io
+import re.re
+
+fun has_alphanum(str)
+{
+    return re("[0-9a-zA-Z]+").find(str)
+}
+
+# For each file on the command line
+for const filename in args[1:] {
+
+    # Sort and print lines which contain any alphanumeric characters
+    io.read_lines(filename) -> filter(has_alphanum)
+                            -> sort()
+                            -> each(print)
+}

--- a/lib/rouge/lexers/kos.rb
+++ b/lib/rouge/lexers/kos.rb
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Kos < RegexLexer
+      tag 'kos'
+      filenames '*.kos'
+      mimetypes 'application/kos', 'text/kos'
+
+      def self.detect?(text)
+        return 1 if text.shebang?('kos')
+      end
+
+      title "Kos"
+      desc 'General-purpose scripting language. (kos-lang.github.io)'
+
+      id_head = /_|(?!\p{Mc})\p{Alpha}|[^\u0000-\uFFFF]/
+      id_rest = /[\p{Alnum}_]|[^\u0000-\uFFFF]/
+      id = /#{id_head}#{id_rest}*/
+
+      keywords = Set.new %w(
+        _ __line__ assert async break case catch continue default
+        defer delete do else fallthrough for get if in instanceof loop
+        match propertyof repeat return set super switch this throw try typeof
+        while with yield
+      )
+
+      declarations = Set.new %w(
+        class const constructor extends fun import public static var
+      )
+
+      constants = Set.new %w(
+        true false void
+      )
+
+      state :inline_whitespace do
+        rule %r/\s+/m, Text
+        mixin :has_comments
+      end
+
+      state :whitespace do
+        rule %r/\n+/m, Text
+        rule %r(\/\/.*?$), Comment::Single
+        rule %r(#.*?$), Comment::Single
+        mixin :inline_whitespace
+      end
+
+      state :has_comments do
+        rule %r(/[*]), Comment::Multiline, :nested_comment
+      end
+
+      state :nested_comment do
+        mixin :has_comments
+        rule %r([*]/), Comment::Multiline, :pop!
+        rule %r([^*/]+)m, Comment::Multiline
+        rule %r/./, Comment::Multiline
+      end
+
+      state :root do
+        mixin :whitespace
+        
+        rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
+
+        rule %r{[()\[\]{}:;,?]}, Punctuation
+        rule %r([-/=+*%<>!&|^.~]+), Operator
+        rule %r/r?"/, Str, :dq
+        rule %r/(\d+(?:_\d+)*\*|(?:\d+(?:_\d+)*)*\.\d+(?:_\d)*)([eEpP][+-]?\d+(?:_\d)*)?/i, Num::Float
+        rule %r/\d+[eEpP][+-]?[0-9]+/i, Num::Float
+        rule %r/0[xX][0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*((\.[0-9A-F]+(?:_[0-9A-F]+)*)?p[+-]?\d+)?/, Num::Hex
+        rule %r/0[bB][01]+(?:_[01]+)*/, Num::Bin
+        rule %r{[\d]+(?:_\d+)*}, Num::Integer
+
+        rule %r/(const|var)\b(\s*)(#{id})/ do
+          groups Keyword, Text, Name::Variable
+        end
+
+        rule id do |m|
+          if keywords.include? m[0]
+            token Keyword
+          elsif declarations.include? m[0]
+            token Keyword::Declaration
+          elsif constants.include? m[0]
+            token Keyword::Constant
+          else
+            token Name
+          end
+        end
+      end
+
+      state :dq do
+        rule %r/\\[\\0fnrtv"]/, Str::Escape
+        rule %r/\\[(]/, Str::Escape, :interp
+        rule %r/\\x\h\h/, Str::Escape
+        rule %r/\\u\{\h{1,8}\}/, Str::Escape
+        rule %r/[^\\"]+/, Str
+        rule %r/"""/, Str, :pop!
+        rule %r/"/, Str, :pop!
+      end
+
+      state :interp do
+        rule %r/[(]/, Punctuation, :interp_inner
+        rule %r/[)]/, Str::Escape, :pop!
+        mixin :root
+      end
+
+      state :interp_inner do
+        rule %r/[(]/, Punctuation, :push
+        rule %r/[)]/, Punctuation, :pop!
+        mixin :root
+      end
+    end
+  end
+end

--- a/spec/lexers/kos_spec.rb
+++ b/spec/lexers/kos_spec.rb
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Kos do
+  let(:subject) { Rouge::Lexers::Kos.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.kos'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'application/kos'
+      assert_guess :mimetype => 'text/kos'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => '#!/usr/bin/env kos'
+    end
+  end
+end

--- a/spec/visual/samples/kos
+++ b/spec/visual/samples/kos
@@ -1,0 +1,187 @@
+#!/usr/bin/env kos
+
+import base.*;
+import io;
+import math.min;
+
+/* multi-line
+   comment
+// */ var a1 = 1
+var a2 = 2 // single-line comment /*
+var a3 = 3 # single-line comment /*
+
+const        constant        = void
+var          variable        = void
+public const public_constant = void
+public var   public_variable = void
+
+class some extends object {
+    constructor {
+        super()
+        print(__line__, this, true, false, void)
+    }
+}
+
+# Let's test literals
+
+const decimal0 = 0
+const decimal1 = 1
+const decimal100 = 100
+const decimalMil = 1_000_000
+const decimalFloatMan = 0.0
+const decimalFloatExp1 = 0e+1
+const decimalFloatExp2 = 0e-1
+const decimalFloatExp3 = 0e1
+const decimalFloatExp4 = 0E+1
+const decimalFloatExp5 = 0E-1
+const decimalFloatExp6 = 0E1
+const decimalFloatExp7 = 0p+1
+const decimalFloatExp8 = 0p-1
+const decimalFloatExp9 = 0p1
+const decimalFloatExpA = 0P+1
+const decimalFloatExpB = 0P-1
+const decimalFloatExpC = 0P1
+const decimalFloatManExp1 = 0.1e+1
+const decimalFloatManExp2 = 0.1e-1
+const decimalFloatManExp3 = 0.1e1
+const decimalFloatManExp4 = 0.1E+1
+const decimalFloatManExp5 = 0.1E-1
+const decimalFloatManExp6 = 0.1E1
+const decimalFloatManExp7 = 0.1p+1
+const decimalFloatManExp8 = 0.1p-1
+const decimalFloatManExp9 = 0.1p1
+const decimalFloatManExpA = 0.1P+1
+const decimalFloatManExpB = 0.1P-1
+const decimalFloatManExpC = 0.1P1
+
+const hex0 = 0x0
+const hex1 = 0x1
+const hex16 = 0x10
+const hexGazillion = 0x1_0000_0000
+
+const bin0 = 0b0
+const Bin0 = 0B0
+const bin16 = 0b1_0000
+const Bin16 = 0B1_0000
+
+const strEmpty = ""
+const strFull = "full"
+const strRaw = r"
+Multi-line raw string
+"
+
+const strInterp = "string\( "".join(strFull -> map(fun(x) { return x + ":" }))
+                            + " in-str " + strEmpty)string"
+
+const strEscape = "eol: \r\n    backslash: \\   quote: \"     tab: \t"
+
+const some_array  = [ "value" ]
+const some_object = { prop: 0 }
+assert "prop" propertyof some_object
+assert "prop" in some_object
+delete some_object.prop
+
+# Let's test operators
+
+const o_add    = 1 + 2
+const o_sub    = 1 - 2
+const o_mul    = 1 * 2
+const o_div    = 1 / 2
+const o_mod    = 1 % 2
+const o_and    = 1 & 2
+const o_or     = 1 | 2
+const o_xor    = 1 ^ 2
+const o_shl    = 1 << 2
+const o_shr    = 1 >> 2
+const o_sar    = 1 >>> 2
+const o_not    = !1
+const o_neg    = ~1
+const o_lt     = 1 <  2
+const o_le     = 1 <= 2
+const o_gt     = 1 >  2
+const o_ge     = 1 >= 2
+const o_eq     = 1 == 2
+const o_ne     = 1 != 2
+const o_which  = 1 ? 2 : 3
+const o_land   = 1 && 2
+const o_lor    = 1 || 2
+
+var val = 0
+val += 1
+val -= 1
+val *= 1
+val /= 1
+val %= 1
+val &= 1
+val |= 1
+val ^= 1
+val <<= 1
+val >>= 1
+val >>>= 1
+
+# Test lambdas and stream operator
+;[1, 2, 3] -> map(x => -x) -> each(print)
+
+# Now let's test  keywords
+for const i, _ in enumerate("abcdefgh") {
+    assert i >= 0 && i < 3
+
+    defer {
+        val &= 0xFF
+    }
+
+    if i < 2 {
+        continue
+    }
+    else {
+        break
+    }
+
+    try {
+        switch i {
+            case 0: {
+                val *= 2
+                fallthrough
+            }
+            case 1 {
+                val *= 3
+                break
+            }
+            default {
+                throw typeof val
+            }
+        }
+    }
+    catch const e {
+        val *= -1
+    }
+}
+
+fun test_generator(base, objs...) {
+    repeat {
+        yield objs[-1] instanceof base
+        objs.resize(objs.size - 1)
+    } while objs.size
+
+    loop {
+        yield 0
+        break
+    }
+}
+
+do {
+    const gen = test_generator(integer, 1)
+    assert gen() == true
+    assert gen() == 0
+}
+
+with const o = { release: fun { } } { }
+
+if false {
+    val.get()
+    val.match()
+    val.set()
+    val.static()
+}
+
+# vim: ft=kos


### PR DESCRIPTION
This commit adds lexer for Kos scripting language.

I'm creating website for the Kos scripting language at http://kos-lang.github.io which will also contain documentation and I'd like to be able to use proper syntax highlighting for Kos examples.

Travis tests are already passing for this change in the fork.