### PR TITLE
Add some unicode operators in Eiffel

### DIFF
--- a/lib/rouge/lexers/eiffel.rb
+++ b/lib/rouge/lexers/eiffel.rb
@@ -44,7 +44,7 @@ module Rouge
         rule %r/(?:\d(?:_*\d)*)?\.(?:(?:\d(?:_*\d)*)?[eE][+-]?)?\d(?:_*\d)*|\d(?:_*\d)*\.?/, Num::Float
 
         rule %r/:=|<<|>>|\(\||\|\)|->|\.|[{}\[\];(),:?]/, Punctuation::Indicator
-        rule %r/\\\\|\|\.\.\||\.\.|\/[~\/]?|[><\/]=?|[-+*^=~]/, Operator
+        rule %r/\\\\|\|\.\.\||\.\.|\/[~\/]?|[><\/]=?|[-+*^=~≤≥−∀∃¦⟳⟲]/, Operator
 
         rule %r/[A-Z][\dA-Z_]*/, Name::Class
         rule %r/[A-Za-z][\dA-Za-z_]*/, Name

--- a/spec/visual/samples/eiffel
+++ b/spec/visual/samples/eiffel
@@ -1,4 +1,9 @@
+-- Unicode operators
+1 ≥ -a -- Unicode minus
+∀ x: array ¦ ∃ y: array ¦ x = y
+⟳ x: array ¦ print (x.out) ⟲
 
+-- Real class example
 note
 	description: "[
 		Sequences of values, all of the same type or of a conforming one,


### PR DESCRIPTION
Eiffel has [Symbolic forms of loops](https://www.eiffel.org/blog/Alexander%20Kogtenkov/2020/03/symbolic-forms-loops) like
```eiffel
∀ c: s ¦ f (c)
∃ c: s ¦ f (c)
⟳ c: s ¦ g (c); h (c) ⟲
```

Also the standard library of EiffelStudio has unicode aliases for several operators like `≤`, `≥`.

This PR adds them to the Eiffel lexer.

Before:
![image](https://github.com/rouge-ruby/rouge/assets/10100907/55c79fe1-bca2-45f0-88c5-a9650b7796c0)

After:
![image](https://github.com/rouge-ruby/rouge/assets/10100907/17e33864-3072-4447-9130-73322541336c)
