### PR TITLE
Add support for the HTTP QUERY method

### DIFF
--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -11,7 +11,7 @@ module Rouge
       option :content, "the language for the content (default: auto-detect)"
 
       def self.http_methods
-        @http_methods ||= %w(GET POST PUT DELETE HEAD OPTIONS TRACE PATCH)
+        @http_methods ||= %w(GET POST PUT DELETE HEAD OPTIONS TRACE PATCH QUERY)
       end
 
       def content_lexer

--- a/spec/lexers/http_spec.rb
+++ b/spec/lexers/http_spec.rb
@@ -15,8 +15,19 @@ describe Rouge::Lexers::HTTP do
                                  ["Operator", "/"],
                                  ["Literal.Number", "2"]
   end
-  
-  it 'lexes a HTTP/1.1 request' do
+
+  it 'lexes a HTTP/1.1 QUERY request' do
+    request = "QUERY / HTTP/1.1"
+    assert_tokens_equal request, ["Name.Function", "QUERY"],
+                                 ["Text", " "],
+                                 ["Name.Namespace", "/"],
+                                 ["Text", " "],
+                                 ["Keyword", "HTTP"],
+                                 ["Operator", "/"],
+                                 ["Literal.Number", "1.1"]
+  end
+
+  it 'lexes a HTTP/1.1 GET request' do
     request = "GET / HTTP/1.1"
     assert_tokens_equal request, ["Name.Function", "GET"],
                                  ["Text", " "],
@@ -30,7 +41,7 @@ describe Rouge::Lexers::HTTP do
   it 'lexes an empty HTTP/1.1 response' do
     response = "HTTP/1.1 200 "
     assert_tokens_equal response, ["Keyword", "HTTP"],
-                                  ["Operator", "/"], 
+                                  ["Operator", "/"],
                                   ["Literal.Number", "1.1"],
                                   ["Text", " "],
                                   ["Literal.Number", "200"],
@@ -40,7 +51,7 @@ describe Rouge::Lexers::HTTP do
   it 'lexes an empty HTTP/2 response' do
     response = "HTTP/2 200 "
     assert_tokens_equal response, ["Keyword", "HTTP"],
-                                  ["Operator", "/"], 
+                                  ["Operator", "/"],
                                   ["Literal.Number", "2"],
                                   ["Text", " "],
                                   ["Literal.Number", "200"],


### PR DESCRIPTION
The [HTTP `QUERY` method](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html) is a new method being drafted in the IETF HTTP working group. This PR adds support for it.

I was a bit unsure where to add a test for the method as I couldn't find extensive tests for the already supported methods. Please point me in the right direction if you think `QUERY` should be tested differently.

## Before
![](https://user-images.githubusercontent.com/12283/205669064-a6168071-e94d-40e5-8028-c2805ae25b3d.png)

## After
![](https://user-images.githubusercontent.com/12283/205669263-f700570b-8890-4f8d-bff5-abf439b91d84.png)
