### PR TITLE
Fix private class unused variable warnings

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -347,8 +347,7 @@ module Rouge
         formatter.format(lexer.lex(input), &method(:print))
       end
 
-    private_class_method
-      def self.parse_cgi(str)
+    private_class_method def self.parse_cgi(str)
         pairs = CGI.parse(str).map { |k, v| [k.to_sym, v.first] }
         Hash[pairs]
       end
@@ -511,8 +510,7 @@ module Rouge
     end
 
 
-  private_class_method
-    def self.normalize_syntax(argv)
+  private_class_method def self.normalize_syntax(argv)
       out = []
       argv.each do |arg|
         case arg

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -12,7 +12,7 @@ module Rouge
       mimetypes 'text/x-gdscript', 'application/x-gdscript'
 
       def self.keywords
-        @keywords = %w(
+        @keywords ||= %w(
           and in not or as breakpoint class class_name extends is func setget
           signal tool const enum export onready static var break continue
           if elif else for pass return match while remote master puppet
@@ -22,13 +22,13 @@ module Rouge
 
       # Reserved for future implementation
       def self.keywords_reserved
-        @keywords_reserved = %w(
+        @keywords_reserved ||= %w(
           do switch case
         ).join('|')
       end
 
       def self.builtins
-        builtins = %w(
+        @builtins ||= %w(
           Color8 ColorN abs acos asin assert atan atan2 bytes2var ceil char
           clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst
           ease exp floor fmod fposmod funcref hash inst2dict instance_from_id
@@ -41,7 +41,7 @@ module Rouge
       end
 
       def self.builtins_type
-        @builtins_type = %w(
+        @builtins_type ||= %w(
           bool int float String Vector2 Rect2 Transform2D Vector3 AABB
           Plane Quat Basis Transform Color RID Object NodePath Dictionary
           Array PoolByteArray PoolIntArray PoolRealArray PoolStringArray

--- a/lib/rouge/lexers/meson.rb
+++ b/lib/rouge/lexers/meson.rb
@@ -38,7 +38,6 @@ module Rouge
       end
 
       identifier =        /[[:alpha:]_][[:alnum:]_]*/
-      _dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
 
       def current_string
         @current_string ||= StringRegister.new

--- a/lib/rouge/lexers/meson.rb
+++ b/lib/rouge/lexers/meson.rb
@@ -38,7 +38,7 @@ module Rouge
       end
 
       identifier =        /[[:alpha:]_][[:alnum:]_]*/
-      dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
+      _dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
 
       def current_string
         @current_string ||= StringRegister.new

--- a/lib/rouge/lexers/objective_c/common.rb
+++ b/lib/rouge/lexers/objective_c/common.rb
@@ -4,8 +4,6 @@
 module Rouge
   module Lexers
     module ObjectiveCCommon
-      _id = /[a-z$_][a-z0-9$_]*/i
-
       def at_keywords
         @at_keywords ||= %w(
           selector private protected public encode synchronized try

--- a/lib/rouge/lexers/objective_c/common.rb
+++ b/lib/rouge/lexers/objective_c/common.rb
@@ -4,7 +4,7 @@
 module Rouge
   module Lexers
     module ObjectiveCCommon
-      id = /[a-z$_][a-z0-9$_]*/i
+      _id = /[a-z$_][a-z0-9$_]*/i
 
       def at_keywords
         @at_keywords ||= %w(

--- a/lib/rouge/lexers/openedge.rb
+++ b/lib/rouge/lexers/openedge.rb
@@ -13,7 +13,7 @@ module Rouge
       desc 'The OpenEdge ABL programming language'
 
       # optional comment or whitespace
-      ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
+      _ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
       id = /[a-zA-Z_&{}!][a-zA-Z0-9_\-&!}]*/
 
       def self.keywords

--- a/lib/rouge/lexers/openedge.rb
+++ b/lib/rouge/lexers/openedge.rb
@@ -12,8 +12,6 @@ module Rouge
       title 'OpenEdge ABL'
       desc 'The OpenEdge ABL programming language'
 
-      # optional comment or whitespace
-      _ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
       id = /[a-zA-Z_&{}!][a-zA-Z0-9_\-&!}]*/
 
       def self.keywords

--- a/lib/rouge/lexers/syzlang.rb
+++ b/lib/rouge/lexers/syzlang.rb
@@ -27,7 +27,7 @@ module Rouge
 
       comment = /#.*$/
       inline_spaces = /[ \t]+/
-      eol_spaces = /[\n\r]+/
+      _eol_spaces = /[\n\r]+/
       spaces = /\s+/
 
       state :inline_break do

--- a/lib/rouge/lexers/syzlang.rb
+++ b/lib/rouge/lexers/syzlang.rb
@@ -27,7 +27,6 @@ module Rouge
 
       comment = /#.*$/
       inline_spaces = /[ \t]+/
-      _eol_spaces = /[\n\r]+/
       spaces = /\s+/
 
       state :inline_break do

--- a/lib/rouge/lexers/ttcn3.rb
+++ b/lib/rouge/lexers/ttcn3.rb
@@ -47,7 +47,7 @@ module Rouge
       end
 
       # optional comment or whitespace
-      ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
+      _ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
       id = /[a-zA-Z_]\w*/
       digit = /\d_+\d|\d/
       bin_digit = /[01]_+[01]|[01]/

--- a/lib/rouge/lexers/ttcn3.rb
+++ b/lib/rouge/lexers/ttcn3.rb
@@ -46,8 +46,6 @@ module Rouge
         )
       end
 
-      # optional comment or whitespace
-      _ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
       id = /[a-zA-Z_]\w*/
       digit = /\d_+\d|\d/
       bin_digit = /[01]_+[01]|[01]/

--- a/lib/rouge/tex_theme_renderer.rb
+++ b/lib/rouge/tex_theme_renderer.rb
@@ -109,7 +109,7 @@ END
     end
 
     def render_blank(tok, &b)
-      out = "\\expandafter\\def#{token_name(tok)}#1{#1}"
+      "\\expandafter\\def#{token_name(tok)}#1{#1}"
     end
 
     def render_style(tok, style, &b)

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -47,8 +47,6 @@ describe Rouge::Guesser do
     it 'sequentially filters' do
       custom = Class.new(Rouge::Guesser) {
         define_method(:filter) { |lexers|
-          passed_lexers = lexers
-
           [Rouge::Lexers::Javascript, Rouge::Lexers::Prolog]
         }
       }.new

--- a/tasks/builtins/lasso.rake
+++ b/tasks/builtins/lasso.rake
@@ -46,7 +46,7 @@ module Rouge
           keywords
         end
 
-        def render_output (keywords, &b)
+        def render_output(keywords, &b)
           return enum_for(:render_output, keywords).to_a.join("\n") unless b
 
           yield   "# -*- coding: utf-8 -*- #"

--- a/tasks/builtins/sqf.rake
+++ b/tasks/builtins/sqf.rake
@@ -24,7 +24,7 @@ module Rouge
     module Builtins
       class SQF
         def extract_keywords(input)
-          input.scrub.scan /(?<=\(").+?(?=")/
+          input.scrub.scan(/(?<=\(").+?(?=")/)
         end
 
         def render_output(keywords, &b)


### PR DESCRIPTION
This reduces around 21 warnings lines as the output of `RUBYOPT='-W' rake check:specs` command (232 -> 211).

Extracted from https://github.com/rouge-ruby/rouge/pull/1962