### PR TITLE
Accept colon(s) in YAML key names

### DIFF
--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -175,7 +175,7 @@ module Rouge
 
       state :block_nodes do
         # implicit key
-        rule %r/([^#,:?\[\]{}"'\n]+)(:)(?=\s|$)/ do |m|
+        rule %r/([^#,?\[\]{}"'\n]+)(:)(?=\s|$)/ do |m|
           groups Name::Attribute, Punctuation::Indicator
           set_indent m[0], :implicit => true
         end

--- a/spec/visual/samples/yaml
+++ b/spec/visual/samples/yaml
@@ -358,3 +358,4 @@ Stack:
 foo/bar: We are great
 foo.bar: Are we really?
 foo+bar: Maybe not
+foo:bar: ...or maybe we are?


### PR DESCRIPTION
as it's ok according to the YAML specs and is widely used in the real world, f.e. in Puppet's Hiera
(https://puppet.com/docs/puppet/7/hiera_quick.html#values_common_data)