### PR TITLE
Drop support for Ruby < 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rake check:style
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
   DisplayCopNames: true
   Exclude:
     - "tasks/**/*"
     - "vendor/**/*"
+  NewCops: enable
 
 Style:
   Enabled: false

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.2'
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rouge-ruby/rouge/issues",
     "changelog_uri"     => "https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md",


### PR DESCRIPTION
With Ruby 2.7 and 3.1 being EOL, we should drop support for old versions to reduce Rouge gem maintenance effort.