### PR TITLE
Improve web accessibility for theme base16 comments

### DIFF
--- a/lib/rouge/themes/base16.rb
+++ b/lib/rouge/themes/base16.rb
@@ -11,7 +11,7 @@ module Rouge
       palette base00: "#151515"
       palette base01: "#202020"
       palette base02: "#303030"
-      palette base03: "#505050"
+      palette base03: "#858585"
       palette base04: "#b0b0b0"
       palette base05: "#d0d0d0"
       palette base06: "#e0e0e0"


### PR DESCRIPTION
## Context
Increase color vs background color contrast in `base16` theme to make it easier to read comments.

### Screenshots using theme base16.dark
| Before `#505050` | After `#858585` |
| ------------- | ------------- |
| <img width="580" alt="comment-color-BEFORE-#505050" src="https://user-images.githubusercontent.com/64730786/236370834-c8301bb7-73b6-4e6e-8831-acea1cf6d35a.png"> | <img width="577" alt="comment-color-AFTER-#858585" src="https://user-images.githubusercontent.com/64730786/236370868-bc79304a-b64f-4f23-b923-36abaf666373.png">  |

### Web accessibility test results
| Before | After |
| ------------- | ------------- |
| <img width="725" alt="contrast-result-BEFORE" src="https://user-images.githubusercontent.com/64730786/236371121-3e0fbd95-6583-4fc4-9edd-ad0cf47f1b77.png"> | <img width="733" alt="contrast-result-AFTER" src="https://user-images.githubusercontent.com/64730786/236371153-51718b29-76cc-4a67-86d3-7f737898448e.png"> |

## Considerations
Tried to keep the comment color as "dark" as possible to keep it inline with the style of the theme while still improving the accessibility.