### PR TITLE
Delete buggy detection for Mosel

### DIFF
--- a/lib/rouge/lexers/mosel.rb
+++ b/lib/rouge/lexers/mosel.rb
@@ -13,10 +13,6 @@ module Rouge
 
       mimetypes 'text/x-mosel'
 
-      def self.detect?(text)
-        return true if text =~ /^\s*(model|package)\s+/
-      end
-
       id = /[a-zA-Z_][a-zA-Z0-9_]*/
 
       ############################################################################################################################


### PR DESCRIPTION
The “Lexer Development” doc says:

    It is important to note that self.detect? should only return true if it is
    100% sure that the language is detected.

The specified function matches any file containing the words “model” or “package” at the beginning of a line, which misfires quite a lot!

Regularly spotted with debian/changelog files on https://salsa.debian.org/ (powered by GitLab).

---

In passing, http://rouge.jneen.net/ (mentioned in the About section) is unreachable.