### PR TITLE
Disambiguate free pascal and puppet

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -131,6 +131,13 @@ module Rouge
         next TeX if matches?(/\A\s*(?:\\|%)/)
         next Apex
       end
+
+      disambiguate '*.pp' do
+        next Pascal if matches?(/\b(function|begin|var)\b/)
+        next Pascal if matches?(/\b(end(;|\.))/)
+
+        Puppet
+      end
     end
   end
 end

--- a/lib/rouge/lexers/pascal.rb
+++ b/lib/rouge/lexers/pascal.rb
@@ -7,7 +7,7 @@ module Rouge
       tag 'pascal'
       title "Pascal"
       desc 'a procedural programming language commonly used as a teaching language.'
-      filenames '*.pas', '*.lpr'
+      filenames '*.pas', '*.lpr', '*.pp'
 
       mimetypes 'text/x-pascal'
 

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -76,4 +76,40 @@ describe Rouge::Guesser do
       assert_guess(Rouge::Lexers::Ruby, :source => '# v' + 'im: syntax=ruby')
     end
   end
+
+  describe 'disambiguation guessing' do
+    describe 'guesses *.pp filename' do
+      it 'guesses pascal' do
+        assert_guess(
+          Rouge::Lexers::Pascal,
+          filename: 'foo.pp',
+          source: <<~SOURCE
+            function sum(a, b: integer): integer;
+            var tempSum: integer
+            begin
+              tempSum := a + b;
+              sum := tempSum;
+            end;
+          SOURCE
+        )
+      end
+
+      it 'guesses puppet' do
+        assert_guess(
+          Rouge::Lexers::Puppet,
+          filename: 'foo.pp',
+          source: <<~SOURCE
+            class foo::bar (
+              Array[String] = foo::bar::baz,
+            ) {
+              $foo = [
+                'bar',
+                'baz',
+              ]
+            }
+          SOURCE
+        )
+      end
+    end
+  end
 end

--- a/spec/lexers/pascal_spec.rb
+++ b/spec/lexers/pascal_spec.rb
@@ -9,7 +9,10 @@ describe Rouge::Lexers::Pascal do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.pas'
-      assert_guess :filename => 'foo.lpr'      
+      assert_guess :filename => 'foo.lpr'
+
+      # *.pp needs source hints because it's also used by Puppet
+      assert_guess :filename => 'foo.pp', :source => 'begin end.'
     end
 
     it 'guesses by mimetype' do

--- a/spec/lexers/puppet_spec.rb
+++ b/spec/lexers/puppet_spec.rb
@@ -8,7 +8,8 @@ describe Rouge::Lexers::Puppet do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'foo.pp'
+      # *.pp needs source hints because it's also used by Pascal
+      assert_guess :filename => 'foo.pp', :source => 'class privileges { }'
     end
 
     it 'guesses by source' do


### PR DESCRIPTION
Both free pascal and puppet are sharing the same file extension, that is `.pp`. This change adds `.pp` as a possible extension for the `pascal` lexer and disambiguates between `puppet` and `pascal` using keywords.

Addresses https://github.com/rouge-ruby/rouge/issues/1842