### PR TITLE
Update Docker file name patterns

### DIFF
--- a/lib/rouge/lexers/docker.rb
+++ b/lib/rouge/lexers/docker.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "Dockerfile syntax"
       tag 'docker'
       aliases 'dockerfile', 'Dockerfile', 'containerfile', 'Containerfile'
-      filenames 'Dockerfile', '*.Dockerfile', '*.docker', 'Containerfile', '*.Containerfile'
+      filenames 'Dockerfile', 'Dockerfile.*', '*.Dockerfile', '*.docker', 'Containerfile', 'Containerfile.*', '*.Containerfile'
       mimetypes 'text/x-dockerfile-config'
 
       KEYWORDS = %w(

--- a/spec/lexers/docker_spec.rb
+++ b/spec/lexers/docker_spec.rb
@@ -11,8 +11,10 @@ describe Rouge::Lexers::Docker do
       assert_guess :filename => 'Dockerfile'
       assert_guess :filename => 'docker.docker'
       assert_guess :filename => 'some.Dockerfile'
+      assert_guess :filename => 'Dockerfile.some'
       assert_guess :filename => 'Containerfile'
       assert_guess :filename => 'some.Containerfile'
+      assert_guess :filename => 'Containerfile.some'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
The `Dockerfile.*` pattern is a common naming scheme when there's more than one file in a repository. Similarly, this can also be extended to `Containerfile.*` files. You can see this in this [build-images project](https://gitlab.com/gitlab-org/security-products/dependencies/build-images), and most projects under the security-products [group](https://gitlab.com/gitlab-org/security-products/dependencies/build-images).