### PR TITLE
Fix NameError in the Mojo lexer in Ruby 2.7

### DIFF
--- a/lib/rouge/lexers/mojo.rb
+++ b/lib/rouge/lexers/mojo.rb
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+require('rouge/lexers/python')
+
 module Rouge
   module Lexers
     class Mojo < Python

--- a/lib/rouge/lexers/mojo.rb
+++ b/lib/rouge/lexers/mojo.rb
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
-require('rouge/lexers/python')
-
 module Rouge
   module Lexers
+    load_lexer 'python.rb'
+    
     class Mojo < Python
       title "Mojo"
       desc "The Mojo programming language (modular.com)"


### PR DESCRIPTION
This PR addresses an issue I encountered building #2067 