### PR TITLE
Coq has non-standard string escapes.

### DIFF
--- a/lib/rouge/demos/coq
+++ b/lib/rouge/demos/coq
@@ -10,4 +10,7 @@ Section with_T.
     end.
 End with_T.
 
-Definition a_string := "hello \" world".
+Definition a_string := "hello
+world".
+Definition escape_string := "0123".
+Definition zero_string := "0".

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -144,14 +144,9 @@ module Rouge
       end
 
       state :string do
-        rule %r/(?:\\")+|[^"]/, Str::Double
-        mixin :escape_sequence
-        rule %r/\\\n/, Str::Double
+        rule %r/[^"]+/, Str::Double
+        rule %r/""/, Str::Double
         rule %r/"/, Str::Double, :pop!
-      end
-
-      state :escape_sequence do
-        rule %r/\\[\\"'ntbr]/, Str::Escape
       end
 
       state :continue_id do

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -10,7 +10,13 @@ Section with_T.
     end.
 End with_T.
 
-Definition a_string := "hello\" world".
+
+Definition a_string := "hello...\n \r \\ \
+world".
+Definition zero_string := "0".
+Definition b_string := "b".
+Definition escape_string := """ hello  world ".
+
 
 Notation "A /\ B" := (and A B) : type_scope.
 


### PR DESCRIPTION
The only escape is "" -> ".

As with previous contributions, I don't know much ruby, so improvements are welcome.