### PR TITLE
Add record keyword declaration for Java 14+

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -51,7 +51,7 @@ module Rouge
         rule %r/(?:#{declarations.join('|')})\b/, Keyword::Declaration
         rule %r/(?:#{types.join('|')})\b/, Keyword::Type
         rule %r/(?:true|false|null)\b/, Keyword::Constant
-        rule %r/(?:class|interface)\b/, Keyword::Declaration, :class
+        rule %r/(?:class|interface|record)\b/, Keyword::Declaration, :class
         rule %r/(?:import|package)\b/, Keyword::Namespace, :import
         rule %r/"""\s*\n.*?(?<!\\)"""/m, Str::Heredoc
         rule %r/"(\\\\|\\"|[^"])*"/, Str


### PR DESCRIPTION
### Description

- Added support for the record keyword declaration for Java 14 and later versions.
- Updated the syntax parsing logic to recognize record as a valid class declaration type.
- Changes in `lib/rouge/lexers/java.rb`


|Before|After|
|----------|-------|
|![image](https://github.com/user-attachments/assets/f67bca33-c84e-4064-b5f7-ebd47257602c)|![image](https://github.com/user-attachments/assets/2ff74ba2-a6e2-4da1-b21c-23533aa8fbe7)|