### PR TITLE
Update the URL of AppleScript documentation

### DIFF
--- a/lib/rouge/lexers/apple_script.rb
+++ b/lib/rouge/lexers/apple_script.rb
@@ -5,7 +5,7 @@ module Rouge
   module Lexers
     class AppleScript < RegexLexer
       title "AppleScript"
-      desc "The AppleScript scripting language by Apple Inc. (https://developer.apple.com/library/mac/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html)"
+      desc "The AppleScript scripting language by Apple Inc. (https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/introduction/ASLR_intro.html)"
 
       tag 'applescript'
       aliases 'applescript'

--- a/lib/rouge/lexers/apple_script.rb
+++ b/lib/rouge/lexers/apple_script.rb
@@ -5,7 +5,7 @@ module Rouge
   module Lexers
     class AppleScript < RegexLexer
       title "AppleScript"
-      desc "The AppleScript scripting language by Apple Inc. (http://developer.apple.com/applescript/)"
+      desc "The AppleScript scripting language by Apple Inc. (https://developer.apple.com/library/mac/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html)"
 
       tag 'applescript'
       aliases 'applescript'


### PR DESCRIPTION
The URL http://developer.apple.com/applescript/ written in the description of AppleScript lexer no longer exists.

According to http://web.archive.org/web/20180109023249/developer.apple.com/applescript/, that URL seems to have been moved to https://developer.apple.com/library/mac/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html. Please see the screenshot below.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/114863/152455682-a9103ad9-176e-412c-bf01-0148c970a1fc.png">
