### PR TITLE
Swift 5.8 and 5.9 updates

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -15,7 +15,7 @@ module Rouge
       id = /#{id_head}#{id_rest}*/
 
       keywords = Set.new %w(
-        autoreleasepool await break case catch continue default defer do else fallthrough guard if in for repeat return switch throw try where while
+        autoreleasepool await break case catch consume continue default defer discard do each else fallthrough guard if in for repeat return switch throw try where while
 
         as dynamicType is new super self Self Type
 
@@ -23,7 +23,7 @@ module Rouge
       )
 
       declarations = Set.new %w(
-        actor any associatedtype class deinit distributed dynamic enum convenience extension fileprivate final func import indirect init internal lazy let nonisolated open optional private protocol public required some static struct subscript typealias var
+        actor any associatedtype borrowing class consuming deinit distributed dynamic enum convenience extension fileprivate final func import indirect init internal lazy let macro nonisolated open optional package private protocol public required some static struct subscript typealias var
       )
 
       constants = Set.new %w(
@@ -71,6 +71,7 @@ module Rouge
         
         rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
         rule %r/\$#{id}/, Name
+        rule %r/~Copyable\b/, Keyword::Type
 
         rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r{(#*)/(?!\s).*(?<![\s\\])/\1}, Str::Regex
@@ -85,6 +86,7 @@ module Rouge
         rule %r{[\d]+(?:_\d+)*}, Num::Integer
 
         rule %r/@#{id}/, Keyword::Declaration
+        rule %r/##{id}/, Keyword
 
         rule %r/(private|internal)(\([ ]*)(\w+)([ ]*\))/ do |m|
           if m[3] == 'set'
@@ -101,14 +103,6 @@ module Rouge
             groups Keyword::Declaration, Error, Keyword::Declaration
           end
         end
-
-        rule %r/#(?:un)?available\([^)]+\)/, Keyword::Declaration
-
-        rule %r/(#(?:selector|keyPath)\()([^)]+?(?:[(].*?[)])?)(\))/ do
-          groups Keyword::Declaration, Name::Function, Keyword::Declaration
-        end
-
-        rule %r/#(line|file|fileID|filePath|column|function|dsohandle)/, Keyword::Declaration
 
         rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -15,17 +15,15 @@ module Rouge
       id = /#{id_head}#{id_rest}*/
 
       keywords = Set.new %w(
-        await break case continue default do else fallthrough if in for return switch where while try catch throw guard defer repeat
+        await break case continue default do else fallthrough if in for return switch where while try catch throw guard defer repeat autoreleasepool
 
-        as dynamicType is new super self Self Type __COLUMN__ __FILE__ __FUNCTION__ __LINE__
+        as dynamicType is new super self Self Type
 
-        associativity async didSet get infix inout isolated mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup
-
-        #available #colorLiteral #column #else #elseif #endif #error #file #fileLiteral #function #if #imageLiteral #line #selector #sourceLocation #warning
+        associativity async didSet get infix inout isolated mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup left right
       )
 
       declarations = Set.new %w(
-        actor class deinit enum convenience extension final func import init internal lazy let nonisolated optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some
+        actor class deinit enum convenience extension final func import init internal lazy let nonisolated optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some any distributed
       )
 
       constants = Set.new %w(
@@ -69,6 +67,7 @@ module Rouge
         mixin :whitespace
         
         rule %r/\$(([1-9]\d*)?\d)/, Name::Variable
+        rule %r/\$#{id}/, Name
 
         rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r([-/=+*%<>!&|^.~]+), Operator
@@ -99,13 +98,13 @@ module Rouge
           end
         end
 
-        rule %r/#available\([^)]+\)/, Keyword::Declaration
+        rule %r/#(?:un)?available\([^)]+\)/, Keyword::Declaration
 
         rule %r/(#(?:selector|keyPath)\()([^)]+?(?:[(].*?[)])?)(\))/ do
           groups Keyword::Declaration, Name::Function, Keyword::Declaration
         end
 
-        rule %r/#(line|file|column|function|dsohandle)/, Keyword::Declaration
+        rule %r/#(line|file|fileID|filePath|column|function|dsohandle)/, Keyword::Declaration
 
         rule %r/(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -15,15 +15,15 @@ module Rouge
       id = /#{id_head}#{id_rest}*/
 
       keywords = Set.new %w(
-        await break case continue default do else fallthrough if in for return switch where while try catch throw guard defer repeat autoreleasepool
+        autoreleasepool await break case catch continue default defer do else fallthrough guard if in for repeat return switch throw try where while
 
         as dynamicType is new super self Self Type
 
-        associativity async didSet get infix inout isolated mutating none nonmutating operator override postfix precedence prefix set unowned weak willSet throws rethrows precedencegroup left right
+        associativity async didSet get infix inout isolated left mutating none nonmutating operator override postfix precedence precedencegroup prefix rethrows right set throws unowned weak willSet
       )
 
       declarations = Set.new %w(
-        actor class deinit enum convenience extension final func import init internal lazy let nonisolated optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype open fileprivate some any distributed
+        actor any associatedtype class deinit distributed dynamic enum convenience extension fileprivate final func import indirect init internal lazy let nonisolated open optional private protocol public required some static struct subscript typealias var
       )
 
       constants = Set.new %w(

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -249,8 +249,9 @@ repeat {
 if #available(iOS 8.0, OSX 10.10, *) {
    // Use Handoff APIs when available.
    let activity = NSUserActivity(activityType:"com.example.ShoppingList.view")
-} else {
+} else if #unavailable(linux) {
     // Fall back when Handoff APIs not available.
+} else {
 }
 
 //MARK: Classes
@@ -452,12 +453,23 @@ func test(t: Types?) -> Bool {
 	}
 }
 
-actor AnActor {
+distributed actor AnActor {
   nonisolated func funcA() {}
   func funcB(otherActor: isolated AnActor) async {
     await otherActor.funcB()
     async let v = funcA()
   }
+}
+
+func existential(arg: any Proto1) -> some Proto2 {
+  autoreleasepool {
+  }
+}
+
+func pwrap() -> Bool {
+  @SmallNum var myNum: Int = 8
+  self.$myOwnNum = 8
+  return $myNum
 }
 
 foo() // end-of-file comment

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -400,7 +400,7 @@ typealias StringDictionary<T> = Dictionary<String, T>
 @available(*, unavailable, renamed: "MyRenamedProtocol")
 @discardableResult func f() -> T {}
 
-#sourceLocation(file: "foo", line: 42)
+_ = #sourceLocation(file: "foo", line: 42)
 
 @available(swift, obsoleted: 5.0.0, renamed: "foo2(file:line:)")
 func foo(_ file: StaticString = #file, line: UInt = #line) { }
@@ -497,5 +497,25 @@ let res = [
   still going
   /##
 ]
+
+package struct FileDescriptor: ~Copyable {
+  private var fd: Int32
+
+  consuming func close() throws {
+    discard self
+  }
+}
+
+func makePairs<each First, each Second>(
+  firsts first: repeat each First,
+  seconds second: repeat each Second
+) -> (repeat Pair<each First, each Second>) {
+  return (repeat Pair(each first, each second))
+}
+
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "m", type: "t")
+
+let p = #stringify(x + y)
 
 foo() // end-of-file comment

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -472,4 +472,30 @@ func pwrap() -> Bool {
   return $myNum
 }
 
+let res = [
+  // comment not a regex
+  #//#, // empty regex
+  ##//##, // another
+  ##//#, // unbalanced #
+  #//##, // unbalanced #
+  / not a regex /,
+  /a regex/,
+  /not a single-line
+  regex/,
+  /re with \/ escaped/,
+  ##/usr/lib/#modules/vmlinuz/##, // unescaped / with ##
+  /(#*)/(?!\s)[^\n]*(?<![\s\\])/\1/,
+
+  #/
+  multiline regex
+  /#,
+
+  ##/
+  multiline # comment
+  /#
+  /###
+  still going
+  /##
+]
+
 foo() // end-of-file comment


### PR DESCRIPTION
Swift lexer updates for Swift 5.8 (and probably 5.7).
First commit:
* Add long-term missing keywords `autoreleasepool` `left` `right`
* Add recent new keywords`any` `distributed` and `#unavailable` `#fileID` `#filePath` directives
* Add 'property wrapper projection' syntax -- means non-numeric identifiers can begin with `$` symbol
* Remove incredibly old C-style __-prefixed things

Second commit is about [regular expression literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md) which have some quirks due to being retrofitted to the language including:
* Single-line REs can't begin/end with spaces
* Single-line REs can have `#` delimiters which work like non-slash delims in other languages
* REs don't have trailing flags
* Multi-line REs must have `#` delims and always support extended syntax meaning #-end-of-line comments

There are some corners I haven't captured including turning off extended syntax inside multi-line REs.

Final commit re-alphabetizes some keyword lists without trying to think too much about why the separate lists exist.