### PR TITLE
Update BPF lexer

### DIFF
--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -9,7 +9,7 @@ module Rouge
       tag 'bpf'
 
       TYPE_KEYWORDS = %w(
-        u8 u16 u32 u64 ll
+        u8 u16 u32 u64 s8 s16 s32 s64 ll
       ).join('|')
 
       MISC_KEYWORDS = %w(

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -13,7 +13,7 @@ module Rouge
       ).join('|')
 
       MISC_KEYWORDS = %w(
-        be16 be32 be64 exit lock map
+        be16 be32 be64 le16 le32 le64 bswap16 bswap32 bswap64 exit lock map
       ).join('|')
 
       state :root do

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -37,16 +37,16 @@ module Rouge
         end
 
         # Unconditional jumps
-        rule %r/(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
-          groups Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
+        rule %r/(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+          groups Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 
         # Conditional jumps
-        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
-          groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Literal::Number, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
+        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+          groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Literal::Number, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
-        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)([rw]\d+)(\s*)(goto)(\s*)(\+\d+)?(\s*)(<?\w+>?)/i do
-          groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Name, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Integer, Text::Whitespace, Name::Label
+        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)([rw]\d+)(\s*)(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+          groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Name, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 
         # Dereferences

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -70,7 +70,7 @@ module Rouge
         rule %r/#{MISC_KEYWORDS}/i, Keyword
 
         # Literals and global objects (maps) refered by name
-        rule %r/(0x\h+|[-]?\d+)(\s*)(ll)?/i do
+        rule %r/([-]?0x\h+|[-]?\d+)(\s*)(ll)?/i do
           groups Literal::Number, Text::Whitespace, Keyword::Type
         end
         rule %r/(\w+)(\s*)(ll)/i do

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -32,7 +32,7 @@ module Rouge
         rule %r/(call)(\s+)(\d+)/i do
           groups Keyword, Text::Whitespace, Literal::Number::Integer
         end
-        rule %r/(call)(\s+)(\w+)(#)(\d+)/i do
+        rule %r/(call)(\s+)(\w+)(?:(#)(\d+))?/i do
           groups Keyword, Text::Whitespace, Name::Builtin, Punctuation, Literal::Number::Integer
         end
 

--- a/lib/rouge/lexers/bpf.rb
+++ b/lib/rouge/lexers/bpf.rb
@@ -37,15 +37,15 @@ module Rouge
         end
 
         # Unconditional jumps
-        rule %r/(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+        rule %r/(gotol?)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 
         # Conditional jumps
-        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)(0x\h+|[-]?\d+)(\s*)(gotol?)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Literal::Number, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
-        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)([rw]\d+)(\s*)(goto)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
+        rule %r/(if)(\s+)([rw]\d+)(\s*)([s!=<>]+)(\s*)([rw]\d+)(\s*)(gotol?)(\s*)([-+]0x\w+)?([-+]\d+)?(\s*)(<?\w+>?)/i do
           groups Keyword, Text::Whitespace, Name, Text::Whitespace, Operator, Text::Whitespace, Name, Text::Whitespace, Keyword, Text::Whitespace, Literal::Number::Hex, Literal::Number::Integer, Text::Whitespace, Name::Label
         end
 

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -100,9 +100,11 @@ Llabel0 :
   r9 = r10    // BPF_MOV  | BPF_X
   r10 s>>= r0 // BPF_ARSH | BPF_X
 
-  r1 = be16 r1  // BPF_END  | BPF_TO_BE
-  r2 = be32 r2  // BPF_END  | BPF_TO_BE
-  r3 = be64 r3  // BPF_END  | BPF_TO_BE
+  r1 = be16 r1    // BPF_END | BPF_TO_BE
+  r2 = be32 r2    // BPF_END | BPF_TO_BE
+  r3 = be64 r3    // BPF_END | BPF_TO_BE
+  r1 = le16 r1    // BPF_END | BPF_TO_LE
+  r1 = bswap32 r1 // BPF_ALU64 | BPF_END | BPF_TO_BE
 
   r0 += 1           // BPF_ADD  | BPF_K
   r1 -= 0x1         // BPF_SUB  | BPF_K

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -87,6 +87,7 @@ LBB0_4:
   if r9 s<= -1 goto Llabel0         // BPF_JSLE | BPF_K
 
   goto +1 <LBB0_2>            // BPF_JMP | BPF_JA
+  gotol +0x7fffffff <LBB0_2>  // BPF_JMP32 | BPF_JA
 
 // ======== BPF_ALU64 Class ========
   r0 += r1    // BPF_ADD  | BPF_X

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -55,6 +55,7 @@ LBB0_4:
 // ======== BPF_JMP Class ========
   goto Llabel0               // BPF_JA
   call 1                     // BPF_CALL
+  call bpf_skb_load_bytes    // BPF_CALL
   exit                       // BPF_EXIT
 
   if r0 == r1 goto Llabel0   // BPF_JEQ  | BPF_X

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -89,6 +89,7 @@ LBB0_4:
   r1 -= r2    // BPF_SUB  | BPF_X
   r2 *= r3    // BPF_MUL  | BPF_X
   r3 /= r4    // BPF_DIV  | BPF_X
+  r1 s/= -0x5 // BPF_SDIV | BPF_X
 
 Llabel0 :
   r2 = -r2    // BPF_NEG

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -41,6 +41,7 @@ LBB0_4:
   r6 = *(u16 *)(r1 + 8)  // BPF_LDX | BPF_H
   r7 = *(u32 *)(r2 + 16) // BPF_LDX | BPF_W
   r8 = *(u64 *)(r3 - 30) // BPF_LDX | BPF_DW
+  r1 = *(s32 *)(r6 +0)   // BPF_SMEM | BPF_LDX | BPF_W
 
 // ======== BPF_STX Class ========
   *(u8 *)(r0 + 0) = r7    // BPF_STX | BPF_B

--- a/spec/visual/samples/bpf
+++ b/spec/visual/samples/bpf
@@ -71,6 +71,8 @@ LBB0_4:
   if r8 s< r9 goto Llabel0   // BPF_JSLT | BPF_X
   if r9 s<= r10 goto Llabel0 // BPF_JSLE | BPF_X
 
+  if r9 < r1 goto -0x5 <Llabel0> // BPF_JLT | BPF_X
+
   if r0 == 0 goto Llabel0           // BPF_JEQ  | BPF_K
   if r3 != -1 goto Llabel0          // BPF_JNE  | BPF_K
 
@@ -83,6 +85,8 @@ LBB0_4:
   if r7 <= 0xffff goto Llabel0      // BPF_JLE  | BPF_K
   if r8 s< 0 goto Llabel0           // BPF_JSLT | BPF_K
   if r9 s<= -1 goto Llabel0         // BPF_JSLE | BPF_K
+
+  goto +1 <LBB0_2>            // BPF_JMP | BPF_JA
 
 // ======== BPF_ALU64 Class ========
   r0 += r1    // BPF_ADD  | BPF_X


### PR DESCRIPTION
This pull request updates the BPF lexer to highlight several constructs and keywords that were either missed in the initial lexer or were recently added to BPF:
- The `s8`, `s16`, `s32`, and `s64` type keywords.
- The `call helper_name` syntax.
- The existing `le16`, `le32`, `le64` and the new `bswap16`, `bswap32`, `bswap64` keywords.
- The `-0xa5` syntax for negative hexadecimal.
- The `goto 0x1234 <label>` syntax for jumps.
- The `gotol` keyword for long jumps.

All come with visual examples.