### PR TITLE
Swift lexer update for syntax highlight for macros and keywords

### DIFF
--- a/spec/lexers/swift_spec.rb
+++ b/spec/lexers/swift_spec.rb
@@ -58,5 +58,41 @@ EOS
                           ['Text', "\n\n"],
                           ['Comment.Multiline', separate_comment]
     end
+
+    it 'lexes Swift Testing macros as built-ins' do
+      # Test #expect macro
+      expect_code = '#expect(result == 42)'
+      assert_tokens_equal expect_code,
+                          ['Name.Builtin', '#expect'],
+                          ['Punctuation', '('],
+                          ['Name', 'result'],
+                          ['Text', ' '],
+                          ['Operator', '=='],
+                          ['Text', ' '],
+                          ['Literal.Number.Integer', '42'],
+                          ['Punctuation', ')']
+
+      # Test #require macro
+      require_code = '#require(value != nil)'
+      assert_tokens_equal require_code,
+                          ['Name.Builtin', '#require'],
+                          ['Punctuation', '('],
+                          ['Name', 'value'],
+                          ['Text', ' '],
+                          ['Operator', '!='],
+                          ['Text', ' '],
+                          ['Keyword.Constant', 'nil'],
+                          ['Punctuation', ')']
+    end
+
+    it 'lexes other # prefixed identifiers as keywords' do
+      # Test that non-testing macros are still lexed as keywords
+      other_macro = '#selector(buttonTapped)'
+      assert_tokens_equal other_macro,
+                          ['Keyword', '#selector'],
+                          ['Punctuation', '('],
+                          ['Name', 'buttonTapped'],
+                          ['Punctuation', ')']
+    end
   end
 end


### PR DESCRIPTION
Hi,

I've reviewed the code of conduct. Here is a summary of the changes.

### What is the issue?
-  The Rouge syntax highlighter for Swift didn't recognize #expect from Swift Testing framework, treating it as a generic preprocessor instead of a testing assertion. Basically, the rule catches ANY line starting with `#` (except for `##`, `#"`, or `#/`) and treats the entire line as a preprocessor comment.

### Changes
- Added a `testing_macros` set containing `expect` and `require`

- Modified the rule for `#` prefixed identifiers to check if they're Swift Testing macros

- Swift Testing macros (`#expect`, `#require`) are now highlighted as `Name::Builtin`

- Other Swift macros (like `#selector`) continue to be highlighted as `Keyword`

- Preprocessor directives (`#if`, `#else`, `#endif`) are properly handled in the `:bol` state

### Testing
- Ran the the tests locally, looks alright. 
