### PR TITLE
Add "wolfram" as an alias for Mathematica

### DIFF
--- a/lib/rouge/lexers/mathematica.rb
+++ b/lib/rouge/lexers/mathematica.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Mathematica"
       desc "Wolfram Mathematica, the world's definitive system for modern technical computing."
       tag 'mathematica'
-      aliases 'wl'
+      aliases 'wl', 'wolfram'
       filenames '*.m', '*.wl'
       mimetypes 'application/vnd.wolfram.mathematica.package', 'application/vnd.wolfram.wl'
 


### PR DESCRIPTION
I think this is the actual name of this programming language https://en.wikipedia.org/wiki/Wolfram_Language