### PR TITLE
Fix template strings problem in javascript lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -271,7 +271,7 @@ module Rouge
       state :template_string do
         rule %r/[$]{/, Punctuation, :template_string_expr
         rule %r/`/, Str::Double, :pop!
-        rule %r/\\[$`]/, Str::Escape
+        rule %r/\\[$`\\]/, Str::Escape
         rule %r/[^$`\\]+/, Str::Double
         rule %r/[\\$]/, Str::Double
       end


### PR DESCRIPTION
Backslashes should escape backslashes. Example of currently incorrectly highlighted code:

```js
var a = "\\";
var b = '\\';
var c = `\\`;
```

[on rouge.jneen.net](http://rouge.jneen.net/v4.0.0/javascript/dmFyIGEgPSAiXFwiOwp2YXIgYiA9ICdcXCc7CnZhciBjID0gYFxcYDs)