### PR TITLE
Improve disambiguation rules on .pp extension

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -133,7 +133,8 @@ module Rouge
       end
 
       disambiguate '*.pp' do
-        next Pascal if matches?(/\b(function|begin|var)\b/)
+        next Puppet if matches?(/(::)?([a-z]\w*::)/)
+        next Pascal if matches?(/^(function|begin|var)\b/)
         next Pascal if matches?(/\b(end(;|\.))/)
 
         Puppet

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -103,8 +103,8 @@ describe Rouge::Guesser do
               Array[String] = foo::bar::baz,
             ) {
               $foo = [
-                'bar',
-                'baz',
+                'var',
+                'end.',
               ]
             }
           SOURCE


### PR DESCRIPTION
This tightens the disambiguation around `.pp` extension that is shared between Puppet and Pascal lexer.

- Add qualified names check for Puppet
- Ensure Pascal keywords are at the start of strings

Closes https://github.com/rouge-ruby/rouge/issues/1866