### PR TITLE
Fix Twig/Jinja: incorrect recognition of some special tokens like keywords

### DIFF
--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -14,25 +14,25 @@ module Rouge
                 'text/html+django', 'text/html+jinja'
 
       def self.keywords
-        @@keywords ||= %w(as context do else extends from ignore missing
-                          import include reversed recursive scoped
-                          autoescape endautoescape block endblock call endcall
-                          filter endfilter for endfor if endif macro endmacro
-                          set endset trans endtrans with endwith without)
+        @keywords ||= %w(as context do else extends from ignore missing
+                         import include reversed recursive scoped
+                         autoescape endautoescape block endblock call endcall
+                         filter endfilter for endfor if endif macro endmacro
+                         set endset trans endtrans with endwith without)
       end
 
       def self.tests
-        @@tests ||= %w(callable defined divisibleby equalto escaped even iterable
-                       lower mapping none number odd sameas sequence string
-                       undefined upper)
+        @tests ||= %w(callable defined divisibleby equalto escaped even iterable
+                      lower mapping none number odd sameas sequence string
+                      undefined upper)
       end
 
       def self.pseudo_keywords
-        @@pseudo_keywords ||= %w(true false none True False None)
+        @pseudo_keywords ||= %w(true false none True False None)
       end
 
       def self.word_operators
-        @@word_operators ||= %w(is in and or not)
+        @word_operators ||= %w(is in and or not)
       end
 
       state :root do

--- a/lib/rouge/lexers/twig.rb
+++ b/lib/rouge/lexers/twig.rb
@@ -16,24 +16,24 @@ module Rouge
       mimetypes 'application/x-twig', 'text/html+twig'
 
       def self.keywords
-        @@keywords ||= %w(as do extends flush from import include use else starts
-                          ends with without autoescape endautoescape block
-                          endblock embed endembed filter endfilter for endfor
-                          if endif macro endmacro sandbox endsandbox set endset
-                          spaceless endspaceless)
+        @keywords ||= %w(as do extends flush from import include use else starts
+                         ends with without autoescape endautoescape block
+                         endblock embed endembed filter endfilter for endfor
+                         if endif macro endmacro sandbox endsandbox set endset
+                         spaceless endspaceless)
       end
 
       def self.tests
-        @@tests ||= %w(constant defined divisibleby empty even iterable null odd
-                       sameas)
+        @tests ||= %w(constant defined divisibleby empty even iterable null odd
+                      sameas)
       end
 
       def self.pseudo_keywords
-        @@pseudo_keywords ||= %w(true false none)
+        @pseudo_keywords ||= %w(true false none)
       end
 
       def self.word_operators
-        @@word_operators ||= %w(b-and b-or b-xor is in and or not)
+        @word_operators ||= %w(b-and b-or b-xor is in and or not)
       end
     end
   end

--- a/spec/lexers/twig_spec.rb
+++ b/spec/lexers/twig_spec.rb
@@ -12,4 +12,14 @@ describe Rouge::Lexers::Twig do
       assert_guess mimetype: 'text/html+twig'
     end
   end
+
+  describe 'regression: PR #1949' do
+    it 'has different keyword set than its superclass' do
+      refute_equal Rouge::Lexers::Twig.keywords, Rouge::Lexers::Jinja.keywords
+    end
+
+    it 'has different operator set than its superclass' do
+      refute_equal Rouge::Lexers::Twig.word_operators, Rouge::Lexers::Jinja.word_operators
+    end
+  end
 end


### PR DESCRIPTION
# Bug

Twig and Jinja may return incorrect token types for some special tokens like keywords. It depends on loading order.

cf. https://github.com/rouge-ruby/rouge/pull/1939#issuecomment-1499007812

# Cause

`Twig` and `Jinja` lexers share class variables. Both classes define `keywords` method like this:

```ruby
class Jinja
  def self.keywords
    @@keywords ||= ...
  end
end

class Twig < Jinja
  def self.keywords
    @@keywords ||= ...
  end
end
```

If `Twig.keywords` is called before `Jinja.keywords`, `@@keywords` is set to Twig's and both methods return the same value. If not, `@@keywords` is initialized to Jinja's.

# Solution

I changed class variables to instance variables. Other lexer classes define their keywords as instance variables.
