### PR TITLE
Simplify rules with groups syntax on coq lexer

### DIFF
--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -110,3 +110,14 @@ Proof.
   1,2: { done. }
   1,2,3: { done. }
 Qed.
+
+Unset Implicit Arguments.
+Set Strict Implicit.
+Set Printing Notations.
+CoInductive Trace (A:automaton) : states A -> LList (actions A) -> Prop :=
+| empty_trace : forall q:states A, deadlock A q -> Trace A q LNil
+| lcons_trace :
+    forall (q q':states A) (a:actions A) (l:LList (actions A)),
+      In q' (transitions A q a) -> Trace A q' l -> Trace A q (LCons a l).
+Set Implicit Arguments.
+Unset Strict Implicit.


### PR DESCRIPTION
- Use groups syntax for ordered tokens
- Remove white spaces
- Add more examples