### PR TITLE
XQuery: common .xqm suffix added

### DIFF
--- a/lib/rouge/lexers/xquery.rb
+++ b/lib/rouge/lexers/xquery.rb
@@ -8,7 +8,7 @@ module Rouge
       title 'XQuery'
       desc 'XQuery 3.1: An XML Query Language'
       tag 'xquery'
-      filenames '*.xquery', '*.xq'
+      filenames '*.xquery', '*.xq', '*.xqm'
       mimetypes 'application/xquery'
 
       def self.keywords

--- a/spec/lexers/xquery_spec.rb
+++ b/spec/lexers/xquery_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::XQuery do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.xq'
+      assert_guess :filename => 'baz.xqm'
       assert_guess :filename => 'bar.xquery'
     end
 


### PR DESCRIPTION
Add .xqm suffix for XQuery files

### Changes
`xqm` is a common suffix for XQuery library modules, it is used by BaseX, eXist-db, and other XQuery processors.
