### PR TITLE
Add python support for match/case

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -21,7 +21,7 @@ module Rouge
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
           return try while yield as with from import yield
-          async await nonlocal
+          async await nonlocal match case
         )
       end
 

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -218,3 +218,10 @@ def do_nothing():
 
     app = FastAPI()
     FastAPIInstrumentor.instrument_app(app)
+
+# Structural pattern matching (PEP634)
+match point:
+    case Point(x, y) if x == y:
+        print(f"The point is located on the diagonal Y=X at {x}.")
+    case Point(x, y):
+        print(f"Point is not on the diagonal.")


### PR DESCRIPTION
This adds match & case as keywords, used by python 3.10 structural pattern matching ( https://peps.python.org/pep-0634/ )

<img width="585" alt="Screenshot 2023-07-28 at 10 44 42" src="https://github.com/rouge-ruby/rouge/assets/5927/7811dfc5-ecc3-4e9f-8f0a-2d3119fb5463">

(screenshot from rouge's visual test page)