### PR TITLE
Use File.basename instead sub to correctly handle long paths on Windows

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -47,11 +47,9 @@ module Rouge
     #
     # @api private
     def load_lexers
-      # The trailing slash is necessary to avoid lexers being loaded multiple
-      # times by `Lexers.load_lexer`
-      lexer_dir = File.join(LIB_DIR, "rouge/lexers/")
-      Dir.glob(File.join(lexer_dir, '*.rb')).each do |f|
-        Lexers.load_lexer(f.sub(lexer_dir, ''))
+      lexer_dir = Pathname.new(LIB_DIR) / "rouge/lexers"
+      Pathname.glob(lexer_dir / '*.rb').each do |f|
+        Lexers.load_lexer(f.relative_path_from(lexer_dir))
       end
     end
   end


### PR DESCRIPTION
### Problem

Recently I faced a crash on windows:

```
C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge/lexer.rb:532:in `load': cannot load such file -- C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge/lexers/C:/Users/runneradmin/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge/lexers/abap.rb (LoadError)
	from C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge/lexer.rb:532:in `load_lexer'
	from C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge.rb:54:in `block in load_lexers'
	from C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge.rb:53:in `each'
	from C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge.rb:53:in `load_lexers'
	from C:/Users/RUNNER~1/AppData/Local/Temp/ocr219E.tmp/lib/ruby/gems/2.7.0/gems/rouge-4.0.1/lib/rouge.rb:69:in `<top (required)>'
```

It looks like `__dir__` may return a short username (or path) `RUNNER~1` instead `runneradmin` as result this prefix not "stripped"

### Proposed solution

There is more reliable way to get filename instead `f.sub(...)` i.e. use `File.basename`