### PR TITLE
support underscore in numbers in go

### DIFF
--- a/lib/rouge/lexers/go.rb
+++ b/lib/rouge/lexers/go.rb
@@ -25,6 +25,7 @@ module Rouge
 
       LETTER                 = /#{UNICODE_LETTER}|_/
       DECIMAL_DIGIT          = /[0-9]/
+      BINARY_DIGIT           = /[01]/
       OCTAL_DIGIT            = /[0-7]/
       HEX_DIGIT              = /[0-9A-Fa-f]/
 
@@ -72,9 +73,10 @@ module Rouge
       # Integer literals
 
       DECIMAL_LIT            = /#{DECIMAL_DIGIT}(?:_?#{DECIMAL_DIGIT})*/
+      BINARY_LIT             = /0[bB]_*#{BINARY_DIGIT}(?:_?#{BINARY_DIGIT})*/
       OCTAL_LIT              = /0[oO]?_*#{OCTAL_DIGIT}(?:_?#{OCTAL_DIGIT})*/
       HEX_LIT                = /0[xX]_*#{HEX_DIGIT}(?:_?#{HEX_DIGIT})*/
-      INT_LIT                = /#{HEX_LIT}|#{DECIMAL_LIT}|#{OCTAL_LIT}/
+      INT_LIT                = /#{BINARY_LIT}|#{HEX_LIT}|#{OCTAL_LIT}|#{DECIMAL_LIT}/
 
       # Floating-point literals
 

--- a/spec/lexers/go_spec.rb
+++ b/spec/lexers/go_spec.rb
@@ -30,6 +30,11 @@ describe Rouge::Lexers::Go do
       assert_tokens_equal '0xDEAD_BEEF', ['Literal.Number', '0xDEAD_BEEF']
     end
 
+    it 'lexes binary integers with underscores' do
+      assert_tokens_equal '0b1010_0110', ['Literal.Number', '0b1010_0110']
+      assert_tokens_equal '0B_1111_0000', ['Literal.Number', '0B_1111_0000']
+    end
+
     it 'lexes octal integers with underscores' do
       assert_tokens_equal '0o755_777', ['Literal.Number', '0o755_777']
       assert_tokens_equal '0O_777', ['Literal.Number', '0O_777']


### PR DESCRIPTION
- **feat: correct numbers in Go having underscore tokenisation**
- **feat: correctly tokenize binary numbers in Go**
