### PR TITLE
Fixes for base16 theme

### DIFF
--- a/lib/rouge/themes/base16.rb
+++ b/lib/rouge/themes/base16.rb
@@ -63,7 +63,8 @@ module Rouge
 
       style Keyword::Constant,
             Keyword::Declaration,
-            Keyword::Type, :fg => :base09
+            Keyword::Type,
+            Literal::Number, :fg => :base09
 
       style Comment::Preproc,
             Name::Class,
@@ -72,7 +73,6 @@ module Rouge
             Name::Tag, :fg => :base0A
 
       style Generic::Inserted,
-            Literal::Number,
             Literal::String,
             Literal::String::Symbol, :fg => :base0B
 

--- a/lib/rouge/themes/base16.rb
+++ b/lib/rouge/themes/base16.rb
@@ -49,43 +49,43 @@ module Rouge
       light!
 
       style Error, :fg => :base00, :bg => :base08
-      style Comment, :fg => :base03
 
-      style Comment::Preproc,
-            Name::Tag, :fg => :base0A
+      style Comment, :fg => :base03
 
       style Operator,
             Punctuation, :fg => :base05
 
-      style Generic::Inserted, :fg => :base0B
       style Generic::Deleted, :fg => :base08
-      style Generic::Heading, :fg => :base0D, :bg => :base00, :bold => true
 
       style Generic::Emph, :italic => true
       style Generic::EmphStrong, :italic => true, :bold => true
       style Generic::Strong, :bold => true
 
-      style Keyword, :fg => :base0E
       style Keyword::Constant,
+            Keyword::Declaration,
             Keyword::Type, :fg => :base09
 
-      style Keyword::Declaration, :fg => :base09
+      style Comment::Preproc,
+            Name::Class,
+            Name::Constant,
+            Name::Namespace,
+            Name::Tag, :fg => :base0A
 
-      style Literal::String, :fg => :base0B
-      style Literal::String::Affix, :fg => :base0E
+      style Generic::Inserted,
+            Literal::Number,
+            Literal::String,
+            Literal::String::Symbol, :fg => :base0B
+
       style Literal::String::Regex, :fg => :base0C
 
-      style Literal::String::Interpol,
-            Literal::String::Escape, :fg => :base0F
-
-      style Name::Namespace,
-            Name::Class,
-            Name::Constant, :fg => :base0A
-
       style Name::Attribute, :fg => :base0D
+      style Generic::Heading, :fg => :base0D, :bg => :base00, :bold => true
 
-      style Literal::Number,
-            Literal::String::Symbol, :fg => :base0B
+      style Keyword,
+            Literal::String::Affix, :fg => :base0E
+
+      style Literal::String::Escape,
+            Literal::String::Interpol, :fg => :base0F
 
       class Solarized < Base16
         name 'base16.solarized'

--- a/lib/rouge/themes/base16.rb
+++ b/lib/rouge/themes/base16.rb
@@ -55,7 +55,8 @@ module Rouge
       style Operator,
             Punctuation, :fg => :base05
 
-      style Generic::Deleted, :fg => :base08
+      style Generic::Deleted,
+            Name, :fg => :base08
 
       style Generic::Emph, :italic => true
       style Generic::EmphStrong, :italic => true, :bold => true
@@ -78,7 +79,8 @@ module Rouge
 
       style Literal::String::Regex, :fg => :base0C
 
-      style Name::Attribute, :fg => :base0D
+      style Name::Attribute,
+            Name::Function, :fg => :base0D
       style Generic::Heading, :fg => :base0D, :bg => :base00, :bold => true
 
       style Keyword,


### PR DESCRIPTION
## Background

Commits are split into refactor/changes/additions, so reviewing them individually should be much easier than the final diff.

Base16 ruby code highlighting reference: https://base16.vercel.app/previews/base16-default-dark

There are still a few discrepancies between the After and the reference highlighting:
- In the base16 reference, `require` is highlighted like a keyword and `attr_accessor`, `print`, and `puts` are highlighted like methods, but the Rouge ruby lexer defines all of these as `Name::Builtin`. I think most of the Rouge's ruby `Name::Builtin` should just be removed so that they can just be methods, but that isn't related to the Base16 theme.
- `self` is correctly highlighted like a keyword in the reference, but the lexer currently says its a `Name::Class`.
- Rouge has `Person::name` as a `Name`, but I _think_ it should be possible to update the lexer to correctly identity them as `Name::Function`

## Example Screenshots

Before:

![image](https://user-images.githubusercontent.com/6014046/215639949-1944078f-6932-4eea-a9d9-a855871fd350.png)

After:

![image](https://user-images.githubusercontent.com/6014046/215639844-2055698f-44af-498f-a09b-a0802a1c92e9.png)