### PR TITLE
Add Meson specs

### DIFF
--- a/docs/Languages.md
+++ b/docs/Languages.md
@@ -124,6 +124,7 @@
 - Mason (`mason`)
 - Mathematica (`mathematica`)
 - MATLAB (`matlab`)
+- Meson (`meson`)
 - MiniZinc (`minizinc`)
 - MoonScript (`moonscript`)
 - Mosel (`mosel`)

--- a/lib/rouge/lexers/meson.rb
+++ b/lib/rouge/lexers/meson.rb
@@ -8,6 +8,7 @@ module Rouge
       desc "Meson's specification language (mesonbuild.com)"
       tag 'meson'
       filenames 'meson.build', 'meson_options.txt'
+      mimetypes 'text/x-meson'
 
       def self.keywords
         @keywords ||= %w(

--- a/lib/rouge/lexers/meson.rb
+++ b/lib/rouge/lexers/meson.rb
@@ -41,7 +41,7 @@ module Rouge
       dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
 
       def current_string
-        @string_register ||= StringRegister.new
+        @current_string ||= StringRegister.new
       end
 
       state :root do

--- a/spec/lexers/meson_spec.rb
+++ b/spec/lexers/meson_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Meson do
+  let(:subject) { Rouge::Lexers::Meson.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'meson.build'
+      assert_guess :filename => 'meson_options.txt'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-meson'
+    end
+  end
+end


### PR DESCRIPTION
Follow-up PR to to address feedback raised in https://github.com/rouge-ruby/rouge/pull/1732 for Meson lexer.

- Add specs
- Add Meson to the list of supported languages
- Add mime-type
- Fix `Naming/MemoizedInstanceVariableName` Rubocop offense