### PR TITLE
Drop support for Ruby < 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.5"
+          ruby-version: "2.7"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rake check:style
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby-version: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   DisplayCopNames: true
   Exclude:
     - "tasks/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -10,17 +10,14 @@ gem 'minitest', '>= 5.0'
 gem 'minitest-power_assert'
 gem 'power_assert', '~> 1.2'
 
-gem 'parallel', '~> 1.13.0' if RUBY_VERSION < '2.2.0'
 gem 'rubocop', '~> 1.0', '<= 1.11'
 gem 'rubocop-performance'
 
 # don't try to install redcarpet under jruby
-gem 'redcarpet', :platforms => :ruby
+gem 'redcarpet', platforms: :ruby
 
 # Profiling
-if RUBY_VERSION >= '2.3.0'
-  gem 'memory_profiler', :require => false
-end
+gem 'memory_profiler', require: false
 
 # Needed for a Rake task
 gem 'git'
@@ -33,11 +30,7 @@ group :development do
   gem 'github-markup'
 
   # for visual tests
-  if RUBY_VERSION < '2.2.0'
-    gem 'sinatra', '~> 1.4.8'
-  else
-    gem 'sinatra'
-  end
+  gem 'sinatra'
 
   # Ruby 3 no longer ships with a web server
   gem 'puma' if RUBY_VERSION >= '3'

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.7'
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rouge-ruby/rouge/issues",
     "changelog_uri"     => "https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md",


### PR DESCRIPTION
With Ruby 2.6 being [EOL](https://www.ruby-lang.org/en/downloads/branches/), we should drop support for old versions to reduce Rouge gem maintenance effort. It also helps to reduce build runtime.