### PR TITLE
PHP: support new syntax (constructor property promotion, readonly modifier, etc.)

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -39,12 +39,12 @@ module Rouge
           old_function cfunction
           __class__ __dir__ __file__ __function__ __halt_compiler __line__
           __method__ __namespace__ __trait__ abstract and array as break case
-          catch clone continue declare default die do echo else elseif
+          catch clone continue declare default die do echo else elseif empty
           enddeclare endfor endforeach endif endswitch endwhile eval exit
           extends final finally fn for foreach global goto if implements
-          include include_once instanceof insteadof isset list new or parent
-          print private protected public require require_once return self
-          static switch throw try var while xor yield
+          include include_once instanceof insteadof isset list match new or
+          parent print private protected public readonly require require_once
+          return self static switch throw try unset var while xor yield
         )
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -366,7 +366,8 @@ module Rouge
       end
 
       state :in_visibility do
-        rule %r/(?=(abstract|const|function|static)\b)/i, Keyword, :pop!
+        rule %r/\bstatic\b/i, Keyword
+        rule %r/(?=(abstract|const|function)\b)/i, Keyword, :pop!
         rule %r/\??#{id}/, Keyword::Type, :pop!
         mixin :escape
         mixin :whitespace

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -366,7 +366,7 @@ module Rouge
       end
 
       state :in_visibility do
-        rule %r/\bstatic\b/i, Keyword
+        rule %r/\b(?:readonly|static)\b/i, Keyword
         rule %r/(?=(abstract|const|function)\b)/i, Keyword, :pop!
         rule %r/\??#{id}/, Keyword::Type, :pop!
         mixin :escape

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -305,6 +305,7 @@ module Rouge
         rule %r/,/, Punctuation
         rule %r/[.]{3}/, Punctuation
         rule %r/=/, Operator, :in_assign
+        rule %r/\b(?:public|protected|private|readonly)\b/i, Keyword
         rule %r/\??#{id}/, Keyword::Type, :in_assign
         mixin :escape
         mixin :whitespace

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -106,6 +106,12 @@ function sort_on(array &$array, string $key) {
     usort($array, function ($a, $b) use($key) { return $a <=> $b; });
 }
 
+// Function-like keywords.
+isset($foo);
+empty($bar);
+unset($baz);
+die($qux);
+
 // No "use"
 $example = function () {
     some_fn($message);
@@ -173,6 +179,23 @@ class User
     {
         $this->id = $id;
         $this->name = $name;
+    }
+}
+
+class C {
+    private readonly $x;
+    protected readonly int $y;
+    private string $z;
+
+    public static ?string $a = "";
+    public static int $b = 0;
+
+    public function __construct(
+        public $foo,
+        protected readonly $bar,
+        private readonly array $baz = [],
+        private string $qux = "",
+    ) {
     }
 }
 
@@ -267,6 +290,12 @@ switch($header_info['compression_method']) {
   default:
     return false;
 }
+
+$y = match ($x) {
+  0 => 1,
+  1 => -1,
+  default => 0,
+};
 
 /* Loops */
 


### PR DESCRIPTION
# Summary

* Add missing keywords
  * `empty`
  * `match`
  * `readonly`
  * `unset`
* Fix parsing of static properties
* Support `readonly` modifiers
* Support constructor property promotion


# Details

## Add missing keywords

`empty` and `unset` are function-like keywords. Previously they are parsed as built-in functions like this:

cf. https://www.php.net/manual/en/reserved.keywords.php

![image](https://user-images.githubusercontent.com/54318333/172254869-f76244bb-74d9-40ba-8c1b-3b6eb74de366.png)

They should be parsed as keywords as `isset()` and `die()`.

![image](https://user-images.githubusercontent.com/54318333/172254881-12d1e9dd-f264-458a-a6c7-8918b2d50d1a.png)

Also, `match` expression is introduced since PHP 8.0.

cf. https://www.php.net/manual/en/control-structures.match.php

![image](https://user-images.githubusercontent.com/54318333/172255448-dcab43cc-f9ee-4061-9687-05d15e329fd3.png)

![image](https://user-images.githubusercontent.com/54318333/172255461-f8b5f7f6-0189-4e2b-8561-80eeb8de6963.png)


## Fix parsing of static properties

Previously, static property declaration with type hint like `public static int $x;` was parsed as the following:

* Keyword (`public`)
* Keyword (`static`)
* Unknown token (`int`)
* Variable (`$x`)

`int` should be parsed as a type.

The previous parser state `:in_visibility` defines these rules:

```ruby
state :in_visibility do
  rule %r/(?=(abstract|const|function|static)\b)/i, Keyword, :pop!
  rule %r/\??#{id}/, Keyword::Type, :pop!
  # ...
end
```

Because a parser pops the current state once it find `static`, it cannot recognize a type hint following the `static` keyword.

I split the rule into two, `static` and other. If a parser encounters `static`, it stays in the current state and then parses a type hints.

![image](https://user-images.githubusercontent.com/54318333/172255725-63a34f7e-4623-47e3-94cc-56eb88838e72.png)

![image](https://user-images.githubusercontent.com/54318333/172255737-f34e69cb-0b65-442e-be52-6c3872043fce.png)


## Support `readonly` modifiers

`readonly` is a new property modifier, available in PHP 8.1 or later.

cf. https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties


## Support constructor property promotion

Since PHP 8.0, you can prepend visibility modifiers to parameters of constructors. These parameters are "promoted" to class properties.
Since 8.1, you can specify `readonly` modifier as class properties.

cf. https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion