### PR TITLE
Support mustache template in Svelte

### DIFF
--- a/lib/rouge/lexers/svelte.rb
+++ b/lib/rouge/lexers/svelte.rb
@@ -62,7 +62,7 @@ module Rouge
         rule %r/}/, Str::Interpol, :pop!
 
         # Allow JS lexer to handle matched curly braces within template
-        rule(/(?<=^|[^\\])\{.*?(?<=^|[^\\])\}/) do
+        rule(/(?<=^|[^\\])\{+.*?(?<=^|[^\\])\}+/) do
           delegate @js
         end
 

--- a/spec/visual/samples/svelte
+++ b/spec/visual/samples/svelte
@@ -76,3 +76,24 @@ Hey { name}, check out our { cats.length } cats!
         font-size: 2em;
     }
 </style>
+
+<div class="flex gap-1.5">
+  <Tooltip
+    className="w-full relative"
+    content={$i18n.t(`WebUI will make requests to "{{url}}/api/chat"`, {url})}
+    placement="top-start"
+  >
+    {#if !(config?.enable ?? true)}
+      <div
+        class="absolute top-0 bottom-0 left-0 right-0 opacity-60 bg-white dark:bg-gray-900 z-10"
+      ></div>
+    {/if}
+
+    <input
+      class="w-full text-sm bg-transparent outline-none odl-text-test"
+      placeholder={$i18n.t('Enter URL (e.g. http://localhost:11434)')}
+      bind:value={url}
+      class="w-full text-sm bg-transparent outline-none odl-text-test"
+    />
+  </Tooltip>
+</div>


### PR DESCRIPTION
This ensures we delegate the handling of `{{}}` in mustache template to JS lexer.

| Before | After |
| -- | -- |
| ![Screenshot 2024-12-19 at 12 01 34 am](https://github.com/user-attachments/assets/ff907a95-1ea7-423d-bf45-e0620fe93e7d)| ![Screenshot 2024-12-19 at 12 01 00 am](https://github.com/user-attachments/assets/fba609ae-2837-4b22-9735-abb89c0b3ad8)|
