### PR TITLE
Support private property identifier in JS lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -190,8 +190,8 @@ module Rouge
 
         rule %r/function(?=(\(.*\)))/, Keyword::Declaration # For anonymous functions
 
-        rule %r/(#{id})[ \t]*(?=(\(.*\)))/m do |m|
-          if self.class.keywords.include? m[1]
+        rule %r/(#?#{id})[ \t]*(?=(\(.*\)))/m do |m|
+          if self.class.keywords.include?(m[1])
             # "if" in "if (...)" or "switch" in "switch (...)" are recognized as keywords.
             token Keyword
           else
@@ -201,7 +201,7 @@ module Rouge
 
         rule %r/[{}]/, Punctuation, :statement
 
-        rule id do |m|
+        rule %r/#?#{id}/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
             push :expr_start

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -297,3 +297,21 @@ ret += "\n";
 
 let baz;
 baz ??= 'default';
+
+class ClassWithPrivate {
+  #privateField;
+  #privateFieldWithInitializer = 42;
+
+  #privateMethod(obj) {
+    if (#privateField in obj) return obj.#privateField;
+
+    return "invalid obj"
+  }
+
+  static #privateStaticField;
+  static #privateStaticFieldWithInitializer = 42;
+
+  static #privateStaticMethod() {
+    // …
+  }
+}


### PR DESCRIPTION
This adds support to highlight private property identifier in JS lexer.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties

| Before | After |
| -- | -- |
| ![Screenshot 2024-09-25 at 10 46 45 PM](https://github.com/user-attachments/assets/76bdb312-11dc-4220-90b7-c8a6d4bc56dd) | ![Screenshot 2024-09-25 at 10 46 17 PM](https://github.com/user-attachments/assets/888ee07a-98e3-4950-ad8a-9e1f26452626) |

