### PR TITLE
Allow Groovy files to start with a shebang

### DIFF
--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -42,6 +42,12 @@ module Rouge
       end
 
       state :root do
+        # groovy allows a file to start with a shebang
+        rule %r/\A#!(.*?)$/, Comment::Preproc
+        rule %r//, Text, :base
+      end
+
+      state :base do
         rule %r(^
           (\s*(?:\w[\w.\[\]]*\s+)+?) # return arguments
           (\w\w*) # method name


### PR DESCRIPTION
This adds proper syntax highlighting for shebangs in Groovy and Nextflow files.