### PR TITLE
Add basic support for Dart 3 features

### DIFF
--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -53,7 +53,7 @@ module Rouge
         rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
         rule %r/(?:#{types.join('|')})\b/, Keyword::Type
         rule %r/(?:true|false|null)\b/, Keyword::Constant
-        rule %r/(?:class|interface|mixin)\b/, Keyword::Declaration, :class
+        rule %r/(?:class|mixin)\b/, Keyword::Declaration, :class
         rule %r/(?:#{imports.join('|')})\b/, Keyword::Namespace, :import
         rule %r/(\.)(#{id})/ do
           groups Operator, Name::Attribute

--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -12,16 +12,16 @@ module Rouge
       mimetypes 'text/x-dart'
 
       keywords = %w(
-        as assert await break case catch continue default do else finally for
-        if in is new rethrow return super switch this throw try while with yield
+        as assert await break case catch continue default do else finally for if
+        in is new rethrow return super switch this throw try while when with yield
       )
 
       declarations = %w(
-        abstract async dynamic const covariant external extends factory final get
-        implements late native on operator required set static sync typedef var
+        abstract base async dynamic const covariant external extends factory final get implements
+        inline interface late native on operator required sealed set static sync typedef var
       )
 
-      types = %w(bool Comparable double Dynamic enum Function int List Map Never Null num Object Pattern Set String Symbol Type Uri void)
+      types = %w(bool Comparable double Dynamic enum Function int List Map Never Null num Object Pattern Record Set String Symbol Type Uri void)
 
       imports = %w(import deferred export library part\s*of part source)
 


### PR DESCRIPTION
Adds support for keywords from following features (with links to their feature specifications):

- The `when` keyword from [patterns](https://github.com/dart-lang/language/blob/master/accepted/future-releases/0546-patterns/feature-specification.md)
- The declaration keywords:
  - `base` and `interface` from [class modifiers](https://github.com/dart-lang/language/blob/master/accepted/future-releases/class-modifiers/feature-specification.md)
  - `sealed` from [sealed types](https://github.com/dart-lang/language/blob/master/accepted/future-releases/sealed-types/feature-specification.md)
  - `inline` from [inline classes](https://github.com/dart-lang/language/tree/master/accepted/future-releases/inline-classes)
- The `Record` type from [records](https://github.com/dart-lang/language/blob/master/accepted/future-releases/records/records-feature-specification.md)

Also removes the old `interface` from the `:class` declarations, since `interface` never existed in that form, it is instead a declaration modifier, similar to `abstract`.