### PR TITLE
Add *.razor file glob to HTML  [EASY MERGE]

### DIFF
--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -7,7 +7,7 @@ module Rouge
       title "HTML"
       desc "HTML, the markup language of the web"
       tag 'html'
-      filenames '*.htm', '*.html', '*.xhtml', '*.cshtml'
+      filenames '*.htm', '*.html', '*.xhtml', '*.cshtml', '*.razor'
       mimetypes 'text/html', 'application/xhtml+xml'
 
       def self.detect?(text)

--- a/spec/lexers/html_spec.rb
+++ b/spec/lexers/html_spec.rb
@@ -66,6 +66,7 @@ describe Rouge::Lexers::HTML do
       assert_guess :filename => 'foo.htm'
       assert_guess :filename => 'foo.xhtml'
       assert_guess :filename => 'foo.cshtml'
+      assert_guess :filename => 'foo.razor'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
This is a copy of https://github.com/rouge-ruby/rouge/pull/1522 but for .razor files which are basically the successor of .cshtml files and use roughly the same syntax (see https://stackoverflow.com/a/56271408/8915326)

Using HTML syntax highlighting on .razor files will already be MUCH better than having no syntax highlighting at all.  

I came here after reading this Gitlab issue https://gitlab.com/gitlab-org/gitlab-foss/-/issues/42855 we don't have hightlighting on .razor files on Gitlab because of this :)