### PR TITLE
lexer: TOML: Support more integer and floating formats

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -28,8 +28,8 @@ module Rouge
 
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
-        rule %r/[+-]?\d+(_\d+)*\.\d+(_\d+)*([eE][+-]?\d+(_\d+)*)?/, Num::Float
-        rule %r/[+-]?\d+(_\d+)*[eE][+-]?\d+(_\d+)*/, Num::Float
+        rule %r/[+-]?\d+(?:_\d+)*\.\d+(?:_\d+)*(?:[eE][+-]?\d+(?:_\d+)*)?/, Num::Float
+        rule %r/[+-]?\d+(?:_\d+)*[eE][+-]?\d+(?:_\d+)*/, Num::Float
         rule %r/[+-]?(?:nan|inf)/, Num::Float
 
         rule %r/0x\h+(?:_\h+)*/, Num::Hex

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -31,6 +31,10 @@ module Rouge
         rule %r/[+-]?\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
         rule %r/[+-]?\d+[eE][+-]?[0-9]+/, Num::Float
         rule %r/[+-]?(nan|inf)/, Num::Float
+
+        rule %r/0x\h+(_\h+)*/, Num::Integer
+        rule %r/0o[0-7]+(_[0-7]+)*/, Num::Integer
+        rule %r/0b[0-1]+(_[0-1]+)*/, Num::Integer
         rule %r/[+-]?\d+/, Num::Integer
       end
 

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -28,14 +28,14 @@ module Rouge
 
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
-        rule %r/[+-]?\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
-        rule %r/[+-]?\d+[eE][+-]?[0-9]+/, Num::Float
+        rule %r/[+-]?\d+(_\d+)*\.\d+(_\d+)*([eE][+-]?\d+(_\d+)*)?/, Num::Float
+        rule %r/[+-]?\d+(_\d+)*[eE][+-]?\d+(_\d+)*/, Num::Float
         rule %r/[+-]?(nan|inf)/, Num::Float
 
         rule %r/0x\h+(_\h+)*/, Num::Integer
         rule %r/0o[0-7]+(_[0-7]+)*/, Num::Integer
         rule %r/0b[0-1]+(_[0-1]+)*/, Num::Integer
-        rule %r/[+-]?\d+/, Num::Integer
+        rule %r/[+-]?\d+(_\d+)*/, Num::Integer
       end
 
       state :root do

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -30,6 +30,7 @@ module Rouge
 
         rule %r/[+-]?\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
         rule %r/[+-]?\d+[eE][+-]?[0-9]+/, Num::Float
+        rule %r/[+-]?(nan|inf)/, Num::Float
         rule %r/[+-]?\d+/, Num::Integer
       end
 

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -33,7 +33,7 @@ module Rouge
         rule %r/[+-]?(nan|inf)/, Num::Float
 
         rule %r/0x\h+(_\h+)*/, Num::Integer
-        rule %r/0o[0-7]+(_[0-7]+)*/, Num::Integer
+        rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule %r/0b[0-1]+(_[0-1]+)*/, Num::Integer
         rule %r/[+-]?\d+(_\d+)*/, Num::Integer
       end

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -28,8 +28,8 @@ module Rouge
 
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
-        rule %r/(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?/, Num::Float
-        rule %r/\d+[eE][+-]?[0-9]+j?/, Num::Float
+        rule %r/\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
+        rule %r/\d+[eE][+-]?[0-9]+/, Num::Float
         rule %r/\-?\d+/, Num::Integer
       end
 

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -34,7 +34,7 @@ module Rouge
 
         rule %r/0x\h+(_\h+)*/, Num::Integer
         rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule %r/0b[0-1]+(_[0-1]+)*/, Num::Integer
+        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r/[+-]?\d+(_\d+)*/, Num::Integer
       end
 

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -30,7 +30,7 @@ module Rouge
 
         rule %r/[+-]?\d+(_\d+)*\.\d+(_\d+)*([eE][+-]?\d+(_\d+)*)?/, Num::Float
         rule %r/[+-]?\d+(_\d+)*[eE][+-]?\d+(_\d+)*/, Num::Float
-        rule %r/[+-]?(nan|inf)/, Num::Float
+        rule %r/[+-]?(?:nan|inf)/, Num::Float
 
         rule %r/0x\h+(?:_\h+)*/, Num::Hex
         rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -35,7 +35,7 @@ module Rouge
         rule %r/0x\h+(?:_\h+)*/, Num::Hex
         rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
-        rule %r/[+-]?\d+(_\d+)*/, Num::Integer
+        rule %r/[+-]?\d+(?:_\d+)*/, Num::Integer
       end
 
       state :root do

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -28,9 +28,9 @@ module Rouge
 
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
-        rule %r/\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
-        rule %r/\d+[eE][+-]?[0-9]+/, Num::Float
-        rule %r/\-?\d+/, Num::Integer
+        rule %r/[+-]?\d+\.\d+([eE][+-]?[0-9]+)?/, Num::Float
+        rule %r/[+-]?\d+[eE][+-]?[0-9]+/, Num::Float
+        rule %r/[+-]?\d+/, Num::Integer
       end
 
       state :root do

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -32,7 +32,7 @@ module Rouge
         rule %r/[+-]?\d+(_\d+)*[eE][+-]?\d+(_\d+)*/, Num::Float
         rule %r/[+-]?(nan|inf)/, Num::Float
 
-        rule %r/0x\h+(_\h+)*/, Num::Integer
+        rule %r/0x\h+(?:_\h+)*/, Num::Hex
         rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
         rule %r/[+-]?\d+(_\d+)*/, Num::Integer

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -118,3 +118,23 @@ point = { x = 1, y = 2 }
 physical.color = "orange"
 physical.shape = "round"
 site."google.com" = true
+
+# floating point numbers
+float_space1 = 3.141_592_653
+float_space2 = 123_456.789_012e+1_000
+just_inf = inf
+pos_inf  = +inf
+neg_inf  = -inf
+just_nan = nan
+pos_nan  = +nan
+neg_nan  = -nan
+
+# integer formats
+dec         = 123456
+dec_spacing = 123_456
+hex         = 0xdeadBEEF
+hex_spacing = 0xdead_BEEF
+oct         = 0o755
+oct_spacing = 0o755_777
+bin         = 0b1100
+bin_spacing = 0b0101_1100


### PR DESCRIPTION
Hi,
I wrote this patch to fix #1831 .

I added hex, bin, oct integers and special floating point numbers to the rule. And I modified the existing definition of integer and floating point numbers to allow underscores.
I also added some examples of those new features to `spec/visual/samples/toml`.

Then I visually checked that the examples of the features I mentioned in the issue.

<img width="278" alt="rouge-toml-lexer" src="https://user-images.githubusercontent.com/12286045/173572009-f11c29d5-af48-4802-a3be-691ab9970db3.PNG">

In the screenshot I included some invalid examples to check if those are highlighted as an error, but I didn't include them in the `spec/visual/sample` to avoid confusion.
If those invalid examples are beneficial, I will add them.

Please check it when you have time.
Thanks!
