### PR TITLE
Update list of maintainers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ Rouge uses [Semantic Versioning 2.0.0][sv2].
 
 Rouge is largely the result of the hard work of unpaid volunteers. It was
 originally developed by Jeanine Adkisson (@jneen) and is currently maintained by
-Jeanine Adkisson, Drew Blessing (@dblessing) and Goro Fuji (@gfx).
+Jeanine Adkisson, Drew Blessing (@dblessing), Goro Fuji (@gfx) and Tan Le
+(@tancnle).
 
 ## License
 


### PR DESCRIPTION
This commit adds @tancnle as a maintainer of Rouge. He joined as a maintainer from 10 December 2021.