### PR TITLE
Add Typescript support for `.cts` and `.mts` files

### DIFF
--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -15,7 +15,7 @@ module Rouge
       tag 'typescript'
       aliases 'ts'
 
-      filenames '*.ts', '*.d.ts'
+      filenames '*.ts', '*.d.ts', '*.cts', '*.mts'
 
       mimetypes 'text/typescript'
     end


### PR DESCRIPTION
Adds Typescript syntax highlighting to `.cts` and `.mts` files. These file extensions only specify to Typescript/Node what module system to use. They use the same syntax highlighting as `.ts` files. More info [here](https://www.typescriptlang.org/docs/handbook/esm-node.html#new-file-extensions).