### PR TITLE
Add Cisco IOS lexer to Languages doc

### DIFF
--- a/docs/Languages.md
+++ b/docs/Languages.md
@@ -25,6 +25,7 @@
 - C (`c`)
 - Ceylon (`ceylon`)
 - CFScript (`cfscript`)
+- Cisco IOS (`cisco_ios`)
 - Clean (`clean`)
 - Clojure (`clojure`)
 - CMake (`cmake`)


### PR DESCRIPTION
We have already added Cisco IOS lexer in https://github.com/rouge-ruby/rouge/pull/1875. This PR adds it to the list of supported languages.