### PR TITLE
lexer: c: Highlight #includes as Comment::PreprocFile

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -170,12 +170,22 @@ module Rouge
       end
 
       state :macro do
-        # NB: pop! goes back to :bol
-        rule %r/\n/, Comment::Preproc, :pop!
+        mixin :include
         rule %r([^/\n\\]+), Comment::Preproc
         rule %r/\\./m, Comment::Preproc
         mixin :inline_whitespace
         rule %r(/), Comment::Preproc
+        # NB: pop! goes back to :bol
+        rule %r/\n/, Comment::Preproc, :pop!
+      end
+
+      state :include do
+        rule %r/(include)(\s*)(<[^>]+>)([^\n]*)/ do
+          groups Comment::Preproc, Text, Comment::PreprocFile, Comment::Single
+        end
+        rule %r/(include)(\s*)("[^"]+")([^\n]*)/ do
+          groups Comment::Preproc, Text, Comment::PreprocFile, Comment::Single
+        end
       end
 
       state :if_0 do

--- a/spec/visual/samples/c
+++ b/spec/visual/samples/c
@@ -51,6 +51,13 @@ void foo() {
     }
   }
 
+#include <string.h> /* this is a comment */
+#include <string.h> // this is a comment
+#include "string.h" /* this is a comment */
+#include "string.h" // this is a comment
+#include<string>/* this is a comment */
+#include<string>// this is a comment
+
 /* Execute compiled code */
 
 /* XXX TO DO:


### PR DESCRIPTION
When changing https://chrisdown.name over from Pygments to Rouge, one
quite noticeable change was that `{% highlight c %}` blocks lost the
delineation between #include statements and the actual include, with
them all now just being stylised as a comment.

This patch brings back Comment::PreprocFile support for C-like
languages, as it was with Pygments.

Tested locally by rebuilding chrisdown.name with a gem from this commit,
and seeing that the Comment::PreprocFile highlighting reappeared.