### PR TITLE
Fix highlight of hex numbers in Pascal lexer

### DIFF
--- a/lib/rouge/lexers/pascal.rb
+++ b/lib/rouge/lexers/pascal.rb
@@ -55,6 +55,7 @@ module Rouge
         mixin :whitespace
 
         rule %r{((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?}, Num
+        rule %r/\$[0-9A-Fa-f]+/, Num::Hex
         rule %r{[~!@#\$%\^&\*\(\)\+`\-={}\[\]:;<>\?,\.\/\|\\]}, Punctuation
         rule %r{'([^']|'')*'}, Str
         rule %r/(true|false|nil)\b/i, Name::Builtin

--- a/spec/visual/samples/pascal
+++ b/spec/visual/samples/pascal
@@ -487,3 +487,18 @@ PROGRAM a1 (input,output);
                 ReadString(Command)
             END
     END.
+
+-- Hex numbers
+function UnicodeToISO_8859_9(Unicode: cardinal): integer;
+begin
+  case Unicode of
+  0..255: Result:=Unicode;
+  $011E: Result:= $D0;
+  $0130: Result:= $DD;
+  $015E: Result:= $DE;
+  $011F: Result:= $F0;
+  $0131: Result:= $FD;
+  $015F: Result:= $FE;
+  else Result:=-1;
+  end;
+end;


### PR DESCRIPTION
Fix highlight of [hex numbers](https://www.freepascal.org/docs-html/ref/refse6.html) in Pascal lexer.

I have also added an example and verified it via the visual test site.

![Screen Shot 2022-06-26 at 4 29 35 pm](https://user-images.githubusercontent.com/756722/175802471-f6af5cee-6f47-4524-8c55-b072f97da4fb.png)

Closes https://github.com/rouge-ruby/rouge/issues/1835