### PR TITLE
Fix string interpolation in Ruby percent literal

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -42,7 +42,7 @@ module Rouge
         rule %r/%([rqswQWxiI])?([^\w\s])/ do |m|
           open = Regexp.escape(m[2])
           close = Regexp.escape(delimiter_map[m[2]] || m[2])
-          interp = /[rQWxI]/ === m[1]
+          interp = /[rQWxI]/ === m[1] || !m[1]
           toktype = Str::Other
 
           puts "    open: #{open.inspect}" if @debug

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -329,6 +329,8 @@ X "foo" # This is a method call, heredoc ends at the prev line
 
 %q[haha! [nesting [rocks] ! ] ] # commeht here
 
+%(a #{interpolation_variable} b)
+%Q(a #{interpolation_variable} b)
 
 ##################################################################
 class                                                  NP


### PR DESCRIPTION
This PR fixes string interpolation in Ruby's percent literal `%`.

| Before | After |
| -- | -- |
| ![before](https://user-images.githubusercontent.com/756722/235347243-bc725011-7773-44e2-b9e1-a6b09b4827ad.png) | ![after](https://user-images.githubusercontent.com/756722/235347241-fdbf2a06-59d1-42e5-b797-ccf84373891b.png) | 

Closes #1944