### PR TITLE
Remove Regexps and espace $ from Terraform Lexer

### DIFF
--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -44,6 +44,7 @@ module Rouge
           token Punctuation
           push :interpolation
         end
+        rule %r/\$/, Str
       end
 
       state :dq do
@@ -74,24 +75,9 @@ module Rouge
         mixin :expression
       end
 
-      state :regexps do
-        rule %r/"\// do
-          token Str::Delimiter
-          goto :regexp_inner
-        end
-      end
-
-      state :regexp_inner do
-        rule %r/[^"\/\\]+/, Str::Regex
-        rule %r/\\./, Str::Regex
-        rule %r/\/"/, Str::Delimiter, :pop!
-        rule %r/["\/]/, Str::Regex
-      end
-
       id = /[$a-z_\-][a-z0-9_\-]*/io
 
       state :expression do
-        mixin :regexps
         mixin :primitives
         rule %r/\s+/, Text
 

--- a/spec/visual/samples/terraform
+++ b/spec/visual/samples/terraform
@@ -98,4 +98,7 @@ EOT
 locals {
   demo_dollars_1 = "$${local.demo}"
   demo_dollars_2 = "%%{for i in items}"
+
+  interpolation_with_slashes = "interpolated-${replace("string", "?", "-")}"
+  interpolation_with_slashes = "interpolated-${replace("string", "/", "-")}"
 }

--- a/spec/visual/samples/terraform
+++ b/spec/visual/samples/terraform
@@ -85,6 +85,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   aliases = ["www.${replace(var.domain_name, "/\\.$/", "")}"]
 }
 
+## Object with single-quoted regular expression
+resource "aws_cloudfront_distribution" "s3_distribution_single_quote" {
+  aliases = ["www.${replace(var.domain_name, '/\\.$/', "")}"]
+}
+
 # Directives in string templates
 locals {
   policy = <<EOT


### PR DESCRIPTION
Solves the original issue from #1304, the issue #2087 as well as single quoted regexps.

This behavior matches the GitHub highlighter by not highlighting Regular expressions and considering them as String instead. I'm open to any challenge if someone has a use-case for Regexps or is able to implement some kind of backtracking/lookahead.

Screenshot of the result:
![image](https://github.com/user-attachments/assets/228bc777-ca57-44c3-a098-a32ca87b5cda)
