### PR TITLE
Fix handling of Powershell subexpressions in interpolation

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -182,6 +182,10 @@ module Rouge
 
       state :parameters do
         rule %r/`./m, Str::Escape
+        rule %r/\)/ do
+          token Punctuation
+          pop!(2) if in_state?(:interpol) # pop :parameters and :interpol
+        end
         rule %r/\s*?\n/, Text::Whitespace, :pop!
         rule %r/[;(){}\]]/, Punctuation, :pop!
         rule %r/[|=]/, Operator, :pop!

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -215,6 +215,7 @@ Function Get-IPv4Scopes
 } #end function
 
 Write-Output "Updating: $($file.FullName)"
+Write-Output "PowerShell PID: $(Get-Process powershell | Select -ExpandProperty Id) and Notepad PID: $(Get-Process notepad | Select -ExpandProperty Id)"
 # $content = Get-Content $file.FullName
 
 # Without Error
@@ -228,3 +229,23 @@ Write-Output `$hello
 
 # Where-Object alias
 Get-process | ? {$_.workingset -gt 25000*1024}
+
+# Handle subexpressions nested within strings
+function Write-Log {
+    Param(
+        $Message,
+        $Path = "L:\IISSiteAudit.txt"
+    )
+
+    function TS { return "[{0:MM/dd/yy} {0:HH:mm:ss}]" -f (Get-Date) }
+    "$(TS) $Message" | Tee-Object -FilePath $Path -Append | Write-Verbose
+}
+
+function NewVMSnapshot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$VM,
+        [string[]]$Name = (Get-Date -Format 'yyyy-MM-dd_HH:mm:ss') + "_$VM",
+        [string[]]$Description = "`Snapshot taken via $(Split-Path $PSCommandPath -leaf) by $global:vsphereuser."
+    )
+}


### PR DESCRIPTION
The closing bracket of the subexpression only pops out of the `parameters` state instead of the whole `interpol` state. This change ensures the closing bracket of the subexpression pops out of the `interpol` state.

| Before | After |
| -- | -- |
|  ![Screenshot 2022-12-05 at 10 43 55 am](https://user-images.githubusercontent.com/756722/205523147-35a7f4c7-5eb4-4867-9768-ac6841a561cc.png) | ![Screenshot 2022-12-05 at 10 41 38 am](https://user-images.githubusercontent.com/756722/205523040-ed22bc32-3579-4e57-9988-e11b5366d54b.png) |

- Supersedes https://github.com/rouge-ruby/rouge/pull/1758
- Closes https://github.com/rouge-ruby/rouge/issues/1757