### PR TITLE
Fix already initialized constant warning in YAML

### DIFF
--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -18,8 +18,6 @@ module Rouge
         return true if text =~ /\A\s*%YAML/m
       end
 
-      SPECIAL_VALUES = Regexp.union(%w(true false null))
-
       # NB: Tabs are forbidden in YAML, which is why you see things
       # like /[ ]+/.
 
@@ -340,7 +338,7 @@ module Rouge
         end
 
         rule %r/[ ]+/, Str
-        rule SPECIAL_VALUES, Name::Constant
+        rule %r((true|false|null)\b), Keyword::Constant
         rule %r/\d+(?:\.\d+)?(?=(\r?\n)| +#)/, Literal::Number, :pop!
 
         # regular non-whitespace characters


### PR DESCRIPTION
This PRs fixes an already initialized constant warning in YAML lexer.

```shell
$ bundle exec rake check:specs
/home/runner/work/rouge/rouge/lib/rouge/lexers/yaml.rb:21: warning: already initialized constant Rouge::Lexers::YAML::SPECIAL_VALUES
/home/runner/work/rouge/rouge/lib/rouge/lexers/yaml.rb:21: warning: previous definition of SPECIAL_VALUES was here
<snipped>
```