### PR TITLE
Replace usage of `cgi` for ruby 3.5 compatibility

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -5,6 +5,7 @@
 # to use this module, require 'rouge/cli'.
 
 require 'rbconfig'
+require 'uri'
 
 module Rouge
   class FileReader
@@ -348,7 +349,7 @@ module Rouge
       end
 
     private_class_method def self.parse_cgi(str)
-        pairs = CGI.parse(str).map { |k, v| [k.to_sym, v.first] }
+        pairs = URI.decode_www_form(str).map { |k, v| [k.to_sym, v] }
         Hash[pairs]
       end
     end

--- a/lib/rouge/formatters/html_legacy.rb
+++ b/lib/rouge/formatters/html_legacy.rb
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
-# stdlib
-require 'cgi'
-
 module Rouge
   module Formatters
     # Transforms a token stream into HTML output.


### PR DESCRIPTION
In Ruby 3.5, most of the cgi gem is removed. That includes `CGI.parse`, which `rouge` uses.

But, we can subsistute it with `URI.decode_www_form`. The data is returned in a slightly different format (array of arrays instead of a hash), so do some processing to get back into the expected structure.

https://bugs.ruby-lang.org/issues/21258