### PR TITLE
Support quoted keys in TOML

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -11,14 +11,15 @@ module Rouge
       filenames '*.toml', 'Pipfile'
       mimetypes 'text/x-toml'
 
-      identifier = /\S+/
+      # bare keys and quoted keys
+      identifier = %r/(?:\S+|"[^"]+"|'[^']+')/
 
       state :basic do
         rule %r/\s+/, Text
         rule %r/#.*?$/, Comment
         rule %r/(true|false)/, Keyword::Constant
 
-        rule %r/(\S+)(\s*)(=)(\s*)(\{)/ do |m|
+        rule %r/(#{identifier})(\s*)(=)(\s*)(\{)/ do
           groups Name::Namespace, Text, Operator, Text, Punctuation
           push :inline
         end
@@ -48,6 +49,11 @@ module Rouge
 
       state :content do
         mixin :basic
+
+        rule %r/(#{identifier})(\s*)(=)/ do
+          groups Name::Property, Text, Punctuation
+        end
+
         rule %r/"""/, Str, :mdq
         rule %r/"/, Str, :dq
         rule %r/'''/, Str, :msq
@@ -94,10 +100,6 @@ module Rouge
 
       state :inline do
         mixin :content
-
-        rule %r/(#{identifier})(\s*)(=)/ do
-          groups Name::Property, Text, Punctuation
-        end
 
         rule %r/\}/, Punctuation, :pop!
       end

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -102,5 +102,19 @@ test_string = "You'll hate me after this - #"          # " Annoying, isn't it?
 
 東京都 = 123
 
+# Inline table
 name = { first = "Tom", last = "Preston-Werner" }
 point = { x = 1, y = 2 }
+'student names' = { "first name" = "Tom", "last name" = "Preston-Werner" }
+
+# Quoted keys
+"127.0.0.1" = "value"
+"character encoding" = "value"
+"ʎǝʞ" = "value"
+'key2' = "value"
+'quoted "value"' = "value"
+
+# Dotted keys
+physical.color = "orange"
+physical.shape = "round"
+site."google.com" = true


### PR DESCRIPTION
Add support for [quoted keys](https://toml.io/en/v1.0.0#keyvalue-pair) in TOML.

Extracted from the [doc](https://toml.io/en/v1.0.0#keyvalue-pair):

> Quoted keys follow the exact same rules as either basic strings or literal strings and allow you to use a much broader set of key names. Best practice is to use bare keys except when absolutely necessary.

I have also added some example and verify via the visual test site

<img width="637" alt="Screen Shot 2022-01-05 at 5 16 53 pm" src="https://user-images.githubusercontent.com/756722/148169610-19984f25-07b7-411d-95fc-d69caacea3c4.png">

Closes https://github.com/rouge-ruby/rouge/issues/1632

