### PR TITLE
Default .cfg highlight to INI lexer

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -66,6 +66,12 @@ module Rouge
         end
       end
 
+      disambiguate '*.cfg' do
+        next CiscoIos if matches?(/\A\s*(version|banner|interface)\b/)
+
+        INI
+      end
+
       disambiguate '*.pl' do
         next Perl if contains?('my $')
         next Prolog if contains?(':-')

--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -9,7 +9,7 @@ module Rouge
       tag 'ini'
 
       # TODO add more here
-      filenames '*.ini', '*.INI', '*.gitconfig'
+      filenames '*.ini', '*.INI', '*.gitconfig', '*.cfg'
       mimetypes 'text/x-ini'
 
       identifier = /[\w\-.]+/

--- a/spec/lexers/cisco_ios_spec.rb
+++ b/spec/lexers/cisco_ios_spec.rb
@@ -8,7 +8,9 @@ describe Rouge::Lexers::CiscoIos do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'foo.cfg'
+      # Disambiguate with INI
+      assert_guess :filename => 'foo.cfg', :source => "version 13.4"
+      assert_guess :filename => 'foo.cfg', :source => "interface FastEthernet0.20"
     end
 
     it 'guesses by mimetype' do

--- a/spec/lexers/ini_spec.rb
+++ b/spec/lexers/ini_spec.rb
@@ -10,6 +10,7 @@ describe Rouge::Lexers::INI do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.ini'
       assert_guess :filename => '.gitconfig'
+      assert_guess :filename => 'setup.cfg', :source => "[metadata]\nname = my_package"
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
Cisco IOS shares the same extension but we want to limit it given the relevant content. For other cases such as `setup.cfg`, we would prefer INI syntax.

| Before | After |
| -- | -- |
| Ciso IOS | INI |
| <img width="516" alt="Screenshot 2024-09-18 at 11 04 11 AM" src="https://github.com/user-attachments/assets/8722de5d-fb90-453f-9dc2-526a1939e91b"> | <img width="516" alt="Screenshot 2024-09-18 at 11 04 23 AM" src="https://github.com/user-attachments/assets/5df06a27-4420-4e68-b2b2-588eb2eee344"> |
