### PR TITLE
Fix array being parsed as table header in TOML

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -39,7 +39,7 @@ module Rouge
       state :root do
         mixin :basic
 
-        rule %r/(?<!=)\s*\[\s*[\S]+\s*\]/, Name::Namespace
+        rule %r/(?<!=)\s*\[.*?\]+/, Name::Namespace
 
         rule %r/(#{identifier})(\s*)(=)/ do
           groups Name::Property, Text, Punctuation

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -24,8 +24,6 @@ module Rouge
           push :inline
         end
 
-        rule %r/(?<!=)\s*\[[\S]+\]/, Name::Namespace
-
         rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
 
         rule %r/[+-]?\d+(?:_\d+)*\.\d+(?:_\d+)*(?:[eE][+-]?\d+(?:_\d+)*)?/, Num::Float
@@ -40,6 +38,8 @@ module Rouge
 
       state :root do
         mixin :basic
+
+        rule %r/(?<!=)\s*\[\s*[\S]+\s*\]/, Name::Namespace
 
         rule %r/(#{identifier})(\s*)(=)/ do
           groups Name::Property, Text, Punctuation

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -28,6 +28,11 @@ enabled = true
 [dog."tater.man"]
 type.name = "pug"
 
+[a.b.c]            # this is best practice
+[ d.e.f ]          # same as [d.e.f]
+[ g .  h  . i ]    # same as [g.h.i]
+[ j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
+
 [clients]
 data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it
 

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -25,6 +25,9 @@ enabled = true
   ip = "10.0.0.2"
   dc = "eqdc10"
 
+[dog."tater.man"]
+type.name = "pug"
+
 [clients]
 data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it
 
@@ -114,6 +117,14 @@ point = { x = 1, y = 2 }
 'key2' = "value"
 'quoted "value"' = "value"
 
+# Array
+integers = [ 1, 2, 3 ]
+colors = [ "red", "yellow", "green" ]
+nested_arrays_of_ints = [ [ 1, 2 ], [3, 4, 5] ]
+nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
+string_array = [ "all", 'strings', """are the same""", '''type''' ]
+link-libraries = ["mylib::mylib"]
+
 # Dotted keys
 physical.color = "orange"
 physical.shape = "round"
@@ -138,3 +149,15 @@ oct         = 0o755
 oct_spacing = 0o755_777
 bin         = 0b1100
 bin_spacing = 0b0101_1100
+
+[[products]]
+name = "array of table"
+sku = 738594937
+emptyTableAreAllowed = true
+
+[[products]]
+
+[[products]]
+name = "Nail"
+sku = 284758393
+color = "gray"


### PR DESCRIPTION
This ensures the table is pushed up to the root stack and not picked up as a value in the basic mix-in. I have also added a few more examples from the official [doc](https://toml.io/en/v1.0.0#table) for testing. 

|Before|After|
|--|--|
|![Screen Shot 2022-08-18 at 10 21 04 am](https://user-images.githubusercontent.com/756722/185265971-2c010293-9ae4-42b5-aa64-3b35b6e9dc7b.png) |![Screen Shot 2022-08-18 at 10 21 21 am](https://user-images.githubusercontent.com/756722/185265950-54c85d4e-425d-40b0-b01d-ed0979639d80.png)|

Fixes https://github.com/rouge-ruby/rouge/issues/1719

##  📓 Troubleshooting notes

- Create a file containing the problematic text (named `example.toml`)
   ```
   link-libraries = ["mylibmylib"]
   ```

- Run `./bin/rougify debug example.toml`
- Inspect the output

   <details>
   <summary>👉🏼 Before</summary>

   ```
   lexer: toml
   stack: [:root]
   stream: "link-libraries = [\"m"  
   // snipped
   
   lexer: toml
   stack: [:root, :value]
   stream: "[\"mylibmylib\"]\n"
     trying: #<Rule /\n/>
     entering: mixin :content
     entering: mixin :basic
     trying: #<Rule /\s+/>
     trying: #<Rule /#.*?$/>
     trying: #<Rule /(true|false)/>
     trying: #<Rule /((?-mix:\S+|"[^"]+"|'[^']+'))(\s*)(=)(\s*)(\{)/>
     trying: #<Rule /(?<!=)\s*\[\s*[\S]+\s*\]/>
       got: "[\"mylibmylib\"]"
       yielding: Name.Namespace, "[\"mylibmylib\"]"
   Text " "
   // snipped
   ```

   </details>

   <details>
   <summary>👉🏼 After</summary>

   ```
   lexer: tom
   stack: [:root]
   stream: "link-libraries = [\"m"  
   // snipped
   
   lexer: toml
   stack: [:root, :value]
   stream: " [\"mylibmylib\"]\n"
     trying: #<Rule /\n/>
     entering: mixin :content
     entering: mixin :basic
     trying: #<Rule /\s+/>
       got: " "
       yielding: Text, " "
   Punctuation "="
   // snipped
   ```

    </details>
