### PR TITLE
Rough sketch of a TLA+ lexer

### DIFF
--- a/lib/rouge/demos/tla
+++ b/lib/rouge/demos/tla
@@ -1,0 +1,13 @@
+--- MODULE asdf ---
+
+EXTENDS TLC, Integers
+
+CONSTANTS N
+VARIABLES k
+
+Init == k = 0
+Next == IF k = N THEN k' = 0 ELSE k' = k + 1
+
+Spec == Init /\\ [][Next]_k
+
+===================

--- a/lib/rouge/lexers/tla.rb
+++ b/lib/rouge/lexers/tla.rb
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class TLA < RegexLexer
+      title "TLA+"
+      desc "The TLA+ modeling language for systems and programs"
+      tag 'tla'
+      aliases 'tlaplus'
+      filenames '*.tla'
+
+      # FIXME pretty sure this is too restrictive, but it'll do for now
+      id = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+      keywords = %w/
+        MODULE EXTENDS CONSTANT CONSTANTS VARIABLE VARIABLES
+        ASSUME THEOREM
+        LOCAL INSTANCE WITH
+        IF THEN ELSE TRUE FALSE CASE OTHER
+        LET IN
+        ENABLED UNCHANGED
+        DOMAIN EXCEPT ASSERT
+        CHOOSE
+        SUBSET UNION MOD
+      /
+
+      state :root do
+        rule %r/\s+/m, Text
+
+        rule %r/(\[\]\[)([^\]]+)(\]_)/ do |m|
+          token Operator, m[1]
+          token Name, m[2]
+          token Operator, m[3]
+        end
+
+        rule %r/\-\-.*/, Comment::Single
+        rule %r/\(\*.*\*\)/m, Comment::Multiline
+        rule %r/^===+/, Comment::Single
+
+        rule %r/(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/\\[a-z]+/, Name
+        rule %r/"(\\\\|\\"|[^"])*"/, Str
+        rule %r/#{id}'?/, Name
+        rule %r/[0-9]+\.[0-9]*/, Num::Float
+        rule %r/[0-9]+/, Num::Integer
+
+        rule %r/[\\~#!%^&*+\|:.,<>=\[\]\(\)\{\}\/_@-]/, Operator
+      end
+    end
+  end
+end

--- a/spec/lexers/tla_spec.rb
+++ b/spec/lexers/tla_spec.rb
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::TLA do
+  let(:subject) { Rouge::Lexers::TLA.new }
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'handles single line comments' do
+      assert_tokens_equal '-- comment', ['Comment.Single', '-- comment']
+    end
+
+    it 'handles multiline comments' do
+      assert_tokens_equal '(* comment *)', ['Comment.Multiline', '(* comment *)']
+    end
+
+    it 'handles keywords' do
+      assert_tokens_equal 'EXTENDS', ['Keyword', 'EXTENDS']
+    end
+
+    it 'handles \in, \cup, etc.' do
+      assert_tokens_equal 'a \in b', ['Name', 'a'], ['Text', ' '], ['Name', '\in'], ['Text', ' '], ['Name', 'b']
+    end
+
+    it 'handles basic TLA+ spec' do
+      source = <<EOF
+--- MODULE asdf ---
+
+EXTENDS TLC, Integers
+
+CONSTANTS N
+VARIABLES k
+
+Init == k = 0
+Next == IF k = N THEN k' = 0 ELSE k' = k + 1
+
+Spec == Init /\\ [][Next]_k
+
+===================
+EOF
+
+      # tokens of the same type get merged, so matches for
+      #
+      #   ["Operator", "["], ["Operator", "]"], ["Operator", "["]
+      #
+      # becomes
+      #
+      #   ["Operator", "[]["]
+      #
+      expected =
+        ['Comment.Single', '--- MODULE asdf ---'], ['Text', "\n\n"],
+        ['Keyword', 'EXTENDS'], ['Text', ' '], ['Name', 'TLC'], ['Operator', ','], ['Text', ' '], ['Name', 'Integers'], ['Text', "\n\n"],
+        ['Keyword', 'CONSTANTS'], ['Text', ' '], ['Name', 'N'], ['Text', "\n"],
+        ['Keyword', 'VARIABLES'], ['Text', ' '], ['Name', 'k'], ['Text', "\n\n"],
+        ['Name', 'Init'], ['Text', ' '], ['Operator', '=='], ['Text', ' '], ['Name', 'k'], ['Text', ' '], ['Operator', '='], ['Text', ' '], ['Literal.Number.Integer', '0'], ['Text', "\n"],
+        ['Name', 'Next'], ['Text', ' '], ['Operator', '=='], ['Text', ' '], ['Keyword', 'IF'], ['Text', ' '], ['Name', 'k'], ['Text', ' '], ['Operator', '='], ['Text', ' '], ['Name', 'N'], ['Text', ' '], ['Keyword', 'THEN'], ['Text', ' '], ['Name', "k'"], ['Text', ' '], ['Operator', '='], ['Text', ' '], ['Literal.Number.Integer', '0'], ['Text', ' '], ['Keyword', 'ELSE'], ['Text', ' '], ['Name', "k'"], ['Text', ' '], ['Operator', '='], ['Text', ' '], ['Name', 'k'], ['Text', ' '], ['Operator', '+'], ['Text', ' '], ['Literal.Number.Integer', '1'], ['Text', "\n\n"],
+        ['Name', 'Spec'], ['Text', ' '], ['Operator', '=='], ['Text', ' '], ['Name', 'Init'], ['Text', ' '], ['Operator', '/\\'], ['Text', ' '], ['Operator', '[]['], ['Name', 'Next'], ['Operator', ']_'], ['Name', 'k'], ['Text', "\n\n"],
+        ['Comment.Single', '==================='], ['Text', "\n"]
+      assert_tokens_equal source, *expected
+    end
+  end
+end

--- a/spec/visual/samples/tla
+++ b/spec/visual/samples/tla
@@ -1,0 +1,13 @@
+--- MODULE asdf ---
+
+EXTENDS TLC, Integers
+
+CONSTANTS N
+VARIABLES k
+
+Init == k = 0
+Next == IF k = N THEN k' = 0 ELSE k' = k + 1
+
+Spec == Init /\\ [][Next]_k
+
+===================


### PR DESCRIPTION
I'm new to writing Rouge lexers and no expert when it comes to the TLA+ language but this does a decent enough job of syntax highlighting basic TLA+ files on my personal Jekyll-based site so thought I'd open it up in case others find it useful.

No pluscal support yet but something I hope to get around to at some point.
