### PR TITLE
Avoid backtracing in ceylon interpolation regex

### DIFF
--- a/lib/rouge/lexers/ceylon.rb
+++ b/lib/rouge/lexers/ceylon.rb
@@ -51,8 +51,8 @@ module Rouge
 
         rule %r("(\\\\|\\"|[^"])*"), Literal::String
         rule %r('\\.'|'[^\\]'|'\\\{#[0-9a-fA-F]{4}\}'), Literal::String::Char
-        rule %r(".*``.*``.*"', String::Interpol
-        rule %r(\.)([a-z_]\w*)) do
+        rule %r("[^`]*``[^`]*``[^`]*"), Literal::String::Interpol
+        rule %r((\.)([a-z_]\w*)) do
           groups Operator, Name::Attribute
         end
         rule %r([a-zA-Z_]\w*:), Name::Label

--- a/spec/visual/samples/ceylon
+++ b/spec/visual/samples/ceylon
@@ -32,3 +32,6 @@ module com.acme.test "1.0.0" {
 }
 
 package com.example;
+
+print("Hello, ``person.firstName`` ``person.lastName``, the time is ``Time()``.");
+print("1 + 1 = ``1 + 1``");


### PR DESCRIPTION
Fix backtracing in ceylon interpolation regex.

Addresses the third remaining Regex Denial Of Service vulnerability reported in https://hackerone.com/reports/1283484. The other two mentioned in that report have already been addressed as part of https://github.com/rouge-ruby/rouge/pull/1690.