### PR TITLE
toml: support inline tables in arrays

### DIFF
--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -67,6 +67,7 @@ module Rouge
         mixin :esc_str
         rule %r/\,/, Punctuation
         rule %r/\[/, Punctuation, :array
+        rule %r/\{/, Punctuation, :inline
       end
 
       state :dq do

--- a/spec/visual/samples/toml
+++ b/spec/visual/samples/toml
@@ -135,6 +135,7 @@ nested_arrays_of_ints = [ [ 1, 2 ], [3, 4, 5] ]
 nested_mixed_array = [ [ 1, 2 ], ["a", "b", "c"] ]
 string_array = [ "all", 'strings', """are the same""", '''type''' ]
 link-libraries = ["mylib::mylib"]
+points = [ { x = 1, y = 2 }, { x = 3, y = 4 } ]
 
 # Dotted keys
 physical.color = "orange"


### PR DESCRIPTION
Syntax like this is valid TOML:

```toml
list = [ { z = 1 } ]
```

but currently it gets incorrectly rejected by Rouge:

![image](https://github.com/user-attachments/assets/92ef1359-8c05-4355-9d9b-48cb0f5e3d83)

I believe this change fixes that without introducing any obvious side-effects.

As a side-note: since 1bdd9486297f37bb95c298eb68409666bd9906fc, I think the special case for `ident = {` in :basic is probably no longer necessary, but I'm not confident enough in that to actually remove it right now. I also think having the `ident =` case in :content is incorrect, and that should be in :inline instead (or in some mixin that can be shared by :root and :inline) – currently, things like `x = [ y = 2 ]` are accepted despite being invalid TOML, and I believe that rule is the reason for that.