### PR TITLE
Guess `.pyi` files as Python

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -8,8 +8,8 @@ module Rouge
       desc "The Python programming language (python.org)"
       tag 'python'
       aliases 'py'
-      filenames '*.py', '*.pyw', '*.sc', 'SConstruct', 'SConscript', '*.tac',
-                '*.bzl', 'BUCK', 'BUILD', 'BUILD.bazel', 'WORKSPACE'
+      filenames '*.py', '*.pyi', '*.pyw', '*.sc', 'SConstruct', 'SConscript',
+                '*.tac', '*.bzl', 'BUCK', 'BUILD', 'BUILD.bazel', 'WORKSPACE'
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)

--- a/spec/lexers/python_spec.rb
+++ b/spec/lexers/python_spec.rb
@@ -9,6 +9,7 @@ describe Rouge::Lexers::Python do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.py'
+      assert_guess :filename => 'foo.pyi'
       assert_guess :filename => 'foo.pyw'
       assert_guess :filename => '*.sc', :source => '# A comment'
       assert_guess :filename => 'SConstruct'


### PR DESCRIPTION
Python `.pyi` files are defined in [PEP 484 as _Stub Files_](https://peps.python.org/pep-0484/#stub-files). They have the same syntax as Python modules, except are only for use by the type checker, and are not used at runtime. This change recognizes files with this extension as Python stub files.

Similar behaviour was introduced to Pygments in https://github.com/pygments/pygments/pull/2231.