### PR TITLE
irb lexer: recognize the SIMPLE prompt

### DIFF
--- a/lib/rouge/lexers/irb.rb
+++ b/lib/rouge/lexers/irb.rb
@@ -23,7 +23,13 @@ module Rouge
       end
 
       def prompt_regex
-        /^.*?(irb|pry|>).*?[>"*]/
+        %r(
+          ^.*?
+          (
+            (irb|pry).*?[>"*] |
+            [>"*]>
+          )
+        )x
       end
 
       def allow_comments?

--- a/lib/rouge/lexers/irb.rb
+++ b/lib/rouge/lexers/irb.rb
@@ -23,7 +23,7 @@ module Rouge
       end
 
       def prompt_regex
-        /^.*?(irb|pry).*?[>"*]/
+        /^.*?(irb|pry|>).*?[>"*]/
       end
 
       def allow_comments?

--- a/spec/lexers/irb_spec.rb
+++ b/spec/lexers/irb_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::IRBLexer do
+  let(:subject) { Rouge::Lexers::IRBLexer.new }
+  let(:klass) { Rouge::Lexers::IRBLexer }
+
+  include Support::Lexing
+  
+  it "parses IRB's :DEFAULT prompt" do
+    assert_tokens_equal 'irb(main):001:0> self',
+      ['Generic.Prompt', 'irb(main):001:0>'],
+      ['Text.Whitespace', ' '],
+      ['Name.Builtin', 'self']
+  end
+  
+  it "parses IRB's :SIMPLE prompt" do
+    assert_tokens_equal '>> self',
+      ['Generic.Prompt', '>>'],
+      ['Text.Whitespace', ' '],
+      ['Name.Builtin', 'self']
+  end
+  
+  it "parses Pry's default prompt" do
+    assert_tokens_equal 'pry(main)> self',
+      ['Generic.Prompt', 'pry(main)>'],
+      ['Text.Whitespace', ' '],
+      ['Name.Builtin', 'self']
+  end
+end


### PR DESCRIPTION
I'm used to IRB's "simple" prompt (`>>`), and found out while writing documentation that Rouge didn't support it yet. So this PR basically adds it. Cheers!