### PR TITLE
add halfway support for multiline elixir sigils

### DIFF
--- a/spec/visual/samples/elixir
+++ b/spec/visual/samples/elixir
@@ -71,6 +71,21 @@ string |> String.split(~r/[ -]/) |> Enum.map(&abbreviate_word/1) |> Enum.join()
 ~S|inter #{pol <> "ati#{o}"} n|
 ~S/inter #{pol <> "ati#{o}"} n/
 
+# multiline sigil
+~S"""
+Converts double-quotes to single-quotes.
+
+## Examples
+
+    iex> convert("\"foo\"")
+    "'foo'"
+"""
+
+~H"""
+Current temperature: <%= @temperature %>°F
+<button phx-click="inc_temperature">+</button>
+"""
+
 # first is Operator, second is &1 variable
 &(&1)
 


### PR DESCRIPTION
This changeset treats multiline sigils as doc strings, similar to how things work in GitHub as of time of authoring.

I'm not sure if this is the best approach, but it seems to work equivalently to GitHub, etc which seems good enough for now.

Fixes #2051 