### PR TITLE
php: Support enum definition

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -243,6 +243,13 @@ module Rouge
           groups Keyword::Declaration, Text, Name::Class
         end
 
+        rule %r/(enum)
+                (\s+)
+                (#{id_with_ns})/ix do |m|
+          groups Keyword::Declaration, Text, Name::Class
+          push :in_enum
+        end
+
         mixin :names
 
         rule %r/[;,\(\)\{\}\[\]]/, Punctuation
@@ -375,6 +382,29 @@ module Rouge
         mixin :escape
         mixin :whitespace
         mixin :return
+      end
+
+      state :in_enum do
+        rule %r/:/, Punctuation, :in_enum_base_type
+        rule %r/\{/, Punctuation, :in_enum_body
+        mixin :escape
+        mixin :whitespace
+        mixin :return
+      end
+
+      state :in_enum_base_type do
+        rule id, Keyword::Type, :pop!
+        mixin :escape
+        mixin :whitespace
+        mixin :return
+      end
+
+      state :in_enum_body do
+        rule %r/\}/, Punctuation, :pop!
+        rule %r/(case)(\s+)(#{id})/i do
+          groups Keyword, Text, Name::Constant
+        end
+        mixin :php
       end
     end
   end

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -226,6 +226,22 @@ interface SomeInterface {
 }
 
 
+/* Enums */
+
+enum Suit {
+  case Hearts;
+  case Diamonds;
+  case Clubs;
+  case Spades;
+}
+enum Status: string {
+  case Pending    = 'pending';
+  case Processing = 'processing';
+  case Completed  = 'completed';
+  case Failed     = 'failed';
+}
+
+
 /* Imports */
 
 use some\namespace\ClassA;


### PR DESCRIPTION
Part of https://github.com/rouge-ruby/rouge/issues/2169

Support enum definition since PHP 8.1.

https://www.php.net/manual/en/language.enumerations.basics.php

> ```php
> enum Suit
> {
>     case Hearts;
>     case Diamonds;
>     case Clubs;
>     case Spades;
> }
> ```

https://www.php.net/manual/en/language.enumerations.backed.php

> ```php
> enum Suit: string
> {
>     case Hearts = 'H';
>     case Diamonds = 'D';
>     case Clubs = 'C';
>     case Spades = 'S';
> }
> ```

This pull requests introduced three new states:

* `in_enum`
* `in_enum_base_type`: handles syntax rule of backed-enum, an enum type having base type.
* `in_enum_body`: handles `case` keyword.