### PR TITLE
Update Python builtin keywords, functions, and exceptions to Python version 3

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -18,8 +18,8 @@ module Rouge
 
       def self.keywords
         @keywords ||= %w(
-          assert break continue del elif else except exec
-          finally for global if lambda pass print raise
+          assert break continue del elif else except
+          finally for global if lambda pass raise
           return try while yield as with from import
           async await nonlocal
         )
@@ -27,15 +27,14 @@ module Rouge
 
       def self.builtins
         @builtins ||= %w(
-          __import__ abs all any apply ascii basestring bin bool buffer
-          bytearray bytes callable chr classmethod cmp coerce compile
-          complex delattr dict dir divmod enumerate eval execfile exit
-          file filter float format frozenset getattr globals hasattr hash hex id
-          input int intern isinstance issubclass iter len list locals
-          long map max memoryview min next object oct open ord pow property range
-          raw_input reduce reload repr reversed round set setattr slice
-          sorted staticmethod str sum super tuple type unichr unicode
-          vars xrange zip
+          __import__ abs aiter all anext any ascii bin bool
+          breakpoint bytearray bytes callable chr classmethod compile
+          complex delattr dict dir divmod enumerate eval exec
+          filter float format frozenset getattr globals hasattr hash help hex id
+          input int isinstance issubclass iter len list locals
+          map max memoryview min next object oct open ord pow print property
+          range repr reversed round set setattr slice
+          sorted staticmethod str sum super tuple type vars zip
         )
       end
 
@@ -45,25 +44,23 @@ module Rouge
 
       def self.exceptions
         @exceptions ||= %w(
-          ArithmeticError AssertionError AttributeError
-          BaseException BlockingIOError BrokenPipeError BufferError
-          BytesWarning ChildProcessError ConnectionAbortedError
-          ConnectionError ConnectionRefusedError ConnectionResetError
-          DeprecationWarning EOFError EnvironmentError
-          Exception FileExistsError FileNotFoundError
-          FloatingPointError FutureWarning GeneratorExit IOError
-          ImportError ImportWarning IndentationError IndexError
-          InterruptedError IsADirectoryError KeyError KeyboardInterrupt
-          LookupError MemoryError ModuleNotFoundError NameError
-          NotADirectoryError NotImplemented NotImplementedError OSError
-          OverflowError OverflowWarning PendingDeprecationWarning
-          ProcessLookupError RecursionError ReferenceError ResourceWarning
-          RuntimeError RuntimeWarning StandardError StopAsyncIteration
-          StopIteration SyntaxError SyntaxWarning SystemError SystemExit
-          TabError TimeoutError TypeError UnboundLocalError UnicodeDecodeError
-          UnicodeEncodeError UnicodeError UnicodeTranslateError
-          UnicodeWarning UserWarning ValueError VMSError Warning
-          WindowsError ZeroDivisionError
+          ArithmeticError AssertionError AttributeError BaseException
+          BaseExceptionGroup BlockingIOError BrokenPipeError BufferError
+          BytesWarning ChildProcessError ConnectionAbortedError ConnectionError
+          ConnectionRefusedError ConnectionResetError DeprecationWarning
+          EOFError EncodingWarning Exception ExceptionGroup FileExistsError
+          FileNotFoundError FloatingPointError FutureWarning GeneratorExit
+          ImportError ImportWarning IndentationError IndexError InterruptedError
+          IsADirectoryError KeyError KeyboardInterrupt LookupError MemoryError
+          ModuleNotFoundError NameError NotADirectoryError NotImplementedError
+          OSError OverflowError PendingDeprecationWarning PermissionError
+          ProcessLookupError PythonFinalizationError RecursionError
+          ReferenceError ResourceWarning RuntimeError RuntimeWarning
+          StopAsyncIteration StopIteration SyntaxError SyntaxWarning SystemError
+          SystemExit TabError TimeoutError TypeError UnboundLocalError
+          UnicodeDecodeError UnicodeEncodeError UnicodeError
+          UnicodeTranslateError UnicodeWarning UserWarning ValueError Warning
+          ZeroDivisionError
         )
       end
 

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -18,8 +18,8 @@ module Rouge
 
       def self.keywords
         @keywords ||= %w(
-          assert break continue del elif else except
-          finally for global if lambda pass raise
+          assert break continue del elif else except exec
+          finally for global if lambda pass print raise
           return try while yield as with from import
           async await nonlocal
         )
@@ -27,14 +27,14 @@ module Rouge
 
       def self.builtins
         @builtins ||= %w(
-          __import__ abs aiter all anext any ascii bin bool
-          breakpoint bytearray bytes callable chr classmethod compile
-          complex delattr dict dir divmod enumerate eval exec
+          __import__ abs aiter all anext any apply ascii basestring bin bool
+          buffer breakpoint bytearray bytes callable chr classmethod cmp coerce compile
+          complex delattr dict dir divmod enumerate eval exec execfile exit file
           filter float format frozenset getattr globals hasattr hash help hex id
-          input int isinstance issubclass iter len list locals
+          input int intern isinstance issubclass iter len list locals long
           map max memoryview min next object oct open ord pow print property
-          range repr reversed round set setattr slice
-          sorted staticmethod str sum super tuple type vars zip
+          range raw_input reduce reload repr reversed round set setattr slice
+          sorted staticmethod str sum super tuple type unichr unicode vars xrange zip
         )
       end
 
@@ -48,18 +48,18 @@ module Rouge
           BaseExceptionGroup BlockingIOError BrokenPipeError BufferError
           BytesWarning ChildProcessError ConnectionAbortedError ConnectionError
           ConnectionRefusedError ConnectionResetError DeprecationWarning
-          EOFError EncodingWarning Exception ExceptionGroup FileExistsError
-          FileNotFoundError FloatingPointError FutureWarning GeneratorExit
+          EOFError EnvironmentError EncodingWarning Exception ExceptionGroup FileExistsError
+          FileNotFoundError FloatingPointError FutureWarning GeneratorExit IOError
           ImportError ImportWarning IndentationError IndexError InterruptedError
           IsADirectoryError KeyError KeyboardInterrupt LookupError MemoryError
-          ModuleNotFoundError NameError NotADirectoryError NotImplementedError
-          OSError OverflowError PendingDeprecationWarning PermissionError
+          ModuleNotFoundError NameError NotADirectoryError NotImplemented NotImplementedError
+          OSError OverflowError OverflowWarning PendingDeprecationWarning PermissionError
           ProcessLookupError PythonFinalizationError RecursionError
-          ReferenceError ResourceWarning RuntimeError RuntimeWarning
+          ReferenceError ResourceWarning RuntimeError RuntimeWarning StandardError
           StopAsyncIteration StopIteration SyntaxError SyntaxWarning SystemError
           SystemExit TabError TimeoutError TypeError UnboundLocalError
           UnicodeDecodeError UnicodeEncodeError UnicodeError
-          UnicodeTranslateError UnicodeWarning UserWarning ValueError Warning
+          UnicodeTranslateError UnicodeWarning UserWarning ValueError VMSError Warning WindowsError
           ZeroDivisionError
         )
       end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)
-        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?/)
+        return true if text.shebang?(/pythonw?(?:[3](?:\.\d+)?)?/)
       end
 
       def self.keywords

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -20,7 +20,7 @@ module Rouge
         @keywords ||= %w(
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
-          return try while yield as with from import yield
+          return try while yield as with from import
           async await nonlocal
         )
       end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -27,14 +27,17 @@ module Rouge
 
       def self.builtins
         @builtins ||= %w(
-          __import__ abs aiter all anext any apply ascii basestring bin bool
-          buffer breakpoint bytearray bytes callable chr classmethod cmp coerce compile
-          complex delattr dict dir divmod enumerate eval exec execfile exit file
-          filter float format frozenset getattr globals hasattr hash help hex id
-          input int intern isinstance issubclass iter len list locals long
+          __import__ abs aiter all anext any apply ascii
+          basestring bin bool buffer breakpoint bytearray bytes
+          callable chr classmethod cmp coerce compile complex
+          delattr dict dir divmod enumerate eval exec execfile exit
+          file filter float format frozenset getattr globals
+          hasattr hash help hex
+          id input int intern isinstance issubclass iter len list locals long
           map max memoryview min next object oct open ord pow print property
           range raw_input reduce reload repr reversed round set setattr slice
-          sorted staticmethod str sum super tuple type unichr unicode vars xrange zip
+          sorted staticmethod str sum super tuple type unichr unicode vars
+          xrange zip
         )
       end
 
@@ -48,18 +51,21 @@ module Rouge
           BaseExceptionGroup BlockingIOError BrokenPipeError BufferError
           BytesWarning ChildProcessError ConnectionAbortedError ConnectionError
           ConnectionRefusedError ConnectionResetError DeprecationWarning
-          EOFError EnvironmentError EncodingWarning Exception ExceptionGroup FileExistsError
-          FileNotFoundError FloatingPointError FutureWarning GeneratorExit IOError
-          ImportError ImportWarning IndentationError IndexError InterruptedError
-          IsADirectoryError KeyError KeyboardInterrupt LookupError MemoryError
-          ModuleNotFoundError NameError NotADirectoryError NotImplemented NotImplementedError
-          OSError OverflowError OverflowWarning PendingDeprecationWarning PermissionError
-          ProcessLookupError PythonFinalizationError RecursionError
-          ReferenceError ResourceWarning RuntimeError RuntimeWarning StandardError
-          StopAsyncIteration StopIteration SyntaxError SyntaxWarning SystemError
-          SystemExit TabError TimeoutError TypeError UnboundLocalError
-          UnicodeDecodeError UnicodeEncodeError UnicodeError
-          UnicodeTranslateError UnicodeWarning UserWarning ValueError VMSError Warning WindowsError
+          EOFError EnvironmentError EncodingWarning Exception ExceptionGroup
+          FileExistsError FileNotFoundError FloatingPointError FutureWarning
+          GeneratorExit IOError ImportError ImportWarning IndentationError
+          IndexError InterruptedError IsADirectoryError
+          KeyError KeyboardInterrupt LookupError
+          MemoryError ModuleNotFoundError
+          NameError NotADirectoryError NotImplemented NotImplementedError
+          OSError OverflowError OverflowWarning PendingDeprecationWarning
+          PermissionError ProcessLookupError PythonFinalizationError
+          RecursionError ReferenceError ResourceWarning RuntimeError RuntimeWarning
+          StandardError StopAsyncIteration StopIteration SyntaxError SyntaxWarning
+          SystemError SystemExit TabError TimeoutError TypeError
+          UnboundLocalError UnicodeDecodeError UnicodeEncodeError UnicodeError
+          UnicodeTranslateError UnicodeWarning UserWarning ValueError VMSError
+          Warning WindowsError
           ZeroDivisionError
         )
       end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)
-        return true if text.shebang?(/pythonw?(?:[3](?:\.\d+)?)?/)
+        return true if text.shebang?(/pythonw?(?:[23](?:\.\d+)?)?/)
       end
 
       def self.keywords


### PR DESCRIPTION
Python2 is EOL for a while now, see https://www.python.org/doc/sunset-python-2/. Thus, update the builtin keywords, function, and exceptions as how they are used by Python 3.

See:
    - https://docs.python.org/3/reference/lexical_analysis.html#keywords
    - https://docs.python.org/3/library/functions.html
    - https://docs.python.org/3/library/exceptions.html#exception-hierarchy
