### PR TITLE
Coq unicode improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,4 +38,6 @@ group :development do
     gem 'sinatra'
   end
   gem 'shotgun'
+  # ruby 3+
+  gem 'webrick'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,4 @@ group :development do
     gem 'sinatra'
   end
   gem 'shotgun'
-  # ruby 3+
-  gem 'webrick'
 end

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -135,6 +135,8 @@ module Rouge
           token Keyword::Pseudo, m[1]
           token Punctuation, ':'.dup
         end
+        # numbered goals 1: {} 1,2: {}
+        rule %r/\d+/, Num::Integer, :numeric_labels
         # [named_goal]: { ... }
         rule %r/\[(\s*)(#{id})(\s*)(\])(\s*)(:)/ do |m|
           token Punctuation, '['
@@ -154,9 +156,22 @@ module Rouge
         end
       end
 
+      state :numeric_labels do
+        mixin :whitespace
+        rule %r(,(\s*)(\d+)) do |m|
+          token Punctuation, ','
+          token Text::Whitespace, m[1]
+          token Num::Integer, m[2]
+        end
+        rule %r(:), Punctuation, :pop!
+      end
+
+      state :whitespace do
+        rule %r/\s+/m, Text::Whitespace
+      end
       state :comment_whitespace do
         rule %r/[(][*](?![)])/, Comment, :comment
-        rule %r/\s+/m, Text::Whitespace
+        mixin :whitespace
       end
 
       state :module_setopts do

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -25,7 +25,7 @@ module Rouge
           Variables Class Instance Global Local Include
           Printing Notation Infix Arguments Hint Rewrite Immediate
           Qed Defined Opaque Transparent Existing
-          Compute Eval Print SearchAbout Search About Check
+          Compute Eval Print SearchAbout Search About Check Admitted
         )
       end
 
@@ -102,30 +102,29 @@ module Rouge
           end
           token self.class.end_sentence , '.'
         end
+
+        # up here to beat the id rule for lambda
+        rule %r(:=|=>|;|:>|:|::|_), Punctuation
+        rule %r(->|/\\|\\/|;|:>|[⇒→↔⇔≔≡∀∃∧∨¬⊤⊥⊢⊨∈λ]), Operator
+
         rule id do |m|
           @name = m[0]
           @continue = false
           push :continue_id
         end
-        rule %r(/\\), Operator
-        rule %r/\\\//, Operator
 
         rule %r/-?\d[\d_]*(.[\d_]*)?(e[+-]?\d[\d_]*)/i, Num::Float
-        rule %r/\d[\d_]*/, Num::Integer
+        rule %r/-?\d[\d_]*/, Num::Integer
 
         rule %r/'(?:(\\[\\"'ntbr ])|(\\[0-9]{3})|(\\x\h{2}))'/, Str::Char
         rule %r/'/, Keyword
         rule %r/"/, Str::Double, :string
         rule %r/[~?]#{id}/, Name::Variable
 
-        rule %r([;,()@^|~#.]+), Punctuation
-        # match these *on their own* as punctuation (note negative lookahead)
-        # may be followed by a couple of other punctuation chars, though.
-        rule %r([\[\]{}\-*+?@^|~#]+[.};\]]?(?!\p{S}|\p{P})), Punctuation
-        # these are so common in Coq we won't point them out as operators
-        rule %r(:=|=>|->|/\\|\\/|_|;|:>|:|[⇒→↔⇔≔≡∀∃∧∨¬⊤⊥⊢⊨∈]), Punctuation
+        rule %r(`{|[{}\[\]()?|;,.]), Punctuation
+        rule %r([!@^|~#.%/]+), Operator
         # any other combo of S (symbol), P (punctuation) and some extras just to be sure
-        rule %r((?:\p{S}|\p{P}|[./\:\<=>\-+/*])+), Operator
+        rule %r((?:\p{S}|\p{Pc}|[./\:\<=>\-+*])+), Operator
 
         rule %r/./, Error
       end

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -76,8 +76,12 @@ module Rouge
         end
       end
 
-      id_trail = /(?:\p{L}|\p{N}|_|')/
-      id = /(?:\p{Ll}#{id_trail}*)|(?:(?:_|\p{Ll})#{id_trail}+)/i
+      # https://github.com/coq/coq/blob/110921a449fcb830ec2a1cd07e3acc32319feae6/clib/unicode.ml#L67
+      # https://coq.inria.fr/refman/language/core/basic.html#grammar-token-ident
+      id_first = /\p{L}/
+      id_first_underscore = /(?:\p{L}|_)/
+      id_subsequent = /(?:\p{L}|\p{N}|_|')/ # a few missing? some mathematical ' primes and subscripts
+      id = /(?:#{id_first}#{id_subsequent}*)|(?:#{id_first_underscore}#{id_subsequent}+)/i
       dot_id = /\.(#{id})/i
       dot_space = /\.(\s+)/
       module_type = /Module(\s+)Type(\s+)/

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -131,21 +131,14 @@ module Rouge
         rule %r/(?:\-+|\++|\*+)/, Punctuation
         rule %r/[{}]/, Punctuation
         # toplevel_selector
-        rule %r/(!|all|par):/ do |m|
-          token Keyword::Pseudo, m[1]
-          token Punctuation, ':'.dup
+        rule %r/(!|all|par)(:)/ do
+          groups Keyword::Pseudo, Punctuation
         end
         # numbered goals 1: {} 1,2: {}
         rule %r/\d+/, Num::Integer, :numeric_labels
         # [named_goal]: { ... }
-        rule %r/\[(\s*)(#{id})(\s*)(\])(\s*)(:)/ do |m|
-          token Punctuation, '['
-          token Text::Whitespace, m[1]
-          token Name::Constant, m[2]
-          token Text::Whitespace, m[3]
-          token Punctuation, ']'.dup # without dup, you get an error when you attempt to appending to it with ':'
-          token Text::Whitespace, m[5]
-          token Punctuation, ':'.dup
+        rule %r/(\[)(\s*)(#{id})(\s*)(\])(\s*)(:)/ do
+          groups Punctuation, Text::Whitespace, Name::Constant, Text::Whitespace, Punctuation, Text::Whitespace, Punctuation
         end
         # After parsing the id, end up in sentence_postid
         rule id do |m|
@@ -158,10 +151,8 @@ module Rouge
 
       state :numeric_labels do
         mixin :whitespace
-        rule %r(,(\s*)(\d+)) do |m|
-          token Punctuation, ','
-          token Text::Whitespace, m[1]
-          token Num::Integer, m[2]
+        rule %r/(,)(\s*)(\d+)/ do |m|
+          groups Punctuation, Text::Whitespace, Num::Integer
         end
         rule %r(:), Punctuation, :pop!
       end

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -76,8 +76,9 @@ module Rouge
         end
       end
 
-      id = /(?:[a-z][\w']*)|(?:[_a-z][\w']+)/i
-      dot_id = /\.((?:[a-z][\w']*)|(?:[_a-z][\w']+))/i
+      id_trail = /(?:\p{L}|\p{N}|_|')/
+      id = /(?:\p{Ll}#{id_trail}*)|(?:(?:_|\p{Ll})#{id_trail}+)/i
+      dot_id = /\.(#{id})/i
       dot_space = /\.(\s+)/
       module_type = /Module(\s+)Type(\s+)/
       set_options = /(Set|Unset)(\s+)(Universe|Printing|Implicit|Strict)(\s+)(Polymorphism|All|Notations|Arguments|Universes|Implicit)(\s*)\./m
@@ -126,8 +127,7 @@ module Rouge
         # any other combo of S (symbol), P (punctuation) and some extras just to be sure
         rule %r((?:\p{S}|\p{P}|[./\:\<=>\-+/*])+), Operator
 
-        # let people use anything else as a name
-        rule %r/./, Name::Constant
+        rule %r/./, Error
       end
 
       state :comment do

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -25,3 +25,13 @@ Proof.
   apply ev_SS.
   apply H.
 Qed.
+
+Lemma ghost_var_update γ b' b c :
+  own γ (●E b) -∗ own γ (◯E c) ==∗ own γ (●E b') ∗ own γ (◯E b').
+Proof.
+  iIntros "Hγ● Hγ◯".
+  iMod (own_update_2 _ _ _ (●E b' ⋅ ◯E b') with "Hγ● Hγ◯") as "[$$]".
+  { by apply excl_auth_update. }
+  done.
+  something (a ={n}= b).
+Qed.

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -100,9 +100,10 @@ Proof.
   refine ?[named]. refine ?[named2].
   [named]: done.
   [named2]: { done. }
+  (* Bullets are distinct from operators, and are treated as Punctuation *)
   - done.
     + done.
       -- done.
-    + apply (f -888).
+    + apply (f -888 + 5).
   all: nice.
 Qed.

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -17,6 +17,7 @@ Notation "A /\ B" := (and A B) : type_scope.
 Theorem progress : ∀t T,
   empty ⊢ t ∈ T →
   value t ∨ ∃t', t --> t'.
+Proof. Admitted.
 
 Theorem ev_plus4 : ∀n, even n → even (4 + n).
 Proof.
@@ -26,12 +27,82 @@ Proof.
   apply H.
 Qed.
 
+(*
+   The iris examples here are used under this license:
+
+   > All files in this development, excluding those in docs/ and tex/, are
+   distributed under the terms of the 3-clause BSD license
+   (https://opensource.org/licenses/BSD-3-Clause), included below.
+   > Copyright: Iris developers and contributors
+*)
+
+(* Unicode next to braces, mixed ascii/unicode operators. *)
 Lemma ghost_var_update γ b' b c :
   own γ (●E b) -∗ own γ (◯E c) ==∗ own γ (●E b') ∗ own γ (◯E b').
 Proof.
-  iIntros "Hγ● Hγ◯".
-  iMod (own_update_2 _ _ _ (●E b' ⋅ ◯E b') with "Hγ● Hγ◯") as "[$$]".
-  { by apply excl_auth_update. }
-  done.
   something (a ={n}= b).
+  - by apply case1.
+  - apply case2. eauto.
+Qed.
+
+
+(* #[], {Σ}, `{!xxx}, (?)
+   https://gitlab.mpi-sws.org/iris/iris/-/blob/f1e2242daa0e448135a5074ce99b41e6058ea1c3/iris_heap_lang/adequacy.v *)
+Definition heapΣ : gFunctors :=
+  #[invΣ; gen_heapΣ loc (option val); inv_heapΣ loc (option val); proph_mapΣ proph_id (val * val)].
+Global Instance subG_heapGpreS {Σ} : subG heapΣ Σ → heapGpreS Σ.
+Proof. solve_inG. Qed.
+
+(* (?), `{!class}, greek lettering *)
+Definition heap_adequacy Σ `{!heapGpreS Σ} s e σ φ :
+  (∀ `{!heapGS Σ}, ⊢ inv_heap_inv -∗ WP e @ s; ⊤ {{ v, ⌜φ v⌝ }}) →
+  adequate s e σ (λ v _, φ v).
+Proof.
+  intros Hwp; eapply (wp_adequacy _ _); iIntros (? κs) "".
+  iMod (gen_heap_init σ.(heap)) as (?) "[Hh _]".
+  iMod (inv_heap_init loc (option val)) as (?) ">Hi".
+  iMod (proph_map_init κs σ.(used_proph_id)) as (?) "Hp".
+  (* lambda should highlight as an operator *)
+  iModIntro. iExists
+    (λ σ κs, (gen_heap_interp σ.(heap) ∗ proph_map_interp κs σ.(used_proph_id))%I),
+    (λ _, True%I).
+  iFrame. iApply (Hwp (HeapGS _ _ _ _ _)). done.
+Qed.
+
+(* thorny ops + braces + lettering
+   https://gitlab.mpi-sws.org/iris/iris/-/blob/f1e2242daa0e448135a5074ce99b41e6058ea1c3/iris_heap_lang/primitive_laws.value
+   BSD licensed *)
+Lemma wp_rec_löb s E f x e Φ Ψ :
+  □ ( □ (∀ v, Ψ v -∗ WP (rec: f x := e)%V v @ s; E {{ Φ }}) -∗
+     ∀ v, Ψ v -∗ WP (subst' x v (subst' f (rec: f x := e) e)) @ s; E {{ Φ }}) -∗
+  ∀ v, Ψ v -∗ WP (rec: f x := e)%V v @ s; E {{ Φ }}.
+Proof.
+  iIntros "#Hrec". iLöb as "IH". iIntros (v) "HΨ".
+  (* dotted gives a path *)
+  iApply lifting.wp_pure_step_later; first done.
+  iNext. iApply ("Hrec" with "[] HΨ"). iIntros "!>" (w) "HΨ".
+  iApply ("IH" with "HΨ").
+Qed.
+
+(* unicode symbols distinct from braces and idents *)
+Lemma mapsto_frac_ne l1 l2 dq1 dq2 v1 v2 :
+  ¬ ✓(dq1 ⋅ dq2) → l1 ↦{dq1} v1 -∗ l2 ↦{dq2} v2 -∗ ⌜l1 ≠ l2⌝.
+Proof. apply mapsto_frac_ne. Qed.
+
+Lemma inv_mapsto_own_acc E l v I:
+  ↑inv_heapN ⊆ E →
+  inv_heap_inv -∗ l ↦_I v ={E, E ∖ ↑inv_heapN}=∗
+    (⌜I v⌝ ∗ l ↦ v ∗ (∀ w, ⌜I w ⌝ -∗ l ↦ w ={E ∖ ↑inv_heapN, E}=∗ l ↦_I w)).
+Proof. (*snip*) Qed.
+
+Lemma mapsto_persist l dq v : l ↦{dq} v ==∗ l ↦□ v.
+Proof.
+  refine ?[named]. refine ?[named2].
+  [named]: done.
+  [named2]: { done. }
+  - done.
+    + done.
+      -- done.
+    + apply (f -888).
+  all: nice.
 Qed.

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -106,4 +106,7 @@ Proof.
       -- done.
     + apply (f -888 + 5).
   all: nice.
+  1: { done. }
+  1,2: { done. }
+  1,2,3: { done. }
 Qed.


### PR DESCRIPTION
Fixes #1312 for coq.

Unfortunately it does not fix this for every language, but as a general rule for fixing other languages that should support unicode identifiers, replace `[a-z]`/`\w` or similar with Ruby's regex unicode classes e.g. `\p{L}` for any unicode letter. The Coq version here makes use of `\p{S}|\p{Pc}` to cover all symbols and non-parenthetical punctuation, makes them all operators (with some nuances/overrides).