### PR TITLE
Fix Wollok lexer: entity list is shared between lexer instances

### DIFF
--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -14,8 +14,6 @@ module Rouge
       entity_name = /[a-zA-Z][a-zA-Z0-9]*/
       variable_naming = /_?#{entity_name}/
 
-      entities = []
-
       state :whitespaces_and_comments do
         rule %r/\s+/m, Text::Whitespace
         rule %r(//.*$), Comment::Single
@@ -97,6 +95,12 @@ module Rouge
         rule %r/and\b|or\b|not\b/, Operator
         rule %r/\(|\)|=/, Text
         rule %r/,/, Punctuation
+      end
+
+      private
+
+      def entities
+        @entities ||= []
       end
     end
   end

--- a/spec/lexers/wollok_spec.rb
+++ b/spec/lexers/wollok_spec.rb
@@ -13,4 +13,21 @@ describe Rouge::Lexers::Wollok do
       assert_guess :filename => 'foo.wpgm'
     end
   end
+
+  describe 'lexing' do
+    it 'does not share entity list between instances' do
+      a = Rouge::Lexers::Wollok.new
+      b = Rouge::Lexers::Wollok.new
+
+      # If "foo" is defined as object, it is recognized as Name.Class.
+      result_a1 = a.lex('object foo {}').to_a
+      assert_equal result_a1[2].first, Token['Name.Class']
+      result_a2 = a.lex('foo.bar()').to_a
+      assert_equal result_a2[0].first, Token['Name.Class']
+
+      # If "foo" is undefined, it is recognized as Keyword.Variable.
+      result_b1 = b.lex('foo.bar()').to_a
+      assert_equal result_b1[0].first, Token['Keyword.Variable']
+    end
+  end
 end


### PR DESCRIPTION
cf. https://github.com/rouge-ruby/rouge/pull/1939#issuecomment-1532634686

# Problem

`Wollok` lexer had `entities` class variable to track defined entities, e.g., class, object.

If a token is included in `entities`, it will be recognized as Name.Class; if not, Keyword.Variable

```ruby
          if entities.include?(variable) || ('A'..'Z').cover?(variable[0])
            token Name::Class
          else
            token Keyword::Variable
          end
```

Since a class variable is shared between instances, each lexer shared entity list.

# Solution

I changed `entities` to an instance variable.
