### PR TITLE
Support doctest in Python lexer

### DIFF
--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -173,3 +173,37 @@ class Spam:
     pass
 
 spam = Spam()
+
+# Doctest
+def factorial(n):
+    """Return the factorial of n, an exact integer >= 0.
+
+    >>> [factorial(n) for n in range(6)]
+    [1, 1, 2, 6, 24, 120]
+
+    >>> for i in [factorial(n) for n in range(2)]:
+    ...     print(i)
+    1
+    1
+    >>> factorial(30)
+    265252859812191058636308480000000
+    >>> factorial(-1)
+    Traceback (most recent call last):
+        ...
+    ValueError: n must be >= 0
+
+    Factorials of floats are OK, but the float must be an exact integer:
+    >>> factorial(30.1)
+    Traceback (most recent call last):
+        ...
+    ValueError: n must be exact integer
+    >>> factorial(30.0)
+    265252859812191058636308480000000
+
+    It must also not be ridiculously large:
+    >>> factorial(1e100)
+    Traceback (most recent call last):
+        ...
+    OverflowError: n too large
+    """
+    print("hello world")


### PR DESCRIPTION
Add support to highlight [`doctest`](https://docs.python.org/3/library/doctest.html?highlight=doctest#module-doctest) in Python lexer.

| Before | After |
| -- | -- |
|![before](https://user-images.githubusercontent.com/756722/218653277-2af4e286-72b4-478a-acf8-d8d72a106d1b.png) |  ![after](https://user-images.githubusercontent.com/756722/219923291-6ad49d74-94ce-434b-914c-3707e77f0145.png) | 

Resolves https://github.com/rouge-ruby/rouge/issues/920