### PR TITLE
Update HCL & Terraform Lexers

### DIFF
--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -125,7 +125,6 @@ module Rouge
         mixin :comments_and_whitespace
 
         rule %r/[.,()\\\/*]/, Punctuation
-        rule %r/,/, Punctuation
         rule %r/\]/, Punctuation, :pop!
 
         mixin :root

--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -56,7 +56,7 @@ module Rouge
         @builtins ||= %w()
       end
 
-      id = /[$a-z_][a-z0-9_]*/io
+      id = /[$a-z_\-][a-z0-9_\-]*/io
 
       state :root do
         mixin :comments_and_whitespace
@@ -114,6 +114,7 @@ module Rouge
       state :hash do
         mixin :comments_and_whitespace
 
+        rule %r/[.,()\\\/*]/, Punctuation
         rule %r/\=/, Punctuation
         rule %r/\}/, Punctuation, :pop!
 
@@ -123,6 +124,7 @@ module Rouge
       state :array do
         mixin :comments_and_whitespace
 
+        rule %r/[.,()\\\/*]/, Punctuation
         rule %r/,/, Punctuation
         rule %r/\]/, Punctuation, :pop!
 

--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -37,14 +37,6 @@ module Rouge
         @builtins ||= %w()
       end
 
-      prepend :hash do
-        rule %r/[.,()*]/, Punctuation
-      end
-
-      prepend :array do
-        rule %r/[.,()*]/, Punctuation
-      end
-
       state :strings do
         rule %r/\\./, Str::Escape
         rule %r/\$\{/ do

--- a/spec/visual/samples/hcl
+++ b/spec/visual/samples/hcl
@@ -1,1 +1,86 @@
-# See Terraform lexer
+# Comment
+
+# Object with no key/value pairs
+data "aws_availability_zones" "available" {}
+
+# Object with single key/value
+provider "aws" {
+  most_recent = false
+}
+
+# Object with various comma-separated values
+provider "aws" {
+  most_recent = false, other_value = null
+}
+
+# Object with various newline-separated values
+resource "aws_vpc" "main" {
+  most_recent = true
+  cidr_block = "10.10.0.0/16"
+  region = "${var.aws_region}"
+  count = 0
+  another_num = 3.14
+}
+
+# Object with interpolated values
+resource "aws_subnet" "main" {
+  count             = "${var.az_count}"
+  cidr_block        = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  vpc_id            = "${aws_vpc.main.id}"
+}
+
+# Object with nested object
+resource "aws_route_table" "r" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+}
+
+# Object with list value
+resource "aws_autoscaling_group" "app" {
+  vpc_zone_identifier  = ["${aws_subnet.main.*.id}"]
+}
+
+# Object with nested interpolation
+data "template_file" "cloud_config" {
+  template = "${file("${path.module}/cloud-config.yml")}"
+}
+
+# Object with HEREDOC string
+resource "aws_iam_role" "ecs_service" {
+  name = "tf_example_ecs_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+## Object with first-class expressions
+resource "aws_subnet" "main" {
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+  fqns              = aws_route53_record.cert_validation[*].fqdn
+}
+
+## Object with regular expression
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  aliases = ["www.${replace(var.domain_name, "/\\.$/", "")}"]
+}


### PR DESCRIPTION
This updates the HCL and Terraform Lexers with the following changes:

- Aligns the `id` definition in the HCL Lexer with the Terraform one.
- Moves the `hash` and `array` rules that were added to the Terraform Lexer in #1303 to the HCL Lexer as these changes should apply to the base HCL format.
- Updates the HCL visual sample file with a copy of the Terraform visual sample. This should be highlighted without errors, the same as the Terraform sample, except without the keyword coloring.

### HCL Sample (Before)

Note the red errors

![image](https://github.com/rouge-ruby/rouge/assets/32168619/2a8c5de5-735b-4326-9a7a-cddcbe9c5498)

### HCL Sample (After)

![image](https://github.com/rouge-ruby/rouge/assets/32168619/9a1250b8-eecd-4ab4-a56b-ed0b3ab4ec8c)

The Terraform sample is identical, before and after these changes.