### PR TITLE
Add ruby head version to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This MR add Ruby `head` version to CI check. This ensures that we can detect compatibility issues early.