### PR TITLE
Recognize `.resource` files as Robot Framework file

### DIFF
--- a/lib/rouge/lexers/robot_framework.rb
+++ b/lib/rouge/lexers/robot_framework.rb
@@ -10,7 +10,7 @@ module Rouge
       title "Robot Framework"
       desc 'Robot Framework is a generic open source automation testing framework (robotframework.org)'
 
-      filenames '*.robot'
+      filenames '*.robot', '*.resource'
       mimetypes 'text/x-robot'
 
       def initialize(opts = {})

--- a/spec/lexers/robot_framework_spec.rb
+++ b/spec/lexers/robot_framework_spec.rb
@@ -8,6 +8,7 @@ describe Rouge::Lexers::RobotFramework do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.robot'
+      assert_guess :filename => 'foo.resource'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
**Problem**

RobotFramework supports `.resource` files, but they aren’t highlighted currently.

See documentation:
https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#resource-files

**Solution**

Extend the RobotFramework lexer to detect `.resource` files.

### Before
<img width="650" height="646" alt="Screenshot 2025-08-26 at 12 01 21" src="https://github.com/user-attachments/assets/3b416d51-50ed-4a6d-8f20-5a0e8c459ea0" />


### After

<img width="669" height="742" alt="Screenshot 2025-08-26 at 11 50 36" src="https://github.com/user-attachments/assets/5cdf9290-c4cf-4268-a59d-9f98359b930c" />


