### PR TITLE
 toml: only highlight inf and nan in value, highlight keys starting with digit

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -23,17 +23,6 @@ module Rouge
           groups Name::Namespace, Text, Operator, Text, Punctuation
           push :inline
         end
-
-        rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
-
-        rule %r/[+-]?\d+(?:_\d+)*\.\d+(?:_\d+)*(?:[eE][+-]?\d+(?:_\d+)*)?/, Num::Float
-        rule %r/[+-]?\d+(?:_\d+)*[eE][+-]?\d+(?:_\d+)*/, Num::Float
-        rule %r/[+-]?(?:nan|inf)/, Num::Float
-
-        rule %r/0x\h+(?:_\h+)*/, Num::Hex
-        rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
-        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
-        rule %r/[+-]?\d+(?:_\d+)*/, Num::Integer
       end
 
       state :root do
@@ -58,6 +47,17 @@ module Rouge
         rule %r/(#{identifier})(\s*)(=)/ do
           groups Name::Property, Text, Punctuation
         end
+
+        rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
+
+        rule %r/[+-]?\d+(?:_\d+)*\.\d+(?:_\d+)*(?:[eE][+-]?\d+(?:_\d+)*)?/, Num::Float
+        rule %r/[+-]?\d+(?:_\d+)*[eE][+-]?\d+(?:_\d+)*/, Num::Float
+        rule %r/[+-]?(?:nan|inf)/, Num::Float
+
+        rule %r/0x\h+(?:_\h+)*/, Num::Hex
+        rule %r/0o[0-7]+(?:_[0-7]+)*/, Num::Oct
+        rule %r/0b[01]+(?:_[01]+)*/, Num::Bin
+        rule %r/[+-]?\d+(?:_\d+)*/, Num::Integer
 
         rule %r/"""/, Str, :mdq
         rule %r/"/, Str, :dq

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -166,3 +166,22 @@ emptyTableAreAllowed = true
 name = "Nail"
 sku = 284758393
 color = "gray"
+
+[special-floats]
+inflection = "don't highlight"
+influxdb = 1
+
+nan = nan
+
+inf-1 = inf
+inf-2 = [inf, +nan, -nan, +inf, -inf]
+inf-3 = {inf=inf, nan=nan}
+
+str-inf-1 = 'inf'
+str-inf-2 = "inf"
+str-inf-3 = """ inf nan
+	inf nan
+"""
+str-inf-4 = """ inf nan
+	inf nan
+"""


### PR DESCRIPTION
![cap-2023-10-12T09:01:03](https://github.com/rouge-ruby/rouge/assets/1032692/04a12765-d276-48b8-bdca-1c089e8008fa)

Fixes #1636
Fixes #1873