### PR TITLE
Add support for HTTP/2 responses to HTTP lexer

### DIFF
--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -46,7 +46,7 @@ module Rouge
 
         # response
         rule %r(
-          (HTTPS?)(/)(\d(?:\.\d))([ ]+)  # http version
+          (HTTPS?)(/)(\d(?:\.\d)?)([ ]+) # http version
           (\d{3})([ ]+)?                 # status
           ([^\r\n]*)?(\r?\n|$)           # status message
         )x do

--- a/spec/lexers/http_spec.rb
+++ b/spec/lexers/http_spec.rb
@@ -36,4 +36,14 @@ describe Rouge::Lexers::HTTP do
                                   ["Literal.Number", "200"],
                                   ["Text", " "]
   end
+
+  it 'lexes an empty HTTP/2 response' do
+    response = "HTTP/2 200 "
+    assert_tokens_equal response, ["Keyword", "HTTP"],
+                                  ["Operator", "/"], 
+                                  ["Literal.Number", "2"],
+                                  ["Text", " "],
+                                  ["Literal.Number", "200"],
+                                  ["Text", " "]
+  end
 end


### PR DESCRIPTION
The existing HTTP lexer parses HTTP/2 requests, but not responses marked with HTTP/2. (However, it would accept HTTP/2.0.)

There is no specification for the textual representation of HTTP/2 traffic (as far as I can tell), but some tools generate response headers with only HTTP/2, which fail to be processed correctly by Rouge without this change.

This change makes the version number matching identical between the request and response regexes, which should resolve the issue.