### PR TITLE
Remove `inline` from Dart declaration keywords

### DIFF
--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -18,7 +18,7 @@ module Rouge
 
       declarations = %w(
         abstract base async dynamic const covariant external extends factory final get implements
-        inline interface late native on operator required sealed set static sync typedef var
+        interface late native on operator required sealed set static sync typedef var
       )
 
       types = %w(bool Comparable double Dynamic enum Function int List Map Never Null num Object Pattern Record Set String Symbol Type Uri void)


### PR DESCRIPTION
The [inline classes feature](https://github.com/dart-lang/language/blob/main/working/1426-extension-types/feature-specification-inline-classes.md) this was part of is now obsolete and will not be part of the language. It will likely be replaced by [extension types](https://github.com/dart-lang/language/blob/main/accepted/future-releases/extension-types/feature-specification.md).