### PR TITLE
Fix highlight of nullish coalescing operator in JS

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -149,7 +149,7 @@ module Rouge
         rule %r/\A\s*#!.*?\n/m, Comment::Preproc, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
-        rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===
+        rule %r(\+\+ | -- | ~ | \?\?=? | && | \|\| | \\(?=\n) | << | >>>? | ===
                | !== )x,
           Operator, :expr_start
         rule %r([-<>+*%&|\^/!=]=?), Operator, :expr_start

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -282,3 +282,13 @@ class Œuvre {
     书名 = "Les Misérables";
   }
 }
+
+// Nullish coalescing operator (??)
+let ret = "";
+let foo, bar;
+
+ret += `// ${foo ?? "Unk"}: ${bar ?? "Just do it"}`;
+ret += "\n";
+
+let baz;
+baz ??= 'default';


### PR DESCRIPTION
Fix highlight of [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) operator in JS. Before this change, this operator was picked up as the start of a ternary statement and caused issues for the subsequent string.

| Before | After |
|--|--|
| ![Screen Shot 2022-06-30 at 7 14 58 pm](https://user-images.githubusercontent.com/756722/176640367-7977e16c-a440-41e1-8d11-f7394de22816.png)|![Screen Shot 2022-06-30 at 7 11 23 pm](https://user-images.githubusercontent.com/756722/176639439-e171109f-ef1a-4d3b-a50a-be732b5c21a6.png)|

Fixes https://github.com/rouge-ruby/rouge/issues/1834