### PR TITLE
Allow quoteless continuations in Systemd

### DIFF
--- a/lib/rouge/lexers/systemd.rb
+++ b/lib/rouge/lexers/systemd.rb
@@ -27,7 +27,7 @@ module Rouge
         rule %r/(.*?)(\\\n)/ do
           groups Text, Str::Escape
         end
-        rule %r/(.*)'/, Text, :pop!
+        rule %r/(.*)'?/, Text, :pop!
       end
     end
   end

--- a/spec/lexers/systemd_spec.rb
+++ b/spec/lexers/systemd_spec.rb
@@ -15,4 +15,26 @@ describe Rouge::Lexers::SystemD do
       assert_guess :mimetype => 'text/x-systemd-unit'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'handles continuations without quotes' do
+      systemd_file = <<~SYSTEMD
+        [Service]
+        ExecStart=/exec \\
+                  without-a-quote
+      SYSTEMD
+
+      assert_no_errors systemd_file
+      assert_tokens_equal systemd_file,
+        ['Keyword', '[Service]'],
+        ['Text', "\n"],
+        ['Name.Tag', 'ExecStart'],
+        ['Punctuation', '='],
+        ['Text', '/exec '],
+        ['Literal.String.Escape', "\\\n"],
+        ['Text', "          without-a-quote\n"]
+    end
+  end
 end

--- a/spec/visual/samples/systemd
+++ b/spec/visual/samples/systemd
@@ -1,5 +1,7 @@
 [Unit]
-Description=Snap Daemon
+Description=Snap Daemon \
+            with a continued \
+            description
 Requires=snapd.socket
 OnFailure=snapd.failure.service
 # This is handled by snapd


### PR DESCRIPTION
When continuing a command on the next line, Systemd's file format allows you to elide the quote if you're escaping the newline.

This change enables support for this syntax.