### PR TITLE
Dart: Distinguish between punctuation and operators

### DIFF
--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -61,7 +61,8 @@ module Rouge
 
         rule %r/#{id}:/, Name::Label
         rule %r/\$?#{id}/, Name
-        rule %r/[~^*!%&\[\](){}<>\|+=:;,.\/?-]/, Operator
+        rule %r/[~^*!%&\|+=:\/?-]/, Operator
+        rule %r/[\[\](){}<>\.,;]/, Punctuation
         rule %r/\d*\.\d+([eE]\-?\d+)?/, Num::Float
         rule %r/0x[\da-fA-F]+/, Num::Hex
         rule %r/\d+L?/, Num::Integer


### PR DESCRIPTION
All punctuation type characters were being treated as operators, except the first `(` in a function signature, which led to different markup on opening versus closing parenthesis.  By making all bracket type characters punctuation it will harmonise the formatting.