### PR TITLE
Porting Cisco IOS configuration lexer from pygments-routerlexers

### DIFF
--- a/lib/rouge/demos/cisco_ios
+++ b/lib/rouge/demos/cisco_ios
@@ -1,0 +1,19 @@
+interface FastEthernet0.20
+    encapsulation dot1Q 20
+    no ip route-cache
+    bridge-group 1
+    no bridge-group 1 source-learning
+    bridge-group 1 spanning-disabled
+
+! Supports shortened versions of config words, too
+inter gi0.10
+encap dot1q 10 native
+inter gi0
+
+banner login # Authenticate yourself! #
+
+! Supports #, $ and % to delimit banners, and multiline
+banner motd $
+Attention!
+We will be having scheduled system maintenance on this device.
+$

--- a/lib/rouge/lexers/cisco_ios.rb
+++ b/lib/rouge/lexers/cisco_ios.rb
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+# Based on/regexes mostly from Brandon Bennett's pygments-routerlexers:
+# https://github.com/nemith/pygments-routerlexers
+
+module Rouge
+  module Lexers
+    class CiscoIos < RegexLexer
+      title 'Cisco IOS'
+      desc 'Cisco IOS configuration lexer'
+      tag 'cisco_ios'
+      filenames '*.cfg'
+      mimetypes 'text/x-cisco-conf'
+
+      state :root do
+        rule %r/^!.*/, Comment::Single
+
+        rule %r/^(version\s+)(.*)$/ do
+          groups Keyword, Num::Float
+        end
+
+        rule %r/(desc*r*i*p*t*i*o*n*)(.*?)$/ do
+          groups Keyword, Comment::Single
+        end
+
+        rule %r/^(inte*r*f*a*c*e*|controller|router \S+|voice translation-\S+|voice-port|line)(.*)$/ do
+          groups Keyword::Type, Name::Function
+        end
+
+        rule %r/(password|secret)(\s+[57]\s+)(\S+)/ do
+          groups Keyword, Num, String::Double
+        end
+
+        rule %r/(permit|deny)/, Operator::Word
+
+        rule %r/^(banner\s+)(motd\s+|login\s+)([#$%])/ do
+          groups Keyword, Name::Function, Str::Delimiter
+          push :cisco_ios_text
+        end
+
+        rule %r/^(dial-peer\s+\S+\s+)(\S+)(.*?)$/ do
+          groups Keyword, Name::Attribute, Keyword
+        end
+
+        rule %r/^(vlan\s+)(\d+)$/ do
+          groups Keyword, Name::Attribute
+        end
+
+        # IPv4 Address/Prefix
+        rule %r/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(\/\d{1,2})?/, Num
+
+        # NSAP
+        rule %r/49\.\d{4}\.\d{4}\.\d{4}\.\d{4}\.\d{2}/, Num
+
+        # MAC Address
+        rule %r/[a-f0-9]{4}\.[a-f0-9]{4}\.[a-f0-9]{4}/, Num::Hex
+
+        rule %r/^(\s*no\s+)(\S+)/ do
+          groups Keyword::Constant, Keyword
+        end
+
+        rule %r/^[^\n\r]\s*\S+/, Keyword
+
+        # Obfuscated Passwords
+        rule  %r/\*+/, Name::Entity
+
+        rule %r/(?<= )\d+(?= )/, Num
+
+        # Newline catcher, avoid errors on empty lines
+        rule %r/\n+/m, Text
+
+        # This one goes last, a text catch-all
+        rule %r/./, Text
+      end
+
+      state :cisco_ios_text do
+        rule %r/[^#$%]/, Text
+        rule %r/[#$%]/, Str::Delimiter, :pop!
+      end
+    end
+  end
+end

--- a/spec/lexers/cisco_ios_spec.rb
+++ b/spec/lexers/cisco_ios_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::CiscoIos do
+  let(:subject) { Rouge::Lexers::CiscoIos.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.cfg'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-cisco-conf'
+    end
+  end
+end

--- a/spec/visual/samples/cisco_ios
+++ b/spec/visual/samples/cisco_ios
@@ -2,21 +2,21 @@
 ! http://www.glitchwrks.com/2016/10/06/cisco-access-points
 
 interface FastEthernet0
-    no ip address
-    no ip route-cache
-    duplex auto
-    speed auto
+  no ip address
+  no ip route-cache
+  duplex auto
+  speed auto
 
 interface FastEthernet0.20
-    encapsulation dot1Q 20
-    no ip route-cache
-    bridge-group 1
-    no bridge-group 1 source-learning
-    bridge-group 1 spanning-disabled
+  encapsulation dot1Q 20
+  no ip route-cache
+  bridge-group 1
+  no bridge-group 1 source-learning
+  bridge-group 1 spanning-disabled
 
 interface BVI1
-    ip address dhcp client-id FastEthernet0
-    no ip route cache
+  ip address dhcp client-id FastEthernet0
+  no ip route cache
 
 ! Supports shortened versions of config words, too
 conf ter

--- a/spec/visual/samples/cisco_ios
+++ b/spec/visual/samples/cisco_ios
@@ -1,0 +1,37 @@
+! This sample is given by Glitch Works, LLC from the following article:
+! http://www.glitchwrks.com/2016/10/06/cisco-access-points
+
+interface FastEthernet0
+    no ip address
+    no ip route-cache
+    duplex auto
+    speed auto
+
+interface FastEthernet0.20
+    encapsulation dot1Q 20
+    no ip route-cache
+    bridge-group 1
+    no bridge-group 1 source-learning
+    bridge-group 1 spanning-disabled
+
+interface BVI1
+    ip address dhcp client-id FastEthernet0
+    no ip route cache
+
+! Supports shortened versions of config words, too
+conf ter
+inter gi0.10
+encap dot1q 10 native
+inter gi0
+bridge-group 2
+inter gi0.10
+no encap dot1q 10 native
+encap dot1q 10
+
+banner login # Authenticate yourself! #
+
+! Supports #, $ and % to delimit banners, and multiline
+banner motd $
+Attention!
+We will be having scheduled system maintenance on this device.
+$


### PR DESCRIPTION
This PR adds a port of [pygments-routerlexers](https://github.com/nemith/pygments-routerlexers). The regexes largely come from `pygments-routerlexers` with a few changes to make them more consistent. Included sample files are from a writeup on my site and are given freely under this project's license, if that's acceptable.