### PR TITLE
Add syntax highlighting for Python match-case statements

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -91,6 +91,7 @@ module Rouge
         rule %r/@#{dotted_identifier}/i, Name::Decorator
 
         rule %r/(in|is|and|or|not)\b/, Operator::Word
+        rule %r/\b(match|case)\b/, Keyword
         rule %r/(<<|>>|\/\/|\*\*)=?/, Operator
         rule %r/[-~+\/*%=<>&^|@]=?|!=/, Operator
 

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -21,7 +21,7 @@ module Rouge
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
           return try while yield as with from import yield
-          async await nonlocal
+          async await nonlocal match case
         )
       end
 

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -218,3 +218,12 @@ def do_nothing():
 
     app = FastAPI()
     FastAPIInstrumentor.instrument_app(app)
+
+
+match 1:
+    case 1:
+        print("1 is 1")
+    case 2:
+        print("1 is 2")
+    case _:
+        print("1 is something")


### PR DESCRIPTION
This adds support for Python 3.10's `match`/`case` syntax.

### Changes:
- Added `match` and `case` to the list of Python keywords in the lexer
- Updated the visual sample for Python syntax highlighting (in `spec/visual/samples/python`)

This is part of Python 3.10's structural pattern matching feature.

***

This is my first contribution to Rouge. I'm happy to receive any feedback!