### PR TITLE
Highlight float number in nginx lexer

### DIFF
--- a/lib/rouge/lexers/nginx.rb
+++ b/lib/rouge/lexers/nginx.rb
@@ -53,6 +53,7 @@ module Rouge
         # mimetype
         rule %r([a-z-]+/[a-z-]+)i, Name::Class
 
+        rule %r/\d+\.\d+/, Num::Float
         rule %r/[0-9]+[kmg]?\b/i, Num::Integer
         rule %r/(~)(\s*)([^\s{]+)/ do
           groups Punctuation, Text, Str::Regex

--- a/spec/visual/samples/nginx
+++ b/spec/visual/samples/nginx
@@ -12,6 +12,9 @@ events {
     worker_connections  1024;
 }
 
+server {
+    proxy_http_version 1.1;
+}
 
 http {
     include       mime.types;

--- a/spec/visual/samples/nginx
+++ b/spec/visual/samples/nginx
@@ -120,3 +120,88 @@ http {
 }
 
 # comment at eof
+
+# proxy.conf
+proxy_redirect          off;
+proxy_set_header        Host            $host;
+proxy_set_header        X-Real-IP       $remote_addr;
+proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+client_max_body_size    10m;
+client_body_buffer_size 128k;
+proxy_connect_timeout   90;
+proxy_send_timeout      90;
+proxy_read_timeout      90;
+proxy_buffers           32 4k;
+
+# fastcgi.conf
+fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+fastcgi_param  QUERY_STRING       $query_string;
+fastcgi_param  REQUEST_METHOD     $request_method;
+fastcgi_param  CONTENT_TYPE       $content_type;
+fastcgi_param  CONTENT_LENGTH     $content_length;
+fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+fastcgi_param  REQUEST_URI        $request_uri;
+fastcgi_param  DOCUMENT_URI       $document_uri;
+fastcgi_param  DOCUMENT_ROOT      $document_root;
+fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+fastcgi_param  REMOTE_ADDR        $remote_addr;
+fastcgi_param  REMOTE_PORT        $remote_port;
+fastcgi_param  SERVER_ADDR        $server_addr;
+fastcgi_param  SERVER_PORT        $server_port;
+fastcgi_param  SERVER_NAME        $server_name;
+
+fastcgi_index  index.php;
+
+fastcgi_param  REDIRECT_STATUS    200;
+
+# mime.types
+types {
+  text/html                             html htm shtml;
+  text/css                              css;
+  text/xml                              xml rss;
+  image/gif                             gif;
+  image/jpeg                            jpeg jpg;
+  application/x-javascript              js;
+  text/plain                            txt;
+  text/x-component                      htc;
+  text/mathml                           mml;
+  image/png                             png;
+  image/x-icon                          ico;
+  image/x-jng                           jng;
+  image/vnd.wap.wbmp                    wbmp;
+  application/java-archive              jar war ear;
+  application/mac-binhex40              hqx;
+  application/pdf                       pdf;
+  application/x-cocoa                   cco;
+  application/x-java-archive-diff       jardiff;
+  application/x-java-jnlp-file          jnlp;
+  application/x-makeself                run;
+  application/x-perl                    pl pm;
+  application/x-pilot                   prc pdb;
+  application/x-rar-compressed          rar;
+  application/x-redhat-package-manager  rpm;
+  application/x-sea                     sea;
+  application/x-shockwave-flash         swf;
+  application/x-stuffit                 sit;
+  application/x-tcl                     tcl tk;
+  application/x-x509-ca-cert            der pem crt;
+  application/x-xpinstall               xpi;
+  application/zip                       zip;
+  application/octet-stream              deb;
+  application/octet-stream              bin exe dll;
+  application/octet-stream              dmg;
+  application/octet-stream              eot;
+  application/octet-stream              iso img;
+  application/octet-stream              msi msp msm;
+  audio/mpeg                            mp3;
+  audio/x-realaudio                     ra;
+  video/mpeg                            mpeg mpg;
+  video/quicktime                       mov;
+  video/x-flv                           flv;
+  video/x-msvideo                       avi;
+  video/x-ms-wmv                        wmv;
+  video/x-ms-asf                        asx asf;
+  video/x-mng                           mng;
+}


### PR DESCRIPTION
| Before | After |
| -- | -- |
|  ![Screenshot 2024-01-02 at 12 03 58 pm](https://github.com/rouge-ruby/rouge/assets/756722/bf19c22b-3fbb-466a-9615-f98ca441ca17) | ![Screenshot 2024-01-02 at 12 03 02 pm](https://github.com/rouge-ruby/rouge/assets/756722/b8d13e07-a6b5-478d-8df5-2df1b76d8dfb) |

Fixes https://github.com/rouge-ruby/rouge/issues/1997

Also added more Nginx samples from https://www.nginx.com/resources/wiki/start/topics/examples/full/