### PR TITLE
Fix highlight of functions in CPP lexer

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -71,7 +71,11 @@ module Rouge
         rule %r/\bnullptr\b/, Name::Builtin
         rule %r/(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
         rule %r/(::|<=>)/, Operator
-        rule %r/[{}]/, Punctuation
+        rule %r/[{]/, Punctuation
+        rule %r/}/ do
+          token Punctuation
+          pop! if in_state?(:function) # pop :function
+        end
       end
 
       state :classname do


### PR DESCRIPTION
This fixes a bug where closing bracket does not pops out of the function state and causes subsequent functions not to be highlighted correctly. This change ensures closing bracket in statements mixin is detecting function state.