### PR TITLE
Detect Containerfiles as Dockerfiles

### DIFF
--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -7,8 +7,8 @@ module Rouge
       title "Docker"
       desc "Dockerfile syntax"
       tag 'docker'
-      aliases 'dockerfile', 'Dockerfile'
-      filenames 'Dockerfile', '*.Dockerfile', '*.docker'
+      aliases 'dockerfile', 'Dockerfile', 'containerfile', 'Containerfile'
+      filenames 'Dockerfile', '*.Dockerfile', '*.docker', 'Containerfile', '*.Containerfile'
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/spec/lexers/docker_spec.rb
+++ b/spec/lexers/docker_spec.rb
@@ -11,6 +11,8 @@ describe Rouge::Lexers::Docker do
       assert_guess :filename => 'Dockerfile'
       assert_guess :filename => 'docker.docker'
       assert_guess :filename => 'some.Dockerfile'
+      assert_guess :filename => 'Containerfile'
+      assert_guess :filename => 'some.Containerfile'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
The `podman` & `buildah` tools support files named `Containerfile` in addition to `Dockerfile`, and the syntax is the same:

> A Containerfile uses the same syntax as a Dockerfile internally.

https://docs.podman.io/en/latest/markdown/podman-build.1.html

According to the maintainers, the intent is to keep it the same:

> The content, commands, and any features that are usable in a Dockerfile should also be usable in a Containerfile too. That's the design goal.

https://github.com/containers/buildah/discussions/3170

This patch simply extends the filename globs to include the alternative filenames & extensions.