### PR TITLE
Add Operator Support to the HCL Lexer

### DIFF
--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -26,6 +26,7 @@ module Rouge
       state :primitives do
         rule %r/[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?([kKmMgG]b?)?/, Num::Float
         rule %r/[0-9]+([kKmMgG]b?)?/, Num::Integer
+        rule %r/[-+*\/!%&<>|=:?]/, Operator
 
         rule %r/"/, Str::Double, :dq
         rule %r/'/, Str::Single, :sq

--- a/spec/visual/samples/hcl
+++ b/spec/visual/samples/hcl
@@ -84,3 +84,17 @@ resource "aws_subnet" "main" {
 resource "aws_cloudfront_distribution" "s3_distribution" {
   aliases = ["www.${replace(var.domain_name, "/\\.$/", "")}"]
 }
+
+## operators
+locals {
+  op01 = var.var1 != var.var2 ? var.var1 : var.var2
+  op02 = var.var1 == var.var2 ? var.var1 : var.var2
+  op05 = var.var1 < var.var2 ? var.var1 : var.var2
+  op06 = var.var1 <= var.var2 ? var.var1 : var.var2
+  op07 = var.var1 > var.var2 ? var.var1 : var.var2
+  op08 = var.var1 >= var.var2 ? var.var1 : var.var2
+  op09 = var.var1 && var.var2 ? var.var1 : var.var2
+  op10 = var.var1 || var.var2 ? var.var1 : var.var2
+  op11 = !var.var1 ? var.var1 : var.var2
+  op12 = 1 + 2 * 3 / 4 % 5 - 6
+}


### PR DESCRIPTION
Adds operator support to the HCL Lexer.

### HCL Operator Sample (before)

Note the red errors

![image](https://github.com/rouge-ruby/rouge/assets/32168619/a57f6850-af2b-47fc-8d07-430f65fb0716)

### HCL Operator Sample (after)

![image](https://github.com/rouge-ruby/rouge/assets/32168619/7d72f823-6b04-47ea-a763-b91532092bf5)
