### PR TITLE
Fix missing method error in SASS Lexer

### DIFF
--- a/lib/rouge/lexers/sass/common.rb
+++ b/lib/rouge/lexers/sass/common.rb
@@ -155,7 +155,7 @@ module Rouge
       state :attr_common do
         mixin :has_interp
         rule id do |m|
-          if CSS.attributes.include? m[0]
+          if CSS.properties.include? m[0]
             token Name::Label
           else
             token Name::Attribute


### PR DESCRIPTION
The error was detected in a [build](https://github.com/rouge-ruby/rouge/actions/runs/14698168669/job/41242954438.) in the `master` branch.

The bug was introduced in https://github.com/rouge-ruby/rouge/pull/2118