### PR TITLE
Bugfix: Lua escaped quotes now parsing

### DIFF
--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -106,6 +106,7 @@ module Rouge
         rule %r/[(,]/, Punctuation
         rule %r/\s+/, Text
         rule %r/"/, Str::Regex, :regex
+        rule %r/'/, Str::Single, :escape_sqs
       end
 
       state :regex do

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -105,8 +105,26 @@ module Rouge
         rule %r/\)/, Punctuation, :pop!
         rule %r/[(,]/, Punctuation
         rule %r/\s+/, Text
-        rule %r/"/, Str::Regex, :regex
-        rule %r/'/, Str::Single, :escape_sqs
+        rule %r/'/, Str::Regex, :regex_sq
+        rule %r/"/, Str::Regex, :regex_dq
+      end
+
+      state :regex_sq do
+        rule %r(') do
+          token Str::Regex
+          goto :regex_end
+        end
+
+        mixin :regex
+      end
+
+      state :regex_dq do
+        rule %r(") do
+          token Str::Regex
+          goto :regex_end
+        end
+
+        mixin :regex
       end
 
       state :regex do

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -151,13 +151,15 @@ module Rouge
       end
 
       state :sqs do
+        rule %r(\\'), Str::Escape
         rule %r('), Str::Single, :pop!
-        rule %r([^']+), Str::Single
+        rule %r([^'\\]+), Str::Single
       end
 
       state :dqs do
+        rule %r(\\"), Str::Escape
         rule %r("), Str::Double, :pop!
-        rule %r([^"]+), Str::Double
+        rule %r([^"\\]+), Str::Double
       end
     end
   end

--- a/spec/visual/samples/lua
+++ b/spec/visual/samples/lua
@@ -258,6 +258,8 @@ end
 acc = Account.create(1000)
 acc:withdraw(100)
 
+-- gsub examples
 if
    url = url:gsub("^['\"]", ""):gsub("['\"]$", "")
+   local pattern = attr_name .. '=[\'"]' .. attr_value:gsub('([%.%+%-%*%?%[%]%^%$%(%)%%])', '%%%1') .. '[\'"]'
 end


### PR DESCRIPTION
I addressed the primary bug of escaped quotes not being handled properly. as well as gsub parsing being able to handle single-quoted strings.

Before fixes:
<img width="848" height="20" alt="image" src="https://github.com/user-attachments/assets/7b795b16-efcb-4a0b-8cce-d956d8b64363" />

After fixes:

<img width="851" height="20" alt="image" src="https://github.com/user-attachments/assets/fe10aa1c-bab4-494f-ac74-cb14bb1df755" />

Closes #2153