### PR TITLE
Recognize Thor files as Ruby files

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -11,7 +11,7 @@ module Rouge
       filenames '*.rb', '*.ruby', '*.rbw', '*.rake', '*.gemspec', '*.podspec',
                 'Rakefile', 'Guardfile', 'Gemfile', 'Capfile', 'Podfile',
                 'Vagrantfile', '*.ru', '*.prawn', 'Berksfile', '*.arb',
-                'Dangerfile', 'Fastfile', 'Deliverfile', 'Appfile'
+                'Dangerfile', 'Fastfile', 'Deliverfile', 'Appfile', '*.thor', 'Thorfile'
 
       mimetypes 'text/x-ruby', 'application/x-ruby'
 

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -113,6 +113,8 @@ describe Rouge::Lexers::Ruby do
       assert_guess :filename => 'Deliverfile'
       assert_guess :filename => 'Fastfile'
       assert_guess :filename => 'Appfile'
+      assert_guess :filename => 'Thorfile'
+      assert_guess :filename => 'foo.thor'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
Hi. This pull request add `Thorfile` and `*.thor` files to the filenames of the Ruby lexer since they are Ruby files.

Here are before&after screenshots.

I used these two files: [Thorfile](https://github.com/rails/thor/blob/main/Thorfile) and [command.thor](https://github.com/rails/thor/blob/main/spec/fixtures/command.thor) from the Rails repo to make them:

Command: `./bin/rougify <filename> --theme=github`

|Before|After|
|-------|----------|
|![CleanShot 2024-10-22 at 18 26 59@2x](https://github.com/user-attachments/assets/3e5006d5-c69e-4c60-9c8f-20b5eafeb4a1)|![CleanShot 2024-10-22 at 18 24 40@2x](https://github.com/user-attachments/assets/f458a5cc-5a6a-4e09-931a-82259b4acd8c)|
|![CleanShot 2024-10-22 at 18 26 50@2x](https://github.com/user-attachments/assets/4a369b09-134d-4513-a50b-2717b47fc41e)|![CleanShot 2024-10-22 at 18 25 24@2x](https://github.com/user-attachments/assets/05ea39b8-2c5b-468b-a5d6-8fa71ce6ce7f)|


Reference:
- https://github.com/rails/thor/wiki/Getting-Started#file-names


Thanks!