### PR TITLE
Fix highlight of ellipsis in Python lexer

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -90,8 +90,6 @@ module Rouge
 
         rule %r/@#{dotted_identifier}/i, Name::Decorator
 
-        rule %r/(>>>|\.\.\.)\B/, Generic::Prompt
-
         rule %r/(in|is|and|or|not)\b/, Operator::Word
         rule %r/(<<|>>|\/\/|\*\*)=?/, Operator
         rule %r/[-~+\/*%=<>&^|@]=?|!=/, Operator
@@ -182,7 +180,7 @@ module Rouge
       end
 
       state :generic_string do
-        rule %r/>>>|\.\.\./, Generic::Prompt, :doctest
+        rule %r/^\s*(>>>|\.\.\.)\B/, Generic::Prompt, :doctest
         rule %r/[^'"\\{]+?/, Str
         rule %r/{{/, Str
 

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -207,3 +207,14 @@ def factorial(n):
     OverflowError: n too large
     """
     print("hello world")
+
+def do_nothing():
+    if False:
+        return
+        print("a...a")
+
+    with tracer.start_as_current_span('App Init'):
+        logger.info('OTEL Initialized...')
+
+    app = FastAPI()
+    FastAPIInstrumentor.instrument_app(app)


### PR DESCRIPTION
This fixes ellipsis being incorrectly picked up as start of a prompt in doctest.

| Before | After |
| -- | -- |
| <img width="448" alt="Screenshot 2023-06-01 at 10 02 27 pm" src="https://github.com/rouge-ruby/rouge/assets/756722/9b217e05-5ae2-4fd7-a822-e7a900276fb8"> | <img width="437" alt="Screenshot 2023-06-01 at 10 03 08 pm" src="https://github.com/rouge-ruby/rouge/assets/756722/ad3da1dc-d1c7-425b-a4b1-dbaf7e428dfc"> |

