### PR TITLE
Avoid loading lexers twice

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -527,6 +527,7 @@ module Rouge
     @_loaded_lexers = {}
 
     def self.load_lexer(relpath)
+      relpath = relpath.to_s # allow Pathnames
       return if @_loaded_lexers.key?(relpath)
       @_loaded_lexers[relpath] = true
       Kernel::load File.join(BASE_DIR, relpath)


### PR DESCRIPTION
Rouge.load_lexers passes Pathname objects to Lexer.load_lexer, causing some lexers to get loaded twice