### PR TITLE
Add guessing specs for HCL lexer

### DIFF
--- a/spec/lexers/hcl_spec.rb
+++ b/spec/lexers/hcl_spec.rb
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Hcl do
+  let(:subject) { Rouge::Lexers::Hcl.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.hcl'
+      assert_guess :filename => 'foo.nomad'
+    end
+  end
+end


### PR DESCRIPTION
Add guessing specs for HCL lexer as part of https://github.com/rouge-ruby/rouge/pull/1769.