### PR TITLE
Fix notation of named stages in multi-stage docker builds

### DIFF
--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -20,6 +20,10 @@ module Rouge
       state :root do
         rule %r/\s+/, Text
 
+        rule %r/^(FROM)(.*)(AS)(.*)/io do
+          groups Keyword, Str, Keyword, Str
+        end
+
         rule %r/^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do
           groups Keyword, Text::Whitespace, Keyword, Str
         end

--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -20,8 +20,8 @@ module Rouge
       state :root do
         rule %r/\s+/, Text
 
-        rule %r/^(FROM)(.*)(AS)(.*)/io do
-          groups Keyword, Str, Keyword, Str
+        rule %r/^(FROM)(\s+)(.*)(\s+)(AS)(\s+)(.*)/io do
+          groups Keyword, Text::Whitespace, Str, Text::Whitespace, Keyword, Text::Whitespace, Str
         end
 
         rule %r/^(ONBUILD)(\s+)(#{KEYWORDS})(.*)/io do

--- a/spec/visual/samples/docker
+++ b/spec/visual/samples/docker
@@ -1,3 +1,4 @@
+FROM golang:1.16 AS builder
 maintainer First O'Last
 
 run echo \


### PR DESCRIPTION
`AS` can be used as a keyword to name a stage in a multi-stage Docker build, but it isn't formatted correctly yet.

Before this PR:
**FROM** golang:1.16 AS builder

After this PR:
**FROM** golang:1.16 **AS** builder
