### PR TITLE
Support special escape sequences in Terraform

### DIFF
--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -39,8 +39,9 @@ module Rouge
 
       state :strings do
         rule %r/\\./, Str::Escape
+        rule %r/(\$[\$]+|%[%]+)(\{)/, Str
         rule %r/\$\{/ do
-          token Keyword
+          token Punctuation
           push :interpolation
         end
       end
@@ -66,7 +67,7 @@ module Rouge
 
       state :interpolation do
         rule %r/\}/ do
-          token Keyword
+          token Punctuation
           pop!
         end
 

--- a/spec/visual/samples/terraform
+++ b/spec/visual/samples/terraform
@@ -84,3 +84,18 @@ resource "aws_subnet" "main" {
 resource "aws_cloudfront_distribution" "s3_distribution" {
   aliases = ["www.${replace(var.domain_name, "/\\.$/", "")}"]
 }
+
+# Directives in string templates
+locals {
+  policy = <<EOT
+%{ for ip in aws_instance.example[*].private_ip }
+server ${ip}
+%{ endfor }
+EOT
+}
+
+# Special escape sequences that do not use backslashes
+locals {
+  demo_dollars_1 = "$${local.demo}"
+  demo_dollars_2 = "%%{for i in items}"
+}


### PR DESCRIPTION
This MR adds support for special escape sequences `$${` and `%%{` in Terraform lexer.

https://developer.hashicorp.com/terraform/language/expressions/strings#string-templates

| Before | After |
| -- | -- |
|<img width="516" alt="Screenshot 2024-09-18 at 11 10 53 AM" src="https://github.com/user-attachments/assets/dabeb7a2-1302-473f-bc48-2a225df46673">| ![Screenshot 2024-09-18 at 11 28 47 PM](https://github.com/user-attachments/assets/7dc6ef07-4533-44b6-abb3-1074ca226553) |

Fixes https://github.com/rouge-ruby/rouge/issues/2061