### PR TITLE
Fix angle bracket being confused as diff 

### DIFF
--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -40,7 +40,7 @@ module Rouge
         end
         rule(/^\w.*$\n?/, Punctuation)
         rule(/^=.*$\n?/, Generic::Heading)
-        rule(/\s.*$\n?/, Text)
+        rule(/.+$\n?/, Text)
       end
     end
   end

--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -20,9 +20,19 @@ module Rouge
       state :root do
         rule(/^ .*$\n?/, Text)
         rule(/^---$\n?/, Punctuation)
-        rule(/^[+>]+.*$\n?/, Generic::Inserted)
-        rule(/^\+.*$\n?/, Generic::Inserted)
-        rule(/^[-<]+.*$\n?/, Generic::Deleted)
+
+        rule %r(
+          (^\++.*$\n?) |
+          (^>+[ \t]+.*$\n?) |
+          (^>+$\n?)
+        )x, Generic::Inserted
+
+        rule %r(
+          (^-+.*$\n?) |
+          (^<+[ \t]+.*$\n?) |
+          (^<+$\n?)
+        )x, Generic::Deleted
+
         rule(/^!.*$\n?/, Generic::Strong)
         rule(/^([Ii]ndex|diff).*$\n?/, Generic::Heading)
         rule(/^(@@[^@]*@@)([^\n]*\n)/) do

--- a/spec/visual/samples/diff
+++ b/spec/visual/samples/diff
@@ -13,7 +13,7 @@ index 87f10f4..09ba8c0 100644
  ``` ruby
 -formatter = Rouge::Formatters::HTML.new
 +# make some nice lexed html, compatible with pygments stylesheets
-+formatter = Rouge::Formatters::HTML.new(:css_class => '.highlight')
+!formatter = Rouge::Formatters::HTML.new(:css_class => '.highlight')
  Rouge.highlight(File.read('/etc/bash.bashrc'), 'shell', formatter)
 +
 +# apply a theme
@@ -56,8 +56,23 @@ index ab1701b..155fa52 100644
 
 $ diff a b
 1a2
-> Added line
+>
+> This paragraph contains
+> important new additions
+> to this document.
+> <p>Work with tag</p>
 3c4
-< diff
+< This paragraph contains
+< text that is outdated.
+< It will be deleted in the
+< near future.
+< <p>Work with tag</p>
+<
 ---
 > Line before was removed
+
+
+<div>
+-  <p></p>
++  <span></span>
+</div>


### PR DESCRIPTION
Angle bracket `<` and `>` at the start of the string is confused as inserted and deleted line by diff lexer.

This change ensures we only pick up inserted line if there is some space between `>` and the next character, or immediately followed by a new line. The same rule also applies to the deleted line.

![Screen Shot 2022-07-30 at 8 42 09 pm](https://user-images.githubusercontent.com/756722/181906734-4d9389cd-6edf-4502-9bbd-3584c94a4bc9.png)

Relates to https://github.com/rouge-ruby/rouge/issues/1850
