### PR TITLE
Support match and case keywords in Python

### DIFF
--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -218,3 +218,27 @@ def do_nothing():
 
     app = FastAPI()
     FastAPIInstrumentor.instrument_app(app)
+
+match command.split():
+    case ['to', direction] if direction in destination.route:
+        return 1
+    case 'foo' | 'bar':
+        return 2
+    case 'raz' as name:
+        return 3
+    case ['to', _]:
+        return 4
+    case else_bar:
+        return 5
+    case _:
+        return 6
+
+match command.split():
+    case _Direction():
+        return 1
+    case _ as default:
+        return 2
+
+case = 1
+match = 1
+match if True else bar


### PR DESCRIPTION
This PRs adds support to highligt `match`, `case` and `_` "soft keywords" in Python lexer. Soft keywords are considered keywords only in specific parts of the syntax keywords in Python lexer (see [doc](https://docs.python.org/3.10/reference/compound_stmts.html#the-match-statement)). The implementation is ported from Pygments https://github.com/pygments/pygments/pull/1994.

| Before | After |
| -- | -- |
| ![Screenshot 2025-06-26 at 3 17 29 pm](https://github.com/user-attachments/assets/990a8333-4f35-4e50-98b1-9c934b401ad4) | ![Screenshot 2025-06-26 at 3 48 40 pm](https://github.com/user-attachments/assets/b3dec2e6-93c0-4411-912b-1922965940cb) |
