### PR TITLE
Define missing namespace state for haxe lexer

### DIFF
--- a/lib/rouge/lexers/haxe.rb
+++ b/lib/rouge/lexers/haxe.rb
@@ -18,14 +18,14 @@ module Rouge
       def self.keywords
         @keywords ||= Set.new %w(
           break case cast catch class continue default do else enum false for
-          function if import interface macro new null override package private
+          function if import in interface macro new null override package private
           public return switch this throw true try untyped while
         )
       end
 
       def self.imports
         @imports ||= Set.new %w(
-          import using
+          package import using
         )
       end
 
@@ -55,6 +55,7 @@ module Rouge
       end
 
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/
+      dotted_id = /[$a-zA-Z_][a-zA-Z0-9_.]*/
 
       state :comments_and_whitespace do
         rule %r/\s+/, Text
@@ -75,6 +76,22 @@ module Rouge
         rule %r/[{]/, Punctuation, :object
 
         rule %r//, Text, :pop!
+      end
+
+      state :namespace do
+        mixin :comments_and_whitespace
+
+        rule %r/
+           (#{dotted_id})
+           (\s+)(in)(\s+)
+           (#{id})
+         /x do
+          groups(Name::Namespace, Text::Whitespace, Keyword, Text::Whitespace, Name)
+        end
+
+        rule %r/#{dotted_id}/, Name::Namespace
+
+        rule(//) { pop! }
       end
 
       state :regex do
@@ -141,20 +158,22 @@ module Rouge
         end
 
         rule id do |m|
-          if self.class.keywords.include? m[0]
+          match = m[0]
+
+          if self.class.imports.include?(match)
+            token Keyword::Namespace
+            push :namespace
+          elsif self.class.keywords.include?(match)
             token Keyword
             push :expr_start
-          elsif self.class.imports.include? m[0]
-            token Keyword
-            push :namespace
-          elsif self.class.declarations.include? m[0]
+          elsif self.class.declarations.include?(match)
             token Keyword::Declaration
             push :expr_start
-          elsif self.class.reserved.include? m[0]
+          elsif self.class.reserved.include?(match)
             token Keyword::Reserved
-          elsif self.class.constants.include? m[0]
+          elsif self.class.constants.include?(match)
             token Keyword::Constant
-          elsif self.class.builtins.include? m[0]
+          elsif self.class.builtins.include?(match)
             token Name::Builtin
           else
             token Name::Other

--- a/lib/rouge/lexers/haxe.rb
+++ b/lib/rouge/lexers/haxe.rb
@@ -17,7 +17,7 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          break case cast catch class continue default do else enum false for
+          as break case cast catch class continue default do else enum false for
           function if import in interface macro new null override package private
           public return switch this throw true try untyped while
         )
@@ -83,7 +83,7 @@ module Rouge
 
         rule %r/
            (#{dotted_id})
-           (\s+)(in)(\s+)
+           (\s+)(in|as)(\s+)
            (#{id})
          /x do
           groups(Name::Namespace, Text::Whitespace, Keyword, Text::Whitespace, Name)

--- a/spec/visual/samples/haxe
+++ b/spec/visual/samples/haxe
@@ -2,6 +2,7 @@ package a.b.c;
 
 import haxe.macro.*;
 import String.fromCharCode in f;
+import String.fromCharCode as f;
 using my.package.SomeStaticExtension;
 
 // one line comment

--- a/spec/visual/samples/haxe
+++ b/spec/visual/samples/haxe
@@ -1,5 +1,9 @@
 package a.b.c;
 
+import haxe.macro.*;
+import String.fromCharCode in f;
+using my.package.SomeStaticExtension;
+
 // one line comment
 /*
   multiline


### PR DESCRIPTION
This commit fixes an exception where the namespace state is not defined.

- Standardise import, using and package statement
- Support import with alias (`in` and `as`)
- Distinguish `Keyword::Namespace` token

![Screen Shot 2022-08-18 at 7 56 05 pm](https://user-images.githubusercontent.com/756722/185367679-15056867-42d8-4856-8fae-fd3255739414.png)

Fixes https://github.com/rouge-ruby/rouge/issues/1720