### PR TITLE
Add Swift 5.5 keywords

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -15,17 +15,17 @@ module Rouge
       id = /#{id_head}#{id_rest}*/
 
       keywords = Set.new %w(
-        break case continue default do else fallthrough if in for return switch where while try catch throw guard defer repeat
+        await break case continue default do else fallthrough if in for return switch where while try catch throw guard defer repeat
 
         as dynamicType is new super self Self Type __COLUMN__ __FILE__ __FUNCTION__ __LINE__
 
-        associativity didSet get infix inout mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup
+        associativity async didSet get infix inout isolated mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup
 
         #available #colorLiteral #column #else #elseif #endif #error #file #fileLiteral #function #if #imageLiteral #line #selector #sourceLocation #warning
       )
 
       declarations = Set.new %w(
-        class deinit enum convenience extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some
+        actor class deinit enum convenience extension final func import init internal lazy let nonisolated optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some
       )
 
       constants = Set.new %w(

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -452,4 +452,12 @@ func test(t: Types?) -> Bool {
 	}
 }
 
+actor AnActor {
+  nonisolated func funcA() {}
+  func funcB(otherActor: isolated AnActor) async {
+    await otherActor.funcB()
+    async let v = funcA()
+  }
+}
+
 foo() // end-of-file comment


### PR DESCRIPTION
Simple updates for new keywords for Swift 5.5
* [actor](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID648)
* [nonisolated](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID382)
* [async](https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID647)
* [await](https://docs.swift.org/swift-book/ReferenceManual/Expressions.html#ID646)

And updated 8/20 for Xcode 13 beta 5:
* [isolated](https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md)
   (this is in the Swift 5.5 being shipped but the official docs haven't caught up yet.)

![Screenshot 2021-08-20 at 17 45 27](https://user-images.githubusercontent.com/26768470/130266956-47bc203a-3bcf-4667-9171-3cec9be05182.png)
