### PR TITLE
Add curly braces to SQL

### DIFF
--- a/lib/rouge/lexers/sql.rb
+++ b/lib/rouge/lexers/sql.rb
@@ -126,7 +126,7 @@ module Rouge
         end
 
         rule %r([+*/<>=~!@#%&|?^-]), Operator
-        rule %r/[;:()\[\],.]/, Punctuation
+        rule %r/[;:()\[\]\{\},.]/, Punctuation
       end
 
       state :multiline_comments do


### PR DESCRIPTION
Curly braces are used in SQL for ODBC escape sequences, and by DuckDB's nested types.