### PR TITLE
Add lexer for NuSMV/nuXmv model checker language

### DIFF
--- a/lib/rouge/demos/nuxmv
+++ b/lib/rouge/demos/nuxmv
@@ -1,0 +1,32 @@
+MODULE main
+  VAR c: integer;
+  VAR r: real;
+  VAR g: 0..3;
+  
+  INIT
+    c in {0};
+    r = f'1/2;
+  TRANS next(c) in
+    case
+      c < 9 : {c + 1, c + 2};
+      TRUE : {c};
+    esac;
+  
+  TRANS next(r) =
+    case
+      c > 0 & c < 9 : abs(c / 2.0);
+      TRUE : r;
+    esac;
+
+
+-- Named properties
+LTLSPEC NAME g0 := G (c >= 0);
+LTLSPEC NAME e1 := G F c = 9;   -- Inline comment: Trace ends with c = 9
+LTLSPEC NAME e2 := G F c = 10;  -- Inline comment: Trace ends with c = 10
+LTLSPEC NAME e3 := G F c = 11;  -- Inline comment: Trace ends with c = 11 (unreachable)
+
+-- Anonymous properties
+LTLSPEC G F c = 9;   -- Trace ends with c = 9
+INVARSPEC c >= 0;    -- Invariant that c is always non-negative
+CTLSPEC A F c = 9;   -- CTL specification that eventually c = 9
+

--- a/lib/rouge/lexers/nuxmv.rb
+++ b/lib/rouge/lexers/nuxmv.rb
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class NuXmv < RegexLexer
+      title "nuXmv"
+      desc "A superset of NuSMV, a symbolic model checker (https://nuxmv.fbk.eu/), and the old CMU SMV."
+      tag 'nuxmv'
+      aliases 'nuxmv', 'nusmv', 'smv'
+      filenames '*.smv'
+      mimetypes 'text/x-nuxmv', 'text/x-nusmv'
+
+      def self.keywords
+        @keywords ||= %w(
+          @F~ @O~ A ABF ABG AF AG ASSIGN at next last
+          AX BU case Clock COMPASSION COMPID COMPUTE COMPWFF
+          CONSTANTS CONSTARRAYCONSTRAINT CTLSPEC CTLWFF DEFINE E EBF
+          EBG EF EG esac EX F FAIRNESS FALSE FROZENVAR FUN G H
+          IN in INIT init Integer integer INVAR INVARSPEC ISA ITYPE IVAR JUSTICE
+          LTLSPEC LTLWFF MAX MDEFINE MIN MIRROR MODULE NAME next
+          NEXTWFF noncontinuous O of PRED PREDICATES pi PSLSPEC PARSYNTH READ Real
+          S SAT self SIMPWFF sizeof SPEC T
+          time since until TRANS TRUE typeof U union URGENT
+          V VALID VAR Word word1 WRITE X X~ Y Y~ Z
+        )
+      end
+
+      def self.keywords_type
+        @keywords_type ||= Set.new %w(
+          integer signed unsigned word real clock array boolean set
+        )
+      end
+
+      def self.keywords_builtin_fns
+        @keywords_builtin_fns ||= Set.new %w(
+          abs max min sin cos exp tan ln pow asin acos atan sqrt word1
+          bool toint count swconst uwconst extend resize READ WRITE CONSTARRAY
+          ceil floor
+        )
+      end
+
+      acceptable_word = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+      state :inline_whitespace do
+        rule %r/[ \t\r]+/, Text
+      end
+
+      state :beginline do
+        mixin :inline_whitespace
+
+        rule(//) { pop! }
+      end
+
+      state :whitespace do
+        rule %r/\n+/m, Text, :beginline
+        rule %r(--.*?$), Comment::Single, :beginline
+        mixin :inline_whitespace
+      end
+
+      state :expr_whitespace do
+        rule %r/\n+/m, Text, :beginline
+        mixin :whitespace
+      end
+
+      state :statement do
+        mixin :whitespace
+
+        # Reals, supporting also exponential notation
+        # Omitting the leading 0 is not allowed (.3 is not valid syntax)
+        # Positive exponent has implicit sign, explicit is not allowed
+        # In addition, the fractional syntax is allowed: F'123/456 or f'123/456
+        rule %r/([0-9_]+\.[0-9_]+)(e-?[0-9_]+)?/i, Num::Float
+        rule %r/[0-9_]+e[+-]?[0-9_]+/i, Num::Float
+        rule %r/[Ff]'([0-9_]+)(\/[0-9_]+)?/i, Num::Float
+
+        rule %r/[0-9]+/, Num::Integer
+        rule %r/[0-9_]+[lu]*/i, Num::Integer
+        rule %r((!|&|\||->|<->|=|<|>|<=|>=|\+|-|\*|/|mod|:=|:|xor|xnor)), Operator
+        rule %r/[{}()\[\],.$\#;]/, Punctuation
+
+        rule acceptable_word do |m|
+          name = m[0]
+
+          if self.class.keywords.include? name
+            token Keyword
+          elsif self.class.keywords_type.include? name
+            token Keyword::Type
+          elsif self.class.keywords_builtin_fns.include? name
+            token Name::Builtin
+          else
+            token Name
+          end
+        end
+      end
+
+      state :root do
+        mixin :expr_whitespace
+        rule(//) { push :statement }
+      end
+
+    end
+  end
+end

--- a/spec/lexers/nuxmv_spec.rb
+++ b/spec/lexers/nuxmv_spec.rb
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::NuXmv do
+  let(:subject) { Rouge::Lexers::NuXmv.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.smv'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-nusmv'
+      assert_guess :mimetype => 'text/x-nuxmv'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one-line comments not followed by a newline' do
+      assert_tokens_equal '-- comment', ['Comment.Single', '-- comment']
+    end
+
+    it 'recognizes comments at the end of a line' do
+      assert_tokens_includes 'MODULE main -- main module', ['Comment.Single', '-- main module']
+      assert_tokens_includes 'MODULE main -- main module\n', ['Comment.Single', '-- main module\\n']
+    end
+  end
+end

--- a/spec/visual/samples/nuxmv
+++ b/spec/visual/samples/nuxmv
@@ -1,0 +1,32 @@
+MODULE main
+  VAR c: integer;
+  VAR r: real;
+  VAR g: 0..3;
+  
+  INIT
+    c in {0};
+    r = f'1/2;
+  TRANS next(c) in
+    case
+      c < 9 : {c + 1, c + 2};
+      TRUE : {c};
+    esac;
+  
+  TRANS next(r) =
+    case
+      c > 0 & c < 9 : abs(c / 2.0);
+      TRUE : r;
+    esac;
+
+
+-- Named properties
+LTLSPEC NAME g0 := G (c >= 0);
+LTLSPEC NAME e1 := G F c = 9;   -- Inline comment: Trace ends with c = 9
+LTLSPEC NAME e2 := G F c = 10;  -- Inline comment: Trace ends with c = 10
+LTLSPEC NAME e3 := G F c = 11;  -- Inline comment: Trace ends with c = 11 (unreachable)
+
+-- Anonymous properties
+LTLSPEC G F c = 9;   -- Trace ends with c = 9
+INVARSPEC c >= 0;    -- Invariant that c is always non-negative
+CTLSPEC A F c = 9;   -- CTL specification that eventually c = 9
+


### PR DESCRIPTION
This MR adds support for the [nuXmv](https://nuxmv.fbk.eu)/[NuSMV](https://nusmv.fbk.eu)/[SMV](https://www.cs.cmu.edu/~modelcheck/smv.html) model checkers input language.

nuXmv is a superset and an enhancement over the NuSMV model checker, both of which developed by Fondazione Bruno Kessler, a research institute in Trento (IT). In turn, NuSMV originated by Carnegie Mellon University's "SMV", a symbolic model checker supporting CTL.

Not sure if relevant to the scope of reviewing the merge request, but fyi: Language reference is in User Manuals for both programs, which are listed here: https://nuxmv.fbk.eu/documentation.html.

Adding this language, it being a superset of the two previous languages mentioned, will virtually add support for all of them. (Note the aliases provided by the lexer are in fact: `nuxmv`, `nusmv`, and `smv`)