### PR TITLE
Ignoring RVM/rbenv version and gemset config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ rouge-memory.tmp
 
 # IntelliJ IDEA / RubyMine
 .idea/
+
+# RVM/rbenv configuration files
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
This commit adds `.ruby-version` and `.ruby-gemset` to the `.gitignore` for this project, so that folks using RVM or rbenv (or other tools that may also use these files) won't accidentally commit them.