### PR TITLE
Add Asn.1 interface description language lexer

### DIFF
--- a/docs/Languages.md
+++ b/docs/Languages.md
@@ -12,6 +12,7 @@
 - API Blueprint (`apiblueprint`)
 - AppleScript (`applescript`)
 - ArmAsm (`armasm`)
+- Asn.1 (`asn1`)
 - Augeas (`augeas`)
 - Awk (`awk`)
 - Batchfile (`batchfile`)

--- a/lib/rouge/demos/asn1
+++ b/lib/rouge/demos/asn1
@@ -1,0 +1,12 @@
+Payment-method ::= CHOICE {
+  check       NumericString(SIZE (15)),
+  credit-card Credit-card,
+  cash        NULL
+}
+Credit-card ::= SEQUENCE {
+  type        Card-type,
+  number      NumericString(SIZE (20)),
+  expiry-date NumericString(SIZE (6)) -- MMYYYY
+}
+Card-type ::= ENUMERATED {
+  cb(0), visa(1), eurocard(2), diners(3), american-express(4)}

--- a/lib/rouge/lexers/asn1.rb
+++ b/lib/rouge/lexers/asn1.rb
@@ -30,7 +30,7 @@ module Rouge
       end
 
       def self.multiple_word_keywords_type
-        @multiple_word_type ||= self.keywords_type.filter { |v| v.include? ' ' }
+        @multiple_word_type ||= self.keywords_type.select { |v| v.include? ' ' }
       end
 
       def self.reserved

--- a/lib/rouge/lexers/asn1.rb
+++ b/lib/rouge/lexers/asn1.rb
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Asn1 < RegexLexer
+      title 'Asn.1'
+      desc "Abstract Syntax Notation One"
+      tag 'asn1'
+      filenames '*.asn', '*.asn1'
+      mimetypes 'text/x-ttcn-asn'
+
+      def self.keywords_type
+        @keywords_type ||= Set.new [
+          'BOOLEAN', 'INTEGER', 'ENUMERATED', 'REAL',
+          'BIT STRING', 'OCTET STRING', 'NULL',
+          'SEQUENCE OF', 'SEQUENCE', 'SET OF', 'SET',
+          'CHOICE', 'OBJECT IDENTIFIER',
+          'RELATIVE-OID', 'OID-IRI', 'RELATIVE-OID-IRI', 'EMBEDDED PDV',
+          'EXTERNAL',
+
+          # Restricted character string types (X.680 02/2021 chapter 41)
+          'BMPString', 'GeneralString', 'GraphicString', 'IA5String', 'ISO646String',
+          'NumericString', 'PrintableString', 'TeletexString', 'T61String', 'UniversalString',
+          'UTF8String', 'VideotexString', 'VisibleString',
+
+          # (deprecated) any type (X.208 chapter 27; deprecated in X.680)
+          'ANY DEFINED BY', 'ANY',
+        ]
+      end
+
+      def self.multiple_word_keywords_type
+        @multiple_word_type ||= self.keywords_type.filter { |v| v.include? ' ' }
+      end
+
+      def self.reserved
+        # Reserved words (X.680 02/2021 clause 12.38)
+        @reserved ||= Set.new %w(
+          ABSENT ENCODED INTERSECTION SEQUENCE
+          ABSTRACT-SYNTAX ENCODING-CONTROL ISO646String SET
+          ALL END MAX SETTINGS
+          APPLICATION ENUMERATED MIN SIZE
+          AUTOMATIC EXCEPT MINUS-INFINITY STRING
+          BEGIN EXPLICIT NOT-A-NUMBER SYNTAX
+          BIT EXPORTS NULL T61String
+          BMPString EXTENSIBILITY NumericString TAGS
+          BOOLEAN EXTERNAL OBJECT TeletexString
+          BY FALSE ObjectDescriptor TIME
+          CHARACTER FROM OCTET TIME-OF-DAY
+          CHOICE GeneralizedTime OF TRUE
+          CLASS GeneralString OID-IRI TYPE-IDENTIFIER
+          COMPONENT GraphicString OPTIONAL UNION
+          COMPONENTS IA5String PATTERN UNIQUE
+          CONSTRAINED IDENTIFIER PDV UNIVERSAL
+          CONTAINING IMPLICIT PLUS-INFINITY UniversalString
+          DATE IMPLIED PRESENT UTCTime
+          DATE-TIME IMPORTS PrintableString UTF8String
+          DEFAULT INCLUDES PRIVATE VideotexString
+          DEFINITIONS INSTANCE REAL VisibleString
+          DURATION INSTRUCTIONS RELATIVE-OID WITH
+          EMBEDDED INTEGER RELATIVE-OID-IRI
+        )
+      end
+
+      state :root do
+        mixin :whitespace
+        mixin :values
+        mixin :statements
+      end
+
+      state :statements do
+        rule %r/\b#{Rouge::Lexers::Asn1.multiple_word_keywords_type.join('|')}\b/, Keyword::Type
+
+        rule %r/(&?[a-zA-Z][-a-zA-Z0-9]*)/ do |m|
+          if self.class.keywords_type.include? m[0]
+            token Keyword::Type
+          elsif self.class.reserved.include? m[0]
+            token Keyword
+          else
+            token Name
+          end
+        end
+
+        rule %r/::=|\.\.\.|\.\.|\[\[|\]\]/, Operator
+
+        rule %r/./ do |m|
+          # Single character lexical items (X.680 02/2021 clause 12.37)
+          if "{}<>,./()[]-:=\"\';@|!^".include? m[0]
+            token Punctuation
+          else
+            token Error
+          end
+        end
+      end
+
+      state :values do
+        rule %r/-?([1-9][0-9]*|0)(\.[0-9]+([eE]-?[0-9]+)?|[eE]-?[0-9]+)/, Literal::Number::Float
+        rule %r/-?[1-9][0-9]*|0/, Literal::Number::Integer
+
+        # Binary string (X.680 02/2021 clause 12.10)
+        rule %r/\'[01 ]+\'B/, Literal::Number::Bin
+        # Hexadecimal string (X.680 02/2021 clause 12.12)
+        rule %r/\'[0-9A-Z ]+\'H/i, Literal::Number::Hex
+
+        rule %r/\"/, Literal::String, :string
+      end
+
+      state :string do
+        rule %r/""/, Literal::String::Escape
+        rule %r/"/, Literal::String, :pop!
+        rule %r/[^"]+/, Literal::String
+      end
+
+      state :whitespace do
+        rule %r/\s/, Text::Whitespace
+        rule %r/--.*$/, Comment::Single
+        rule %r(/\*), Comment::Multiline, :nested_comments
+      end
+
+      state :nested_comments do
+        rule %r(\*/), Comment::Multiline, :pop!
+        rule %r(/\*), Comment::Multiline, :nested_comments
+        rule %r([^*/]+|[*/]), Comment::Multiline
+      end
+    end
+  end
+end
+

--- a/spec/lexers/asn1_spec.rb
+++ b/spec/lexers/asn1_spec.rb
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Asn1 do
+  let(:subject) { Rouge::Lexers::Asn1.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.asn'
+      assert_guess :filename => 'foo.asn1'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-ttcn-asn'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'can lex numbers' do
+      assert_tokens_equal '0', ['Literal.Number.Integer', '0']
+      assert_tokens_equal '10', ['Literal.Number.Integer', '10']
+      assert_tokens_equal '-20', ['Literal.Number.Integer', '-20']
+      assert_tokens_equal '1.5', ['Literal.Number.Float', '1.5']
+      assert_tokens_equal '-0.5', ['Literal.Number.Float', '-0.5']
+      assert_tokens_equal '1E-6', ['Literal.Number.Float', '1E-6']
+
+      # Binary string (X.680 02/2021 clause 12.10)
+      assert_tokens_equal "'01101100'B", ['Literal.Number.Bin', "'01101100'B"]
+      # Hexadecimal string (X.680 02/2021 clause 12.12)
+      assert_tokens_equal "'AB0196'H", ['Literal.Number.Hex', "'AB0196'H"]
+    end
+
+    it 'can lex string' do
+      assert_tokens_equal '""', ['Literal.String', '""']
+      assert_tokens_equal '"😀"', ['Literal.String', '"😀"'] # non ascii text
+      assert_tokens_equal %q("Multi\nLine"), ['Literal.String', %q("Multi\nLine")]
+      assert_tokens_equal %q("Escaped""Quotation"),
+        ['Literal.String', %q("Escaped)],
+        ['Literal.String.Escape', %q("")],
+        ['Literal.String', %q(Quotation")]
+    end
+
+    it 'can lex comments' do
+      assert_tokens_equal '-- single line', ['Comment.Single', '-- single line']
+      assert_tokens_equal " /*\n*/ /**/ ",
+        ['Text.Whitespace', ' '],
+        ['Comment.Multiline', "/*\n*/"],
+        ['Text.Whitespace', ' '],
+        ['Comment.Multiline', '/**/'],
+        ['Text.Whitespace', ' ']
+
+      # Nested multiple-line comments (X.680 02/2021 clause 12.6.4)
+      assert_tokens_equal "/* /* nested */ \n-- */",
+        ['Comment.Multiline', "/* /* nested */ \n-- */"]
+    end
+
+  end
+end

--- a/spec/visual/samples/asn1
+++ b/spec/visual/samples/asn1
@@ -1,0 +1,139 @@
+RFC1157-SNMP DEFINITIONS ::= BEGIN
+
+ IMPORTS
+     ObjectName, ObjectSyntax, NetworkAddress, IpAddress, TimeTicks
+         FROM RFC1155-SMI;
+
+
+     -- top-level message
+
+     Message ::=
+             SEQUENCE {
+                 version          -- version-1 for this RFC
+                     INTEGER {
+                         version-1(0)
+                     },
+
+                 community        -- community name
+                     OCTET STRING,
+
+                 data             -- e.g., PDUs if trivial
+                     ANY          -- authentication is being used
+             }
+
+
+     -- protocol data units
+
+     PDUs ::=
+             CHOICE {
+                         get-request
+                             GetRequest-PDU,
+
+                         get-next-request
+                             GetNextRequest-PDU,
+
+                         get-response
+                             GetResponse-PDU,
+
+                         set-request
+                             SetRequest-PDU,
+
+                         trap
+                             Trap-PDU
+                     }
+
+
+     -- PDUs
+
+     GetRequest-PDU ::=
+         [0]
+             IMPLICIT PDU
+
+     GetNextRequest-PDU ::=
+         [1]
+             IMPLICIT PDU
+
+     GetResponse-PDU ::=
+         [2]
+             IMPLICIT PDU
+
+     SetRequest-PDU ::=
+         [3]
+             IMPLICIT PDU
+
+     PDU ::=
+             SEQUENCE {
+                request-id
+                     INTEGER,
+
+                 error-status      -- sometimes ignored
+                     INTEGER {
+                         noError(0),
+                         tooBig(1),
+                         noSuchName(2),
+                         badValue(3),
+                         readOnly(4),
+                         genErr(5)
+                     },
+
+                 error-index       -- sometimes ignored
+                    INTEGER,
+
+                 variable-bindings -- values are sometimes ignored
+                     VarBindList
+             }
+
+     Trap-PDU ::=
+         [4]
+            IMPLICIT SEQUENCE {
+                 enterprise        -- type of object generating
+                                   -- trap, see sysObjectID in [5]
+
+
+                     OBJECT IDENTIFIER,
+
+                 agent-addr        -- address of object generating
+                     NetworkAddress, -- trap
+
+                 generic-trap      -- generic trap type
+                     INTEGER {
+                         coldStart(0),
+                         warmStart(1),
+                         linkDown(2),
+                         linkUp(3),
+                         authenticationFailure(4),
+                         egpNeighborLoss(5),
+                         enterpriseSpecific(6)
+                     },
+
+                 specific-trap  -- specific code, present even
+                     INTEGER,   -- if generic-trap is not
+                                -- enterpriseSpecific
+
+                 time-stamp     -- time elapsed between the last
+                     TimeTicks, -- (re)initialization of the
+                                   network
+                                -- entity and the generation of the
+                                   trap
+
+                  variable-bindings -- "interesting" information
+                     VarBindList
+             }
+
+
+     -- variable bindings
+
+     VarBind ::=
+             SEQUENCE {
+                 name
+                     ObjectName,
+
+                 value
+                     ObjectSyntax
+             }
+
+    VarBindList ::=
+             SEQUENCE OF
+                VarBind
+
+    END


### PR DESCRIPTION
This PR adds a lexer for Abstract Syntax Notation One (ASN.1).

![screenshot-asn](https://user-images.githubusercontent.com/379009/141643129-ac1649ff-d31a-4a71-9691-f211d731a1b3.png)

ASN.1 is an interface description language defined by [ITU-T X.680](https://www.itu.int/rec/T-REC-X.680/). To support legacy version of Asn.1, this lexer contains some legacy keywords defined by obsoleted ITU-T X.208. 