### PR TITLE
Fix template highlight of braces in CPP lexer

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -71,6 +71,7 @@ module Rouge
         rule %r/\bnullptr\b/, Name::Builtin
         rule %r/(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
         rule %r/(::|<=>)/, Operator
+        rule %r/[{}]/, Punctuation
       end
 
       state :classname do

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -112,6 +112,13 @@ void forward_args(F f, Args... args) {
     f(std::forward<Args>(args)...);
 }
 
+// using auto
+template<auto F = requires { foo(); }>
+void func();
+
+template<auto F = []{}>
+void func();
+
 // namespace
 namespace printing {
     inline namespace latest {


### PR DESCRIPTION
Fix highlight of braces `{}` in `template` statement in CPP lexer.

I have also added an example and verified it via the visual test site.

![Screen Shot 2022-06-25 at 10 46 04 am](https://user-images.githubusercontent.com/756722/175751629-6cfdfeef-21a3-4273-be31-586b6d8536aa.png)

Closes https://github.com/rouge-ruby/rouge/issues/1837