### PR TITLE
toml: don't highlight keys with inline tables as tables

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -20,7 +20,7 @@ module Rouge
         rule %r/(true|false)/, Keyword::Constant
 
         rule %r/(#{identifier})(\s*)(=)(\s*)(\{)/ do
-          groups Name::Namespace, Text, Operator, Text, Punctuation
+          groups Name::Property, Text, Operator, Text, Punctuation
           push :inline
         end
 


### PR DESCRIPTION
A TOML table looks like:

	[tblname]
	key = 'value'

You can also use inline tables like so:

	[tblname]
	key = 'value'
	inline = {key = 'value'}

However, the "inline" would get highlighted as a table (same as "[tblname]") rather than a regular key, which is very jarring and unexpected IMHO.

It looks like it's been like this ever since inline tables were added in #1359, but I don't think anyone really wants this behaviour.