### PR TITLE
Add more extensions and mimetypes for INI lexer

### DIFF
--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -8,9 +8,8 @@ module Rouge
       desc 'the INI configuration format'
       tag 'ini'
 
-      # TODO add more here
-      filenames '*.ini', '*.INI', '*.gitconfig', '*.cfg'
-      mimetypes 'text/x-ini'
+      filenames '*.ini', '*.INI', '*.gitconfig', '*.cfg', '.editorconfig', '*.inf'
+      mimetypes 'text/x-ini', 'text/inf'
 
       identifier = /[\w\-.]+/
 

--- a/spec/lexers/ini_spec.rb
+++ b/spec/lexers/ini_spec.rb
@@ -11,10 +11,13 @@ describe Rouge::Lexers::INI do
       assert_guess :filename => 'foo.ini'
       assert_guess :filename => '.gitconfig'
       assert_guess :filename => 'setup.cfg', :source => "[metadata]\nname = my_package"
+      assert_guess :filename => '.editorconfig'
+      assert_guess :filename => 'request.inf'
     end
 
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'text/x-ini'
+      assert_guess :mimetype => 'text/inf'
     end
   end
 end


### PR DESCRIPTION
This MR adds more supported extensions and mimetypes for INI lexer. This change aligns with the Pygments counterpart ([ref](https://github.com/pygments/pygments/blob/5da0e25341a8fff00c8b25625e8f9cbbd4d6836f/pygments/lexers/configs.py#L36C4-L36C5)).