### PR TITLE
Handle common line continuation in PS

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -240,6 +240,8 @@ module Rouge
 
         rule %r/[-+*\/%=!.&|]/, Operator
         rule %r/[{}(),:;]/, Punctuation
+
+        rule %r/`$/, Str::Escape # line continuation
       end
     end
   end

--- a/spec/visual/samples/powershell
+++ b/spec/visual/samples/powershell
@@ -249,3 +249,10 @@ function NewVMSnapshot {
         [string[]]$Description = "`Snapshot taken via $(Split-Path $PSCommandPath -leaf) by $global:vsphereuser."
     )
 }
+
+# Handle line continuation in string interpolation
+Get-CimInstance -ComputerName localhost win32_logicaldisk `
+| where caption -eq "C:" `
+| foreach-object {write " $($_.caption) $('{0:N2}' `
+-f ($_.Size/1gb)) GB total, $('{0:N2}' `
+-f ($_.FreeSpace/1gb)) GB free "}


### PR DESCRIPTION
This fixes error with line continuation character in the middle of the string interpolation.

| Before | After |
| -- | -- |
| ![Screenshot 2022-12-05 at 10 59 12 am](https://user-images.githubusercontent.com/756722/205523873-b9b79845-ab3b-484e-a017-b3771ba4818c.png) |  ![Screenshot 2022-12-05 at 10 59 27 am](https://user-images.githubusercontent.com/756722/205523884-c3ce44fc-2d1d-40ae-b6d8-652eab7c6e6a.png)|

