### PR TITLE
PowerShell: Fix handling of subexpressions nested inside of double quoted strings

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -214,6 +214,8 @@ module Rouge
 
         rule %r/-{1,2}\w+/, Name::Tag
 
+        rule %r/[12]>/, Operator
+
         rule %r/(\.)?([-\w]+)(\[)/ do |m|
           groups Operator, Name, Punctuation
           push :bracket
@@ -221,7 +223,7 @@ module Rouge
 
         rule %r/([\/\\~[a-z]][-.:\/\\~\w]*)(\n)?/i do |m|
           groups Name, Text::Whitespace
-          push :parameters
+          push :parameters unless m[3].nil?
         end
 
         rule %r/(\.)([-\w]+)(?:(\()|(\n))?/ do |m|


### PR DESCRIPTION
This MR will:

* Add a new "unless" condition to an existing "push :paramters" declaration in a rule in the :root state to fix handling of subexpressions nested in strings. 
* Fix side effect of that change by adding a new rule for detection of "2>" style output redirection.

Intended to address issue #1757. That issue links to a sample of the bug on rouge.jneen.net.

I was stepping through the debugger when invoking `rougify` against a local PowerShell file that contains a subexr nested in a string. I'm debugging using Rouge 3.26.1, Ruby 2.6.8p205.

Below is the relevant snippet that of my PowerShell file that the bug surfaces on:

```powershell
function NewVMSnapshot {
    param(
        [Parameter(Mandatory = $true)]
        [string[]]$VM,
        [string[]]$Name = (Get-Date -Format 'yyyy-MM-dd_HH:mm:ss') + "_$VM",
        [string[]]$Description = "`Snapshot taken via $(Split-Path $PSCommandPath -leaf) by $global:vsphereuser."
    )

    try {
```

Once it reached the ` by ` part of the string in the `[string[]]$Description` line, the debugger ends up hitting this rule that's defined in the :root state:

```ruby
        rule %r/([\/\\~[a-z]][-.:\/\\~\w]*)(\n)?/i do |m|
          groups Name, Text::Whitespace
          push :parameters
        end
```

I'm not sure why it's hitting that, but it results in :parameters being pushed to the stack. And since :parameters is pushed to the stack, once it finally hits that closing double quote, it just treats it as a new double quote and pushes another :dq onto the stack -- which is on top of the old one.

Screenshot of the stack below.

![contents of stack](https://user-images.githubusercontent.com/10196496/139367274-ff97642f-d37e-4310-b7fa-56539424fccf.png)

I'm a complete Ruby novice here therefore also a Rogue novice, so my justification for the changes may be tenuous. Feel free to poke holes in it and suggest more appropriate fixes should they be obvious.
