### PR TITLE
Support attributes in PHP lexer

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -211,7 +211,7 @@ module Rouge
 
       state :whitespace do
         rule %r/\s+/, Text
-        rule %r/#.*?$/, Comment::Single
+        rule %r/#[^\[].*?$/, Comment::Single
         rule %r(//.*?$), Comment::Single
         rule %r(/\*\*(?!/).*?\*/)m, Comment::Doc
         rule %r(/\*.*?\*/)m, Comment::Multiline
@@ -234,6 +234,8 @@ module Rouge
                 (#{id_with_ns})/ix do |m|
           groups Keyword::Namespace, Text, Name::Namespace
         end
+
+        rule %r/#\[.*\]$/, Name::Attribute
 
         rule %r/(class|interface|trait|extends|implements)
                 (\s+)

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -341,3 +341,25 @@ class Test {
 <?php endif ?>
 
 <p>it's html here at the end, too.</p>
+
+
+/* Attributes */
+
+<?php
+
+#[MyAttribute]
+#[\MyExample\MyAttribute]
+#[MyAttribute(1234)]
+#[MyAttribute(value: 1234)]
+#[MyAttribute(MyAttribute::VALUE)]
+#[MyAttribute(array("key" => "value"))]
+#[MyAttribute(100 + 200)]
+class SetUp {
+   #[JsonSerialize('Setup')]
+   public const version = '0.0.1';
+
+   #[SetUp]
+   public function fileExists() {}
+}
+
+?>


### PR DESCRIPTION
This PR adds highlight for [PHP Attributes](https://www.php.net/manual/en/language.attributes.overview.php).

![Screenshot 2023-01-18 at 12 14 32 am](https://user-images.githubusercontent.com/756722/212908278-3756a09d-6541-4f40-a1fc-23a88d5bd7ee.png)

Resolves https://github.com/rouge-ruby/rouge/issues/1759