### PR TITLE
Support primitive directives in NASM lexer

### DIFF
--- a/lib/rouge/lexers/nasm.rb
+++ b/lib/rouge/lexers/nasm.rb
@@ -14,11 +14,12 @@ module Rouge
       mimetypes 'text/x-nasm'
 
       state :root do
-			  rule %r/^\s*%/, Comment::Preproc, :preproc
+        rule %r/^\s*%/, Comment::Preproc, :preproc
 
-			  mixin :whitespace
+        mixin :whitespace
+        mixin :punctuation
 
-			  rule %r/[a-z$._?][\w$.?#@~]*:/i, Name::Label
+        rule %r/[a-z$._?][\w$.?#@~]*:/i, Name::Label
 
         rule %r/([a-z$._?][\w$.?#@~]*)(\s+)(equ)/i do
           groups Name::Constant, Keyword::Declaration, Keyword::Declaration
@@ -32,7 +33,7 @@ module Rouge
       end
 
       state :instruction_args do
-			  rule %r/"(\\\\"|[^"\\n])*"|'(\\\\'|[^'\\n])*'|`(\\\\`|[^`\\n])*`/, Str
+        rule %r/"(\\\\"|[^"\\n])*"|'(\\\\'|[^'\\n])*'|`(\\\\`|[^`\\n])*`/, Str
         rule %r/(?:0x[\da-f]+|$0[\da-f]*|\d+[\da-f]*h)/i, Num::Hex
         rule %r/[0-7]+q/i, Num::Oct
         rule %r/[01]+b/i, Num::Bin

--- a/spec/visual/samples/nasm
+++ b/spec/visual/samples/nasm
@@ -1,3 +1,7 @@
+[global Start]
+[BITS 16]
+[ORG 0x7C00]
+
 ; Simple test of the NASM parser
 
 ; Data section, initialized variables


### PR DESCRIPTION
This fixes the highlight of square brackets `[]` around primitive directives in Netwide Assembler (NASM) lexer.

https://www.nasm.us/doc/nasmdoc7.html

| Before | After |
| -- | -- |
| <img width="326" alt="Screenshot 2023-07-04 at 9 04 47 pm" src="https://github.com/rouge-ruby/rouge/assets/756722/359c48ef-6ea8-404c-9986-af0261ab2eb8"> | <img width="323" alt="Screenshot 2023-07-04 at 9 05 31 pm" src="https://github.com/rouge-ruby/rouge/assets/756722/f166cd11-e44b-4f28-99c2-dac01f8b19ea"> |


Fixes https://github.com/rouge-ruby/rouge/issues/1972
