### PR TITLE
toml: support all date formats

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -48,7 +48,8 @@ module Rouge
           groups Name::Property, Text, Punctuation
         end
 
-        rule %r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, Literal::Date
+        rule %r/\d{4}-\d{2}-\d{2}(?:[Tt ]\d{2}:\d{2}:\d{2}(?:[Zz]|[+-]\d{2}:\d{2})?)?/, Literal::Date
+        rule %r/\d{2}:\d{2}:\d{2}/, Literal::Date
 
         rule %r/[+-]?\d+(?:_\d+)*\.\d+(?:_\d+)*(?:[eE][+-]?\d+(?:_\d+)*)?/, Num::Float
         rule %r/[+-]?\d+(?:_\d+)*[eE][+-]?\d+(?:_\d+)*/, Num::Float

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -6,7 +6,13 @@ title = "TOML Example"
 name = "Tom Preston-Werner"
 organization = "GitHub"
 bio = "GitHub Cofounder & CEO\nLikes tater tots and beer."
-dob = 1979-05-27T07:32:00Z # First class dates? Why not?
+# First class dates? Why not?
+dob = [
+	1979-05-27T07:32:00Z,
+	1979-05-27 07:32:00
+	1979-05-27,
+	07:32:00,
+]
 
 [database]
 server = "192.168.1.1"


### PR DESCRIPTION
TOML supports several different date formats:

	2006-01-02T18:19:20Z         # UTC
	2006-01-02T18:19:20+01:00    # Timezone
	2006-01-02 18:19:20+01:00    # Can use space instead of "T"

	2006-01-02 18:19:20          # Local date-time without timezone
	2006-01-02                   # Local date
	18:19:20                     # Local time