### PR TITLE
Add rackup to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,4 +38,6 @@ group :development do
 
   gem "mutex_m" if RUBY_VERSION >= '3.4'
   gem "base64" if RUBY_VERSION >= '3.4'
+
+  gem 'rackup'
 end


### PR DESCRIPTION
This is needed otherwise the instructions on this page...

https://rouge-ruby.github.io/docs/file.DevEnvironment.html

... fail when you get to `bundle exec rackup` with an error because it can't find `rackup`.