### PR TITLE
Update GitHub CI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rouge
 
-[![Build Status](https://secure.travis-ci.org/rouge-ruby/rouge.svg)](https://travis-ci.org/rouge-ruby/rouge)
+![Build Status](https://github.com/rouge-ruby/rouge/actions/workflows/ruby.yml/badge.svg)
 [![Gem Version](https://badge.fury.io/rb/rouge.svg)](https://rubygems.org/gems/rouge)
 [![YARD Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://rouge-ruby.github.io/docs/)
 


### PR DESCRIPTION
Update CI build badge since we have migrated to GitHub actions (see https://github.com/rouge-ruby/rouge/pull/1728)