### PR TITLE
php: fix highlight of fully-qualified identifiers (fix #1718)

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -66,7 +66,7 @@ module Rouge
 
       id = /[\p{L}_][\p{L}\p{N}_]*/
       ns = /(?:#{id}\\)+/
-      id_with_ns = /(?:#{ns})?#{id}/
+      id_with_ns = /\\?(?:#{ns})?#{id}/
 
       start do
         case @start_inline
@@ -273,7 +273,7 @@ module Rouge
       state :in_catch do
         rule %r/\(/, Punctuation
         rule %r/\|/, Operator
-        rule id, Name::Class
+        rule id_with_ns, Name::Class
         mixin :escape
         mixin :whitespace
         mixin :return

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -324,6 +324,8 @@ class Test {
             throw new MyException();
         } catch (MyException | MyOtherException $e) {
             var_dump(get_class($e));
+        } catch (\Exception $x) {
+            throw $x;
         }
     }
 }
@@ -360,6 +362,9 @@ class SetUp {
 
    #[SetUp]
    public function fileExists() {}
+}
+
+function f(\Ns1\Ns2\Ns3\Class $x) {
 }
 
 ?>


### PR DESCRIPTION
It will fix #1718.

# Screenshots

## Before

![Screenshot from 2023-01-28 22-39-46](https://user-images.githubusercontent.com/54318333/215269556-81c609a6-0e33-46aa-bc1e-b312e0651984.png)
![Screenshot from 2023-01-28 22-39-08](https://user-images.githubusercontent.com/54318333/215269566-c3c6c846-43b6-4c6d-ad89-28b22ba4f2f2.png)

## After

![Screenshot from 2023-01-28 22-40-01](https://user-images.githubusercontent.com/54318333/215269577-cf585baf-5d2b-486d-a800-aeb1464acfa0.png)
![Screenshot from 2023-01-28 22-40-20](https://user-images.githubusercontent.com/54318333/215269582-ead35e09-8e1d-4f02-84f5-7b18fde4d993.png)


