### PR TITLE
Add poetry.lock file to TOML lexer

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -5,10 +5,10 @@ module Rouge
   module Lexers
     class TOML < RegexLexer
       title "TOML"
-      desc 'the TOML configuration format (https://github.com/mojombo/toml)'
+      desc 'the TOML configuration format (https://github.com/toml-lang/toml)'
       tag 'toml'
 
-      filenames '*.toml', 'Pipfile'
+      filenames '*.toml', 'Pipfile', 'poetry.lock'
       mimetypes 'text/x-toml'
 
       # bare keys and quoted keys

--- a/spec/lexers/toml_spec.rb
+++ b/spec/lexers/toml_spec.rb
@@ -10,6 +10,7 @@ describe Rouge::Lexers::TOML do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.toml'
       assert_guess :filename => 'Pipfile'
+      assert_guess :filename => 'poetry.lock'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
Automatically lex [`poetry.lock`](https://python-poetry.org/docs/basic-usage/#installing-with-poetrylock) with TOML lexer.

An example content of `poetry.lock`:

```toml
[[package]]                                                                                                                                                                 
name = "anyio"                                                                                                                                                              
version = "3.5.0"                                                                                                                                                           
description = "High level compatibility layer for multiple asynchronous event loop implementations"                                                                         
category = "main"                                                                                                                                                           
optional = false                                                                                                                                                            
python-versions = ">=3.6.2" 
```

