### PR TITLE
Improve Objective-C vs Mathematica lexer disambiguation

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -90,8 +90,13 @@ module Rouge
       disambiguate '*.m' do
         next ObjectiveC if matches?(/@(end|implementation|protocol|property)\b/)
         next ObjectiveC if contains?('@"')
-
-        next Mathematica if contains?('(*')
+        # Opening brace at end of line
+        next ObjectiveC if matches?(/\s*{\s*$/)
+  
+        # Objective-C may use dereferenced pointers in statements: `if (*foo == 0)`.
+        # This is similar to Mathmatica's comment syntax: `(* comment *)`.
+        # Disambiguate by checking for any amount of whitespace (or no whitespace) followed by (*
+        next Mathematica if matches?(/^\s*\(\*/)
         next Mathematica if contains?(':=')
 
         next Mason if matches?(/<%(def|method|text|doc|args|flags|attr|init|once|shared|perl|cleanup|filter)([^>]*)(>)/)

--- a/spec/lexers/mathematica_spec.rb
+++ b/spec/lexers/mathematica_spec.rb
@@ -16,5 +16,10 @@ describe Rouge::Lexers::Mathematica do
       assert_guess :mimetype => 'application/vnd.wolfram.mathematica.package'
       assert_guess :mimetype => 'application/vnd.wolfram.wl'
     end
+
+    it 'guesses by source' do
+      assert_guess :filename => 'foo.m', :source => '(* Mathematica comment *)'
+      assert_guess :filename => 'foo.m', :source => 'a := b'
+    end
   end
 end

--- a/spec/lexers/matlab_spec.rb
+++ b/spec/lexers/matlab_spec.rb
@@ -33,5 +33,10 @@ describe Rouge::Lexers::Matlab do
       end
       eos
     end
+
+    it 'guesses by source' do
+      assert_guess :filename => 'foo.m', :source => '% MATLAB comment'
+      assert_guess :filename => 'foo.m', :source => 'mycell = {'
+    end
   end
 end

--- a/spec/lexers/objective_c_spec.rb
+++ b/spec/lexers/objective_c_spec.rb
@@ -20,6 +20,8 @@ describe Rouge::Lexers::ObjectiveC do
       assert_guess :filename => 'foo.h', :source => '@"foo"'
       assert_guess :filename => 'foo.h', :source => '@implementation Foo'
       assert_guess :filename => 'foo.m', :source => 'if (*bar == 0) {'
+      assert_guess :filename => 'foo.m', :source => 'while (*ptr != NULL)'
+      assert_guess :filename => 'foo.m', :source => 'if (*(void **)(addr + 8) == target) {'
     end
   end
 end

--- a/spec/lexers/objective_c_spec.rb
+++ b/spec/lexers/objective_c_spec.rb
@@ -19,6 +19,7 @@ describe Rouge::Lexers::ObjectiveC do
     it 'guesses by source' do
       assert_guess :filename => 'foo.h', :source => '@"foo"'
       assert_guess :filename => 'foo.h', :source => '@implementation Foo'
+      assert_guess :filename => 'foo.m', :source => 'if (*bar == 0) {'
     end
   end
 end


### PR DESCRIPTION
This PR fixes an issue where Rouge would incorrectly identify Objective-C code as Mathematica when encountering pointer dereference syntax in .m files.

### Problem
The current lexer disambiguation logic for .m files checks for `(*` to identify Mathematica files. However, this pattern also appears in valid Objective-C code when using pointer dereference syntax, like:

```c
if (*foo == 0) {
```

This causes Rouge to incorrectly identify such files as Mathematica, leading to incorrect syntax highlighting.

### Solution
The fix improves the disambiguation logic by:

* Making the Mathematica comment detection more specific - only matching (* when it appears at the start of a line (with optional whitespace)
* Adding an additional Objective-C identifier for lines ending with an opening brace
* Adding a test case to verify the fix

### Related Issues

* This issue was originally reported in GitLab: [gitlab-org/gitlab#292672](https://gitlab.com/gitlab-org/gitlab/-/issues/292672#note_2305187939)
* The bug causes incorrect syntax highlighting in GitLab's UI

![Screenshot 2025-01-20 at 13 14 49](https://github.com/user-attachments/assets/edd04d9d-196b-4fc1-96e7-e8a89ef5c10e)

