### PR TITLE
Add more directives in Makefile lexer

### DIFF
--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -20,11 +20,6 @@ module Rouge
         )
       end
 
-      # TODO: Add support for special keywords
-      # bsd_special = %w(
-      #   include undef error warning if else elif endif for endfor
-      # )
-
       def initialize(opts={})
         super
         @shell = Shell.new(opts)
@@ -45,7 +40,7 @@ module Rouge
           groups Keyword, Text, Name::Variable
         end
 
-        rule %r/(?:else|endif)[\t ]*(?=[#\n])/, Keyword
+        rule %r/(?:else|endif|endef|endfor)[\t ]*(?=[#\n])/, Keyword
 
         rule %r/(export)([\t ]+)(?=[\w\${}()\t -]+\n)/ do
           groups Keyword, Text

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -65,6 +65,11 @@ module Rouge
         rule %r/(override\b)*([\t ])*(define)([\t ]+)([^#\n]+)/ do
           groups Name::Builtin, Text, Keyword, Text, Name::Variable
         end
+
+        rule %r/(\$[({])([\t ]*)(#{Make.functions.join('|')})([\t ]+)/m do
+          groups Name::Function, Text, Name::Builtin, Text
+          push :shell_expr
+        end
       end
 
       state :export do

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -36,7 +36,7 @@ module Rouge
           groups Keyword, Literal::String::Other
         end
 
-        rule %r/(ifn?def|ifn?eq)([\t ]+)([^#\n]+)/ do
+        rule %r/((?:ifn?def|ifn?eq|unexport)\b)([\t ]+)([^#\n]+)/ do
           groups Keyword, Text, Name::Variable
         end
 

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -55,10 +55,8 @@ module Rouge
         rule %r/export[\t ]+/, Keyword
 
         # assignment
-        rule %r/([\w${}().-]+)([\t ]*)([!?:+]?=)/m do |m|
-          token Name::Variable, m[1]
-          token Text, m[2]
-          token Operator, m[3]
+        rule %r/(override\b)*([\t ]*)([\w${}().-]+)([\t ]*)([!?:+]?=)/m do |m|
+          groups Name::Builtin, Text, Name::Variable, Text, Operator
           push :shell_line
         end
 
@@ -67,6 +65,10 @@ module Rouge
         rule %r/([^\n:]+)(:+)([ \t]*)/ do
           groups Name::Label, Operator, Text
           push :block_header
+        end
+
+        rule %r/(override\b)*([\t ])*(define)([\t ]+)([^#\n]+)/ do
+          groups Name::Builtin, Text, Keyword, Text, Name::Variable
         end
       end
 

--- a/spec/visual/samples/make
+++ b/spec/visual/samples/make
@@ -121,6 +121,19 @@ define variable ::=
 define variable +=
 define variable ?=
 
+define PROGRAM_template =
+	$(1): $$($(1)_OBJS) $$($(1)_LIBS:%=-l%)
+	ALL_OBJS += $$($(1)_OBJS)
+endef
+
+# Secondary expansion
+.SECONDEXPANSION:
+ONEVAR = onefile
+TWOVAR = twofile
+myfile: $(ONEVAR) $$(TWOVAR)
+
+main lib: $$(patsubst %.c,%.o,$$($$@_SRCS))
+
 # The eval function
 $(foreach prog,$(PROGRAMS),$(eval $(call PROGRAM_template,$(prog))))
 

--- a/spec/visual/samples/make
+++ b/spec/visual/samples/make
@@ -145,3 +145,10 @@ override variable = value
 override variable := value
 override variable += more text
 override CFLAGS += -g
+
+# export/unexport
+export variable = value
+export variable := value
+export variable += value
+export variable
+unexport variable

--- a/spec/visual/samples/make
+++ b/spec/visual/samples/make
@@ -112,3 +112,19 @@ endif
 
 print_path:
 	echo $$PATH
+
+# The define Directive
+define variable
+define variable =
+define variable :=
+define variable ::=
+define variable +=
+define variable ?=
+# The override Directive
+override define foo =
+endef
+
+override variable = value
+override variable := value
+override variable += more text
+override CFLAGS += -g

--- a/spec/visual/samples/make
+++ b/spec/visual/samples/make
@@ -120,6 +120,10 @@ define variable :=
 define variable ::=
 define variable +=
 define variable ?=
+
+# The eval function
+$(foreach prog,$(PROGRAMS),$(eval $(call PROGRAM_template,$(prog))))
+
 # The override Directive
 override define foo =
 endef


### PR DESCRIPTION
This PR adds more directives in the Makefile lexer.

- Support `define` directive
- Support [secondary expansion](https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html) (`$$`)
- Support [override](https://www.gnu.org/software/make/manual/html_node/Override-Directive.html#Override-Directive) directive
- Support functions that can be specified at the top level such as `foreach` and [`eval`](https://www.gnu.org/software/make/manual/html_node/Eval-Function.html).
- Support [`unexport` ](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html) directive

<img width="585" alt="Screen Shot 2022-07-23 at 11 25 49 pm" src="https://user-images.githubusercontent.com/756722/180607015-0791e634-ca42-4a3e-831e-83cd6752f93e.png">

Address the following issues:

- Resolves https://github.com/rouge-ruby/rouge/issues/1813
- Resolves https://github.com/rouge-ruby/rouge/issues/1814
- Resolves https://github.com/rouge-ruby/rouge/issues/1812