### PR TITLE
Highlight shortened lists for syzlang DSL

### DIFF
--- a/lib/rouge/lexers/syzlang.rb
+++ b/lib/rouge/lexers/syzlang.rb
@@ -148,6 +148,7 @@ module Rouge
 
       state :flags_list do
         rule inline_spaces, Text
+        rule %r/\./, Punctuation
         mixin :mixin_name
         mixin :mixin_number
         mixin :mixin_string
@@ -158,6 +159,7 @@ module Rouge
       state :syscall_args do
         rule spaces, Text
         rule comment, Comment
+        rule %r/\./, Punctuation
         rule id do
           token Name
           push :arg_type

--- a/spec/lexers/syzlang_spec.rb
+++ b/spec/lexers/syzlang_spec.rb
@@ -301,6 +301,31 @@ describe Rouge::Lexers::Syzlang do
         ['Keyword.Type', 'int16']
     end
 
+    # The tests below check that the lexer can process inputs with lists and
+    # syscall arguments replaced with "...". This is useful for highlighting
+    # syzlang snippets that are shortened for readability.
+
+    it 'recognizes shortened flags lists' do
+      assert_tokens_equal "flags = FLAG1, FLAG2, ...",
+        ['Name', 'flags'],
+        ['Text', ' '],
+        ['Punctuation', '='],
+        ['Text', ' '],
+        ['Name', 'FLAG1'],
+        ['Punctuation', ','],
+        ['Text', ' '],
+        ['Name', 'FLAG2'],
+        ['Punctuation', ','],
+        ['Text', ' '],
+        ['Punctuation', '...']
+    end
+
+    it 'recognizes shortened syscalls' do
+      assert_tokens_equal 'foo(...)',
+        ['Name.Function', 'foo'],
+        ['Punctuation', '(...)']
+    end
+
     # The tests below check that the lexer can process inputs with relaxed
     # whitespace usage and after-line comments. This is useful for highlighting
     # syzlang snippets that are split into multiple lines for readability and


### PR DESCRIPTION
Update the lexer for syzlang DSL to allow processing inputs with lists and syscall arguments replaced with `...`. This is useful for highlighting snippets that are shortened for readability.

Also add tests for the new behavior.