### PR TITLE
Praat: support matrix and string vector type

### DIFF
--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -66,13 +66,23 @@ a$ = e$
 a$ = pi$
 
 # Arrays are not comments
-a# = zero# (5, 6)
+a# = zero#(5)
 a [3], 5 = 7
 printline 'a[3,5]', 'a[3]'
 a [1] = 2
 b [a [1]] = 3
 assert b [a [1]] = 3
 printline 'b[2]'
+
+# Matrices
+m## = zero##(5, 6)
+m## = {{1, 2}, {3, 4}}
+m##[1, 2] = 3
+
+# String vectors
+strVec$# = empty$#(10)
+strVec$# = {"foo", "bar"}
+strVec$#[1] = "baz"
 
 # if-block with built-in variables
 if windows


### PR DESCRIPTION
Add types introduced in Praat version 6, matrix and string vector).

I also added some sample codes.

![image](https://user-images.githubusercontent.com/36665200/167076232-5e5270e1-b0a8-4b91-8b1d-4b71721e8632.png)

Closes #1819