### PR TITLE
Fix python call syntax highlighting

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -93,19 +93,21 @@ module Rouge
         rule %r/\\\n/, Str::Escape
       end
 
-      def id(match, type)
-        if self.class.keywords.include? match
+      # Yield a token for an identifier. Handle keywords/builtins, attr accesses
+      def token_for_identifier(word, fallback)
+        if self.class.keywords.include? word
           token Keyword
-        elsif not in_state?(:dot) and self.class.exceptions.include? match
+        elsif not in_state?(:dot) and self.class.exceptions.include? word
           token Name::Builtin
-        elsif not in_state?(:dot) and self.class.builtins.include? match
+        elsif not in_state?(:dot) and self.class.builtins.include? word
           token Name::Builtin
-        elsif not in_state?(:dot) and self.class.builtins_pseudo.include? match
+        elsif not in_state?(:dot) and self.class.builtins_pseudo.include? word
           token Name::Builtin::Pseudo
         else
-          token type
+          token fallback
         end
 
+        # Reset attr access state
         if in_state?(:dot)
           pop!
         end
@@ -143,17 +145,18 @@ module Rouge
           push :generic_string
         end
 
-        # Handle identifiers that look like a call
+        # Identifiers used in a call expr
         rule %r/#{lower_identifier}(?=[[:blank:]]*\()/m do |m|
-          id m[0], Name::Function
+          token_for_identifier m[0], Name::Function
         end
 
         rule %r/#{upper_identifier}(?=[[:blank:]]*\()/m do |m|
-          id m[0], Name::Class
+          token_for_identifier m[0], Name::Class
         end
 
+        # All other identifiers
         rule identifier do |m|
-          id m[0], Name
+          token_for_identifier m[0], Name
         end
 
         digits = /[0-9](_?[0-9])*/

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -71,6 +71,8 @@ module Rouge
       end
 
       identifier =        /[[:alpha:]_][[:alnum:]_]*/
+      lower_identifier =  /[[:lower:]_][[:alnum:]_]*/
+      upper_identifier =  /[[:upper:]_][[:alnum:]_]*/
       dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
       inline_ws = /(?:[ \t]|\\\n)*?/
       inline_content = /(?:[^\\\n]|\\[\n.])*?/
@@ -89,6 +91,24 @@ module Rouge
       state :inline_whitespace do
         rule %r/[ \t]+/, Text
         rule %r/\\\n/, Str::Escape
+      end
+
+      def id(match, type)
+        if self.class.keywords.include? match
+          token Keyword
+        elsif not in_state?(:dot) and self.class.exceptions.include? match
+          token Name::Builtin
+        elsif not in_state?(:dot) and self.class.builtins.include? match
+          token Name::Builtin
+        elsif not in_state?(:dot) and self.class.builtins_pseudo.include? match
+          token Name::Builtin::Pseudo
+        else
+          token type
+        end
+
+        if in_state?(:dot)
+          pop!
+        end
       end
 
       state :root do
@@ -115,6 +135,7 @@ module Rouge
 
         rule %r/class\b/, Keyword, :classname
 
+        # TODO: not in python 3
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rtfbu]{0,2})('''|"""|['"])/i do |m|
           groups Str::Affix, Str::Heredoc
@@ -122,22 +143,18 @@ module Rouge
           push :generic_string
         end
 
-        # using negative lookbehind so we don't match property names
-        rule %r/(?<!\.)#{identifier}/ do |m|
-          if self.class.keywords.include?(m[0])
-            token Keyword
-          elsif self.class.exceptions.include?(m[0])
-            token Name::Exception
-          elsif self.class.builtins.include?(m[0])
-            token Name::Builtin
-          elsif self.class.builtins_pseudo.include?(m[0])
-            token Name::Builtin::Pseudo
-          else
-            token Name
-          end
+        # Handle identifiers that look like a call
+        rule %r/#{lower_identifier}(?=[[:blank:]]*\()/m do |m|
+          id m[0], Name::Function
         end
 
-        rule identifier, Name
+        rule %r/#{upper_identifier}(?=[[:blank:]]*\()/m do |m|
+          id m[0], Name::Class
+        end
+
+        rule identifier do |m|
+          id m[0], Name
+        end
 
         digits = /[0-9](_?[0-9])*/
         decimal = /((#{digits})?\.#{digits}|#{digits}\.)/

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -93,23 +93,18 @@ module Rouge
         rule %r/\\\n/, Str::Escape
       end
 
-      # Yield a token for an identifier. Handle keywords/builtins, attr accesses
+      # Yield a token for an identifier. Handle keywords/builtins
       def token_for_identifier(word, fallback)
         if self.class.keywords.include? word
           token Keyword
-        elsif not in_state?(:dot) and self.class.exceptions.include? word
+        elsif self.class.exceptions.include? word
+          token Name::Exception
+        elsif self.class.builtins.include? word
           token Name::Builtin
-        elsif not in_state?(:dot) and self.class.builtins.include? word
-          token Name::Builtin
-        elsif not in_state?(:dot) and self.class.builtins_pseudo.include? word
+        elsif self.class.builtins_pseudo.include? word
           token Name::Builtin::Pseudo
         else
           token fallback
-        end
-
-        # Reset attr access state
-        if in_state?(:dot)
-          pop!
         end
       end
 
@@ -201,6 +196,7 @@ module Rouge
         mixin :inline_whitespace
         rule %r/([A-Z]\w*)(?=#{inline_ws}[(])/m, Name::Class
         rule %r/(#{identifier})(?=#{inline_ws}[(])/m, Name::Function
+        rule identifier, Name, :pop!
         rule(//) { pop! }
       end
 

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -272,3 +272,11 @@ def take_first(pairs):
 
 # Distinguish between builtins and method calls
 self.filter(filter(lambda x: x == 1, items))
+
+# Builtin exceptions, custom exception classes and plain function calls
+def check(value):
+    if value is None:
+        raise ValueError("bad")
+    if not isinstance(value, MyCustomError):
+        raise MyCustomError("bad")
+    foo()

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -262,3 +262,13 @@ match (100, 200):
       thing \
       :
       other
+
+# Keyword shouldn't be read as function call
+def take_first(pairs):
+    for (first, _) in pairs:
+        yield first
+
+    self.for('nonsense')
+
+# Distinguish between builtins and method calls
+self.filter(filter(lambda x: x == 1, items))


### PR DESCRIPTION
## Summary

Fixes an issue with the Python lexer where any identifier used before an opening paren `(` would be highlighted as a function name. This led to inconsistent highlighting in the case of `for` loops, where one `for` would be rendered as a keyword while the other was rendered as a function name:

![image](https://github.com/rouge-ruby/rouge/assets/1495572/9eade66d-5b7b-4008-9978-24e1d822f375)

This pull request also addresses other edge cases for call expressions:
- distinguishes Exception classes from normal classes in a call expr context
- distinguishes Builtin calls from identically named method calls

## Visual Before and After

|Before|After|
|-|-|
|![Screenshot 2023-08-20 132415](https://github.com/rouge-ruby/rouge/assets/1495572/44ac179d-5c62-45f9-90c7-ff33481afde4)|![Screenshot 2023-08-20 132000](https://github.com/rouge-ruby/rouge/assets/1495572/5e3cb1af-6211-457b-9e5f-61b968a712fb)|
