### PR TITLE
Several improvements to the Rust lexer

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -164,15 +164,16 @@ module Rouge
         rule %r/r(#*)".*?"\1/m, Str
 
         # numbers
-        dot = /[.][0-9_]+/
-        exp = /e[-+]?[0-9_]+/
+        dot = /[.][0-9][0-9_]*/
+        exp = /[eE][-+]?[0-9_]+/
         flt = /f32|f64/
 
         rule %r(
-          [0-9_]+
+          [0-9][0-9_]*
           (#{dot}  #{exp}? #{flt}?
           |#{dot}? #{exp}  #{flt}?
           |#{dot}? #{exp}? #{flt}
+          |[.](?![._a-z])
           )
         )x, Num::Float
 
@@ -180,7 +181,7 @@ module Rouge
           ( 0b[10_]+
           | 0x[0-9a-fA-F_]+
           | 0o[0-7_]+
-          | [0-9_]+
+          | [0-9][0-9_]*
           ) (u#{size}?|i#{size})?
         )x, Num::Integer
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -22,10 +22,10 @@ module Rouge
 
       def self.keywords
         @keywords ||= %w(
-          as assert async await break const continue copy do drop else enum extern
-          fail false fn for if impl let log loop match mod move mut priv pub pure
-          ref return self static struct true trait type unsafe use where
-          while box
+          as assert async await break crate const continue copy do drop dyn else enum extern
+          fail false fn for if impl let log loop macro match mod move mut priv pub pure
+          ref return self Self static struct super true try trait type union unsafe use
+          where while yield box
         )
       end
 
@@ -40,6 +40,9 @@ module Rouge
           Right Send Shl Shr size_t Some ssize_t str Sub Success time_t
           u16 u32 u64 u8 usize uint uintptr_t
           Box Vec String Gc Rc Arc
+          u128 i128 Result Sync Pin Unpin Sized Drop drop Fn FnMut FnOnce
+          Clone PartialEq PartialOrd AsMut AsRef From Into Default
+          DoubleEndedIterator ExactSizeIterator Extend IntoIterator Iterator
         )
       end
 
@@ -110,6 +113,7 @@ module Rouge
         rule %r/\bmacro_rules!/, Name::Decorator, :macro_rules
         rule %r/#{id}!/, Name::Decorator, :macro
 
+        rule %r/'static\b/, Keyword
         rule %r/'#{id}/, Name::Variable
         rule %r/#{id}/ do |m|
           name = m[0]

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -54,7 +54,7 @@ module Rouge
 
       delim_map = { '[' => ']', '(' => ')', '{' => '}' }
 
-      id = /[a-z_]\w*/i
+      id = /[\p{XID_Start}_]\p{XID_Continue}*/
       hex = /[0-9a-f]/i
       escapes = %r(
         \\ ([nrt'"\\0] | x#{hex}{2} | u\{(#{hex}_*){1,6}\})
@@ -173,7 +173,7 @@ module Rouge
           (#{dot}  #{exp}? #{flt}?
           |#{dot}? #{exp}  #{flt}?
           |#{dot}? #{exp}? #{flt}
-          |[.](?![._a-z])
+          |[.](?![._\p{XID_Start}])
           )
         )x, Num::Float
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -57,7 +57,7 @@ module Rouge
       id = /[a-z_]\w*/i
       hex = /[0-9a-f]/i
       escapes = %r(
-        \\ ([nrt'"\\0] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
+        \\ ([nrt'"\\0] | x#{hex}{2} | u\{(#{hex}_*){1,6}\})
       )x
       size = /8|16|32|64|128|size/
 

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -59,7 +59,7 @@ module Rouge
       escapes = %r(
         \\ ([nrt'"\\0] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
       )x
-      size = /8|16|32|64/
+      size = /8|16|32|64|128|size/
 
       # Although not officially part of Rust, the rustdoc tool allows code in
       # comments to begin with `#`. Code like this will be evaluated but not
@@ -179,7 +179,7 @@ module Rouge
         rule %r(
           ( 0b[10_]+
           | 0x[0-9a-fA-F_]+
-          | 0o[0-7]+
+          | 0o[0-7_]+
           | [0-9_]+
           ) (u#{size}?|i#{size})?
         )x, Num::Integer

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -159,13 +159,13 @@ module Rouge
       state :has_literals do
         # constants
         rule %r/\b(?:true|false|nil)\b/, Keyword::Constant
-        # characters
+        # characters/bytes
         rule %r(
-          ' (?: #{escapes} | [^\\] ) '
+          b?' (?: #{escapes} | [^\\] ) '
         )x, Str::Char
 
-        rule %r/"/, Str, :string
-        rule %r/r(#*)".*?"\1/m, Str
+        rule %r/b?"/, Str, :string
+        rule %r/b?r(#*)".*?"\1/m, Str
 
         # numbers
         dot = /[.][0-9][0-9_]*/

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -43,9 +43,12 @@ describe Rouge::Lexers::Rust do
         ["Literal.Number.Integer", "5_000"],
         ["Name.Property", "._"]
     end
-    it 'can lex underscore' do
+    it 'can lex identifier edge cases' do
       assert_tokens_equal '_', ['Name', '_']
       assert_tokens_equal '_0', ["Name", "_0"]
+      assert_tokens_equal 'garçon', ['Name', 'garçon']
+      assert_tokens_equal 'Москва.東京', ["Name", "Москва"], ["Name.Property", ".東京"]
+      assert_tokens_equal '東京', ["Name", "東京"]
     end
     it 'can lex unicode escapes' do
       assert_tokens_equal %q("abc\u{0}def"),

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -29,5 +29,19 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal '0u128', ['Literal.Number.Integer', '0u128']
       assert_tokens_equal '0o5_0_0', ['Literal.Number.Integer', '0o5_0_0']
     end
+    it 'can lex unicode escapes' do
+      assert_tokens_equal %q("abc\u{0}def"),
+        ['Literal.String', '"abc'],
+        ['Literal.String.Escape', '\u{0}'],
+        ['Literal.String', 'def"']
+      assert_tokens_equal %q("abc\u{FDFD}def"),
+        ['Literal.String', '"abc'],
+        ['Literal.String.Escape', '\u{FDFD}'],
+        ['Literal.String', 'def"']
+      assert_tokens_equal %q('\u{10ffff}'),
+        ['Literal.String.Char', %q('\u{10ffff}')]
+      assert_tokens_equal %q('\u{f_f___f_f}'),
+        ['Literal.String.Char', %q('\u{f_f___f_f}')]
+    end
   end
 end

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -29,6 +29,24 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal '0u128', ['Literal.Number.Integer', '0u128']
       assert_tokens_equal '0o5_0_0', ['Literal.Number.Integer', '0o5_0_0']
     end
+    it 'is not confused by float edge cases' do
+      assert_tokens_equal '0.1E4', ['Literal.Number.Float', '0.1E4']
+      assert_tokens_equal '0._1',
+        ["Literal.Number.Integer", "0"],
+        ["Name.Property", "._1"]
+      assert_tokens_equal '1.',
+        ["Literal.Number.Float", "1."]
+      assert_tokens_equal '102. ',
+        ["Literal.Number.Float", "102."],
+        ["Text", " "]
+      assert_tokens_equal '5_000._',
+        ["Literal.Number.Integer", "5_000"],
+        ["Name.Property", "._"]
+    end
+    it 'can lex underscore' do
+      assert_tokens_equal '_', ['Name', '_']
+      assert_tokens_equal '_0', ["Name", "_0"]
+    end
     it 'can lex unicode escapes' do
       assert_tokens_equal %q("abc\u{0}def"),
         ['Literal.String', '"abc'],

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -19,4 +19,15 @@ describe Rouge::Lexers::Rust do
       assert_guess :source => '#!/usr/bin/env rustc --jit'
     end
   end
+  describe 'lexing' do
+    include Support::Lexing;
+
+    it 'can lex integers' do
+      assert_tokens_equal '123usize', ['Literal.Number.Integer', '123usize']
+      assert_tokens_equal '1_2_3_isize', ['Literal.Number.Integer', '1_2_3_isize']
+      assert_tokens_equal '30_000i128', ['Literal.Number.Integer', '30_000i128']
+      assert_tokens_equal '0u128', ['Literal.Number.Integer', '0u128']
+      assert_tokens_equal '0o5_0_0', ['Literal.Number.Integer', '0o5_0_0']
+    end
+  end
 end

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -50,6 +50,19 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal 'Москва.東京', ["Name", "Москва"], ["Name.Property", ".東京"]
       assert_tokens_equal '東京', ["Name", "東京"]
     end
+    it 'can lex (possibly raw) byte chars/strings' do
+      assert_tokens_equal %q(b'1'),
+        ['Literal.String.Char', %q(b'1')]
+      assert_tokens_equal %q(b'\xff'),
+        ['Literal.String.Char', %q(b'\xff')]
+      assert_tokens_equal %q(b"abc\xffdef"),
+        ['Literal.String', 'b"abc'],
+        ['Literal.String.Escape', '\xff'],
+        ['Literal.String', 'def"']
+      # raw string: no escape
+      assert_tokens_equal %q(br##"ab"c\xffd"#ef"##),
+        ['Literal.String', %q(br##"ab"c\xffd"#ef"##)]
+    end
     it 'can lex unicode escapes' do
       assert_tokens_equal %q("abc\u{0}def"),
         ['Literal.String', '"abc'],

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -63,6 +63,76 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal %q(br##"ab"c\xffd"#ef"##),
         ['Literal.String', %q(br##"ab"c\xffd"#ef"##)]
     end
+
+    it 'can lex multiline and doc comments' do
+      assert_tokens_equal "// single line",
+        ['Comment.Single', '// single line']
+      assert_tokens_equal "/// line-style docs (outer)",
+        ['Comment.Doc', '/// line-style docs (outer)']
+      assert_tokens_equal "//! line-style docs (inner)",
+        ['Comment.Doc', '//! line-style docs (inner)']
+      assert_tokens_equal "//// not a doc anymore",
+        ['Comment.Single', '//// not a doc anymore']
+      assert_tokens_equal "///! still doc (but not inner, not that we care)",
+        ['Comment.Doc', '///! still doc (but not inner, not that we care)']
+      assert_tokens_equal "////! plain again",
+        ['Comment.Single', '////! plain again']
+      assert_tokens_equal "1 /**/ 2",
+        ['Literal.Number.Integer', '1'],
+        ['Text', ' '],
+        ['Comment.Multiline', '/**/'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '2']
+      assert_tokens_equal "1 /***/ 2",
+        ['Literal.Number.Integer', '1'],
+        ['Text', ' '],
+        ['Comment.Multiline', '/***/'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '2']
+      assert_tokens_equal "/** outer docs */",
+        ['Comment.Doc', '/** outer docs */']
+      assert_tokens_equal "/*! inner docs */",
+        ['Comment.Doc', '/*! inner docs */']
+      assert_tokens_equal "/*** not docs */",
+        ['Comment.Multiline', '/*** not docs */']
+      assert_tokens_equal "1 /* /* /* nested */ */ */ 2",
+        ['Literal.Number.Integer', '1'],
+        ['Text', ' '],
+        ['Comment.Multiline', '/* /* /* nested */ */ */'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '2']
+      assert_tokens_equal "1 /** /* /* doc nested */ */ */ 2",
+        ['Literal.Number.Integer', '1'],
+        ['Text', ' '],
+        ['Comment.Doc', '/** /* /* doc nested */ */ */'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '2']
+      assert_tokens_equal "1 /* /** /* not doc, still nested */ */ */ 2",
+        ['Literal.Number.Integer', '1'],
+        ['Text', ' '],
+        ['Comment.Multiline', '/* /** /* not doc, still nested */ */ */'],
+        ['Text', ' '],
+        ['Literal.Number.Integer', '2']
+      assert_tokens_equal "/**/// this is still commented\n\"this is not\"",
+        ['Comment.Multiline', '/**/'],
+        ['Comment.Single', '// this is still commented'],
+        ['Text', "\n"],
+        ['Literal.String', '"this is not"']
+      assert_tokens_equal '/* /*/ / * // */ */ "tricky"',
+        ['Comment.Multiline', "/* /*/ / * // */ */"],
+        ['Text', ' '],
+        ['Literal.String', '"tricky"']
+      assert_tokens_equal "/*! abcd /* ef */\n/**/ //! /***/ // */ \"uncommented\"",
+        ['Comment.Doc', "/*! abcd /* ef */\n/**/ //! /***/ // */"],
+        ['Text', ' '],
+        ['Literal.String', '"uncommented"']
+      assert_tokens_equal "8/**//4",
+        ['Literal.Number.Integer', '8'],
+        ['Comment.Multiline', "/**/"],
+        ['Operator', '/'],
+        ['Literal.Number.Integer', '4']
+    end
+
     it 'can lex unicode escapes' do
       assert_tokens_equal %q("abc\u{0}def"),
         ['Literal.String', '"abc'],

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -19,8 +19,9 @@ describe Rouge::Lexers::Rust do
       assert_guess :source => '#!/usr/bin/env rustc --jit'
     end
   end
+
   describe 'lexing' do
-    include Support::Lexing;
+    include Support::Lexing
 
     it 'can lex integers' do
       assert_tokens_equal '123usize', ['Literal.Number.Integer', '123usize']
@@ -29,6 +30,7 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal '0u128', ['Literal.Number.Integer', '0u128']
       assert_tokens_equal '0o5_0_0', ['Literal.Number.Integer', '0o5_0_0']
     end
+
     it 'is not confused by float edge cases' do
       assert_tokens_equal '0.1E4', ['Literal.Number.Float', '0.1E4']
       assert_tokens_equal '0._1',
@@ -43,6 +45,7 @@ describe Rouge::Lexers::Rust do
         ["Literal.Number.Integer", "5_000"],
         ["Name.Property", "._"]
     end
+
     it 'can lex identifier edge cases' do
       assert_tokens_equal '_', ['Name', '_']
       assert_tokens_equal '_0', ["Name", "_0"]
@@ -50,6 +53,7 @@ describe Rouge::Lexers::Rust do
       assert_tokens_equal 'Москва.東京', ["Name", "Москва"], ["Name.Property", ".東京"]
       assert_tokens_equal '東京', ["Name", "東京"]
     end
+
     it 'can lex (possibly raw) byte chars/strings' do
       assert_tokens_equal %q(b'1'),
         ['Literal.String.Char', %q(b'1')]

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -418,3 +418,25 @@ fn tuple_access() {
     let t: (i32, i32) = (42, 13);
     let f: t.0;
 }
+
+// Some smoke tests for comments.
+// See the spec tests for more thorough checking.
+
+/// line-style docs (outer)
+mod external_line_docs {}
+
+mod internal_line_docs {
+    //! also line-style docs (inner)
+    //! still line docs
+}
+
+let _ = /**/ "<- self-closing non-doc comment";
+let _ = /***/ "<- another self-closing non-doc comment";
+
+/**
+ * multiline block doc (outer)
+ * including /* nesting */
+ */
+fn docs_block() {}
+
+mod bar { /*! docs for bar */ }


### PR DESCRIPTION
Each improvement is its own commit, and I tried to comment the code fairly well for anything too complex.

Also, it should basically all have tests (perhaps not exhaustive ones where trivial, e.g. I didn't ), except for the keyword additions which seem too simple to be worth testing.

I don't think this breaks highlighting of anything, e.g. I was careful to left the weird pre-Rust-1.0 stuff as I found it, and I'm very confident that the post-1.0 stuff is only more valid than before (I made these changes while consulting https://doc.rust-lang.org/reference/tokens.html, and for some reason, I've written lexers for Rust before).

I also tried to err on the side of accepting invalid code so long as it doesn't cause anything else to parse incorrectly.

---

P.S. I see that this project supports back to Ruby 2.0, but I tried to test for it, and couldn't follow the dev guide (bundler doesn't work that far back), so I'm somewhat relying on CI to tell me if anything is messed up. (Sorry, I haven't regularly written Ruby in years)