### PR TITLE
javascript: Fix an issue where some keywords like "for" and "if" are mistakenly recognized as functions

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -190,7 +190,14 @@ module Rouge
 
         rule %r/function(?=(\(.*\)))/, Keyword::Declaration # For anonymous functions
 
-        rule %r/(#{id})[ \t]*(?=(\(.*\)))/m, Name::Function
+        rule %r/(#{id})[ \t]*(?=(\(.*\)))/m do |m|
+          if self.class.keywords.include? m[1]
+            # "if" in "if (...)" or "switch" in "switch (...)" are recognized as keywords.
+            token Keyword
+          else
+            token Name::Function
+          end
+        end
 
         rule %r/[{}]/, Punctuation, :statement
 


### PR DESCRIPTION
It fixes #1934. Some keywords like `for` and `if` in JavaScript are mistakenly recognized as functions.

Check if the matched function name is one of the keywords or not.