### PR TITLE
Add HCL file extensions

### DIFF
--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -5,6 +5,7 @@ module Rouge
   module Lexers
     class Hcl < RegexLexer
       tag 'hcl'
+      filenames '*.hcl', '*.nomad'
 
       title 'Hashicorp Configuration Language'
       desc 'Hashicorp Configuration Language, used by Terraform and other Hashicorp tools'


### PR DESCRIPTION
Add HCL file extensions                                                                                                    
                                                                                                                           
HCL is used in [Terraform which uses the `.tf` file extension](https://www.nomadproject.io/docs/commands/job/run#examples) but it is already handled by the [terraform lexer](https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/lexers/terraform.rb). But HCL is also used by other Hashicorp tools like:
 * [Packer which uses the `.pkr.hcl` extension](https://www.nomadproject.io/docs/commands/job/run#examples)                
 * [Vault which uses the `.hcl` extension](https://www.vaultproject.io/docs/commands/server#command-options)               
 * [Consul which uses the `.hcl` extension](https://www.consul.io/docs/agent/options#configuration)                        
 * [Waypoint which uses the `waypoint.hcl` file](https://www.waypointproject.io/docs/waypoint-hcl#project-configuration-waypoint-hcl)
 * [Nomad which uses the `.nomad` extension](https://www.nomadproject.io/docs/commands/job/run#examples) but also [Nomad Packs which uses the `.hcl` extension](https://learn.hashicorp.com/tutorials/nomad/nomad-pack-writing-packs#add-a-new-pack)
                                                                                                                           
(in fact the [list of HCL Schemas](https://learn.hashicorp.com/tutorials/nomad/nomad-pack-writing-packs#add-a-new-pack) seems to be the most comprehensive list of HCL implementations)