### PR TITLE
Highlight Ruby's and/or/not logical operators

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -106,8 +106,8 @@ module Rouge
       end
 
       keywords = %w(
-        BEGIN END alias and begin break case defined\? do else elsif end
-        ensure for if in next not or redo rescue raise retry return super then
+        BEGIN END alias begin break case defined\? do else elsif end
+        ensure for if in next redo rescue raise retry return super then
         undef unless until when while yield
       )
 
@@ -188,6 +188,7 @@ module Rouge
 
         rule %r/(?:#{keywords.join('|')})(?=\W|$)/, Keyword, :expr_start
         rule %r/(?:#{keywords_pseudo.join('|')})\b/, Keyword::Pseudo, :expr_start
+        rule %r/(not|and|or)\b/, Operator::Word, :expr_start
 
         rule %r(
           (module)

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -106,8 +106,8 @@ module Rouge
       end
 
       keywords = %w(
-        BEGIN END alias begin break case defined\? do else elsif end
-        ensure for if in next redo rescue raise retry return super then
+        BEGIN END alias and begin break case defined\? do else elsif end
+        ensure for if in next not or redo rescue raise retry return super then
         undef unless until when while yield
       )
 

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -277,6 +277,11 @@ puts [[x%w].reverse]
 def x(s) puts x end
 x %w].]
 
+# wordy logical operators
+5.prime? or fail "something is terribly wrong"
+chip = Bag.find_potato and chip.eat!
+puts "odd" if not num % 2 == 0
+
 ##################################################################
 # HEREDOCS
 <<-CONTENT.strip_heredoc


### PR DESCRIPTION
I was trying to write a thingy using Jekyll and the Rouge highlighter, and noticed that Ruby's "wordy" logical operators, like `or`, were not being highlighted like other keywords.

This PR adds the `and`, `or` and `not` keywords to the Ruby lexer (see ruby-lang [keywords](https://docs.ruby-lang.org/en/2.2.0/keywords_rdoc.html) reference).

It also adds some statements showcasing these operators on the Ruby visual sample page, which i checked and seems to be being highlighted correctly.

If this is all that's needed for supporting these keywords, then kudos for such an extensible and approachable codebase; the changes were super obvious to make :)