### PR TITLE
Extract regex to constant in HTML formatter

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -5,6 +5,14 @@ module Rouge
   module Formatters
     # Transforms a token stream into HTML output.
     class HTML < Formatter
+      TABLE_FOR_ESCAPE_HTML = {
+        '&' => '&amp;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+      }.freeze
+
+      ESCAPE_REGEX = /[&<>]/.freeze
+
       tag 'html'
 
       # @yield the html output.
@@ -22,20 +30,14 @@ module Rouge
         if tok == Token::Tokens::Text
           safe_val
         else
-          shortname = tok.shortname \
-            or raise "unknown token: #{tok.inspect} for #{safe_val.inspect}"
+          shortname = tok.shortname or raise "unknown token: #{tok.inspect} for #{safe_val.inspect}"
 
           "<span class=\"#{shortname}\">#{safe_val}</span>"
         end
       end
 
-      TABLE_FOR_ESCAPE_HTML = {
-        '&' => '&amp;',
-        '<' => '&lt;',
-        '>' => '&gt;',
-      }
+      private
 
-    private
       # A performance-oriented helper method to escape `&`, `<` and `>` for the rendered
       # HTML from this formatter.
       #
@@ -46,10 +48,9 @@ module Rouge
       # Returns either the given `value` argument string as is or a new string with the
       # special characters replaced with their escaped counterparts.
       def escape_special_html_chars(value)
-        escape_regex = /[&<>]/
-        return value unless value =~ escape_regex
+        return value unless value =~ ESCAPE_REGEX
 
-        value.gsub(escape_regex, TABLE_FOR_ESCAPE_HTML)
+        value.gsub(ESCAPE_REGEX, TABLE_FOR_ESCAPE_HTML)
       end
     end
   end


### PR DESCRIPTION
This helps to reduce multiple instantiations of escape regex variables in the HTML formatter. Also, add some stylish changes around the indentation. 

This PR extracts partial changes proposed in https://github.com/rouge-ruby/rouge/pull/1670 by @robotmay.

I have verified that the change does not affect the HTML output via the visual tester.

![Screenshot 2022-12-14 at 10 20 46 am](https://user-images.githubusercontent.com/756722/207466320-ec567038-3e1d-4dc0-aa6d-b8626ac4cdde.png)



