### PR TITLE
Typescript, adding keywords satisfies and as to the lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -100,7 +100,7 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          as async await break case catch continue debugger default delete
+          async await break case catch continue debugger default delete
           do else export finally from for if import in instanceof new of
           return super switch this throw try typeof void while yield
         )

--- a/lib/rouge/lexers/typescript/common.rb
+++ b/lib/rouge/lexers/typescript/common.rb
@@ -37,6 +37,15 @@ module Rouge
         base.prepend :root do
           rule %r/[?][.]/, base::Punctuation
           rule %r/[?]{2}/, base::Operator
+
+          # Positive Examples:
+          # const cat = { name: "Garfield" } satisfies Person;
+          # import {something as thingy} from 'module'
+          # export { foo as default }
+          # ...spreadOperator as const;
+          # Negative Example:
+          # cy.get('kitten').as('friend')
+          rule %r{(?<![_$[:alnum:]])(?:(?<=\.\.\.)|(?<!\.))(?:(as)|(satisfies))\s+}, base::Keyword::Declaration
         end
 
         base.prepend :statement do

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -163,6 +163,23 @@ declare var foo: Foo;
 export = foo;
 export { foo as default }
 
+cy.get('input').as('text')
+
+cy
+  .get('input')
+  .as('text')
+
+import {something as thingy} from 'module'
+
+const applicant = {
+  myInfo: "John",
+  myOtherInfo: { id: 123, age: 22 },
+} satisfies Person;
+
+const properties = (value.features[0].properties as moreDetails)
+
+...spreadOperator as const;
+
 declare module "foo" {
     export interface IFoo {
         theObject: any;


### PR DESCRIPTION
Howdy! 

Noticed some less than perfect syntax highlighting on a blog post, and thought to fix the issue upstream in rouge. 

In typescript, 'as' and 'satisfies' are type assertion operator, while 'satisfies' is a type operator. There is no 'as' keyword in javascript, and the way the rule was written, functions named "as" were being marked as keywords, rather than functions. 

I took the rule from a textmate grammar, and modified it to work in rouge. 

I also tested this commit against my blog, and noticed the improved syntax highlighting there. 

Now, "satisfies" and "as" are marked as keywords where they are used in a keyword way.

Here are three screenshots, before, after, and delta of visual lexer test. 

## Before
The "satisfies" is not bolded, and the "as" in the function names are bolded. Not ideal. 
<img width="575" alt="Screenshot 2023-12-09 at 5 19 53 PM" src="https://github.com/rouge-ruby/rouge/assets/934880/b7f7fec1-461d-4c09-9ce3-053efb1ef6a8">

## After
The "satisfies" is bolded, and the function names are not bolded, with no regressions to the other "as" 
<img width="588" alt="Screenshot 2023-12-09 at 5 19 13 PM" src="https://github.com/rouge-ruby/rouge/assets/934880/a6ecbea3-5cc9-478e-a937-136fa123a4f0">

## Delta
white is unchanged, teal is text that was made unbolded, and yellow is bolded.
<img width="568" alt="Screenshot 2023-12-10 at 10 58 35 AM" src="https://github.com/rouge-ruby/rouge/assets/934880/b307300d-4e07-46b2-9335-fc87c99c48d3">

