### PR TITLE
Python: Support conversion specifiers in format strings

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -218,9 +218,11 @@ module Rouge
       end
 
       state :generic_interpol do
-        rule %r/[^{}]+/ do |m|
+        rule %r/[^{}!:]+/ do |m|
           recurse m[0]
         end
+        rule %r/![asr]/, Str::Interpol
+        rule %r/:/, Str::Interpol
         rule %r/{/, Str::Interpol, :generic_interpol
         rule %r/}/, Str::Interpol, :pop!
       end

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -150,6 +150,7 @@ x @= y
 f'{hello} world {int(x) + 1}'
 f'{{ {4*10} }}'
 f'result: {value:{width}.{precision}}'
+f'{value!r}
 
 # Unicode identifiers
 α = 10


### PR DESCRIPTION
Fixes #1800. Format string syntax can be found here: https://docs.python.org/3/library/string.html#format-string-syntax

Technically only `[asr]` is allowed after `!`. If wanted, I could make the entire `![asr]` punctuation (or something else entirely), but parsing the specifier as a generic Python expression (so in practice, an identifier) seems fine to me.