### PR TITLE
todo: fix

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-*TODO: ADD CONTACT FOR ROGUE PROJECT*
+reported to the project maintainers responsible for enforcement at jneen@jneen.net or tan.le@hey.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-*conduct@ethicalsource.dev*.
+*TODO: ADD CONTACT FOR ROGUE PROJECT*
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
As I suspected, this was incorrectly copied from e.g. the actual CoC of https://github.com/EthicalSource/contributor_covenant/ or some such place. The below is obviously suboptimal, but it at least ensures that Coraline doesn't get any more unnecessary email.