### PR TITLE
Add HLL lexer

### DIFF
--- a/lib/rouge/demos/hll
+++ b/lib/rouge/demos/hll
@@ -1,0 +1,19 @@
+/* The pigeon holes principles
+   Taken from the specification */
+constants:
+  int NOF_PIGEONS := 10;
+  int NOF_HOLES := NOF_PIGEONS - 1;
+
+inputs:
+  bool P[NOF_PIGEONS, NOF_HOLES];
+
+definitions:
+  // For each hole there is at most one pigeon
+  a := ALL i:[0, NOF_HOLES-1], j:[0, NOF_PIGEONS-1] ALL k:[j+1, NOF_PIGEONS-1]
+         (P[j, i] -> ~P[k, i]);
+
+  // For each pigeon there is at least one hole
+  b := ALL i:[0, NOF_PIGEONS-1] SOME j:[0, NOF_HOLES-1] (P[i,j]);
+
+proof obligations:
+  ~(a & b);

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -38,24 +38,69 @@ module Rouge
             def self.type_keywords
                 @type_keywords ||= Set.new %w(bool int)
             end
+            # Keywords as indicated in
+            # https://hal.science/hal-03356342v1/
+            # but without types (which are in the type_keywords value)
             def self.keywords
                 @keywords ||= Set.new %w(
-                  if then else elif lambda
-                  false true True TRUE False FALSE
-                  enum tuple struct signed unsigned
-                  X I pre PRE
-                  cast
+                  ALL
                   bin2s
                   bin2u
-                  blocks
                   Blocks
-                  ALL SOME SELECT SUM PROD CONJ DISJ sort
-                  Namespaces namespaces
-                  declarations Declarations definitions Definitions
-                  inputs Inputs proof Proof obligations Obligations
-                  Constants constants Constraints constraints
-                  Outputs outputs
-                  type Types u2bin with)
+                  blocks
+                  cast
+                  CONJ
+                  constants
+                  Constants
+                  constraints
+                  Constraints
+                  declarations
+                  Declarations
+                  definitions
+                  Definitions
+                  DISJ
+                  elif
+                  else
+                  false
+                  FALSE
+                  False
+                  I
+                  if
+                  inputs
+                  Inputs
+                  lambda
+                  namespaces
+                  Namespaces
+                  obligations
+                  Obligations
+                  outputs
+                  Outputs
+                  population_count_eq
+                  population_count_gt
+                  population_count_lt
+                  pre
+                  PRE
+                  PROD
+                  proof
+                  Proof
+                  s2bin
+                  SELECT
+                  signed
+                  SOME
+                  sort
+                  struct
+                  SUM
+                  then
+                  true
+                  True
+                  TRUE
+                  tuple
+                  types
+                  Types
+                  u2bin
+                  unsigned
+                  with
+                  X)
             end
         end
     end

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -20,8 +20,10 @@ module Rouge
                 rule %r/"[^"]*"/, Literal::String
                 rule %r/'[^']*'/, Literal::String
                 mixin :comment
-                rule %r([(){}\[\];:,|!^]+), Punctuation
+                rule %r([(){}\[\];:,|]+), Punctuation
                 rule %r(:=), Punctuation
+                rule %r(0(b|B)[0-1](_?[0-1])*), Literal::Number
+                rule %r(0(x|X)[0-9A-Fa-f](_?[0-9A-Fa-f])*), Literal::Number
                 rule %r(\d+), Literal::Number
                 rule %r(\w+) do |m|
                     if self.class.keywords.include?(m[0])
@@ -32,12 +34,14 @@ module Rouge
                         token Name
                     end
                 end
-                rule %r([~&#+\-><*=\.]), Operator
+                rule %r([!~&#+\-><*=./%\^]), Operator
+                rule %r(\$\w+), Keyword # Built in functions
             end
 
             def self.type_keywords
                 @type_keywords ||= Set.new %w(bool int)
             end
+
             # Keywords as indicated in
             # https://hal.science/hal-03356342v1/
             # but without types (which are in the type_keywords value)

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -17,6 +17,8 @@ module Rouge
             state :root do
                 rule %r(\s+), Text::Whitespace
                 rule %r/\w::/, Name::Namespace
+                rule %r/"[^"]*"/, Literal::String
+                rule %r/'[^']*'/, Literal::String
                 mixin :comment
                 rule %r([(){}\[\];:,|!^]+), Punctuation
                 rule %r(:=), Punctuation

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -16,9 +16,8 @@ module Rouge
 
             state :root do
                 rule %r(\s+), Text::Whitespace
+                rule %r/\w::/, Name::Namespace
                 mixin :comment
-                rule %r(Namespaces: \w), Name::Namespace
-                mixin :section
                 rule %r([(){}\[\];:,|!^]+), Punctuation
                 rule %r(:=), Punctuation
                 rule %r(\d+), Num::Integer
@@ -32,20 +31,23 @@ module Rouge
                 rule %r([~&#+\-><*=]), Operator
             end
 
-            state :section do
-                rule %r((D|d)eclarations), Name::Builtin
-                rule %r((D|d)efinitions), Name::Builtin
-                rule %r((I|i)nputs), Name::Builtin
-                rule %r((O|o)utputs), Name::Builtin
-                rule %r((P|p)roof (O|o)bligations), Name::Builtin
-                rule %r((C|c)onstants), Name::Builtin
-                rule %r((C|c)onstraints), Name::Builtin
-            end
-
             def self.keywords
                 @keywords ||= Set.new %w(
-                  if then else elif lambda false true int bool X I pre
-                  ALL SOME SELECT SUM PROD sort)
+                  if then else elif lambda
+                  false true True TRUE False FALSE
+                  int bool enum tuple struct signed unsigned
+                  X I pre PRE
+                  cast
+                  bin2s
+                  bin2u
+                  blocks
+                  Blocks
+                  ALL SOME SELECT SUM PROD CONJ DISJ sort
+                  Namespaces namespaces
+                  declarations Declarations definitions Definitions
+                  inputs Inputs proof Proof obligations Obligations
+                  Constants constants Constraints Constraints
+                  type Types u2bin with)
             end
         end
     end

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Rouge
+    module Lexers
+        class HLL < RegexLexer
+            title 'HLL'
+            desc 'High Level Language'
+            tag 'hll'
+            filenames '*.hll'
+            mimetypes 'text/x-hll'
+
+            state :comments do
+                rule %r(///.*?$), Comment::Doc
+                rule %r(//[^/]*?$), Comment::Single
+                rule %r(/\*[^\*].*?\*/)m, Comment::Multiline
+                rule %r(/\*\*.*?\*/)m, Comment::Doc
+            end
+
+            state :root do
+                rule /\s+/, Text::Whitespace
+                mixin :comments
+                rule /Namespaces: \w/, Name::Namespace
+                mixin :section
+                rule /[(){}\[\];:,|!^]+/, Punctuation
+                rule /:=/, Punctuation
+                rule /\d+/, Num::Integer
+                rule /\w+/ do |m|
+                    if self.class.keywords.include?(m[0])
+                        token Keyword
+                    elsif
+                        token Name
+                    end
+                end
+                rule /[~&#+\-><*=]/, Operator
+            end
+
+            state :section do
+                rule /(D|d)eclarations/, Name::Builtin
+                rule /(D|d)efinitions/, Name::Builtin
+                rule /(I|i)nputs/, Name::Builtin
+                rule /(O|o)utputs/, Name::Builtin
+                rule /(P|p)roof obligations/, Name::Builtin
+                rule /(C|c)onstants/, Name::Builtin
+                rule /(C|c)onstraints/, Name::Builtin
+            end
+
+            def self.keywords
+                @keywords ||= Set.new %w(
+                  if then else elif lambda false true int bool X I pre
+                  ALL SOME SELECT SUM PROD sort)
+            end
+        end
+    end
+end

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -9,7 +9,7 @@ module Rouge
 
             state :comment do
                 rule %r(///.*?$), Comment::Doc
-                rule %r(//[^/]*?$), Comment::Single
+                rule %r(//[^/].*?$), Comment::Single
                 rule %r(/\*[^\*].*?\*/)m, Comment::Multiline
                 rule %r(/\*\*.*?\*/)m, Comment::Doc
             end

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -53,7 +53,8 @@ module Rouge
                   Namespaces namespaces
                   declarations Declarations definitions Definitions
                   inputs Inputs proof Proof obligations Obligations
-                  Constants constants Constraints Constraints
+                  Constants constants Constraints constraints
+                  Outputs outputs
                   type Types u2bin with)
             end
         end

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Rouge
     module Lexers
         class HLL < RegexLexer
@@ -9,7 +7,7 @@ module Rouge
             filenames '*.hll'
             mimetypes 'text/x-hll'
 
-            state :comments do
+            state :comment do
                 rule %r(///.*?$), Comment::Doc
                 rule %r(//[^/]*?$), Comment::Single
                 rule %r(/\*[^\*].*?\*/)m, Comment::Multiline
@@ -17,31 +15,31 @@ module Rouge
             end
 
             state :root do
-                rule /\s+/, Text::Whitespace
-                mixin :comments
-                rule /Namespaces: \w/, Name::Namespace
+                rule %r(\s+), Text::Whitespace
+                mixin :comment
+                rule %r(Namespaces: \w), Name::Namespace
                 mixin :section
-                rule /[(){}\[\];:,|!^]+/, Punctuation
-                rule /:=/, Punctuation
-                rule /\d+/, Num::Integer
-                rule /\w+/ do |m|
+                rule %r([(){}\[\];:,|!^]+), Punctuation
+                rule %r(:=), Punctuation
+                rule %r(\d+), Num::Integer
+                rule %r(\w+) do |m|
                     if self.class.keywords.include?(m[0])
                         token Keyword
-                    elsif
+                    else
                         token Name
                     end
                 end
-                rule /[~&#+\-><*=]/, Operator
+                rule %r([~&#+\-><*=]), Operator
             end
 
             state :section do
-                rule /(D|d)eclarations/, Name::Builtin
-                rule /(D|d)efinitions/, Name::Builtin
-                rule /(I|i)nputs/, Name::Builtin
-                rule /(O|o)utputs/, Name::Builtin
-                rule /(P|p)roof obligations/, Name::Builtin
-                rule /(C|c)onstants/, Name::Builtin
-                rule /(C|c)onstraints/, Name::Builtin
+                rule %r((D|d)eclarations), Name::Builtin
+                rule %r((D|d)efinitions), Name::Builtin
+                rule %r((I|i)nputs), Name::Builtin
+                rule %r((O|o)utputs), Name::Builtin
+                rule %r((P|p)roof (O|o)bligations), Name::Builtin
+                rule %r((C|c)onstants), Name::Builtin
+                rule %r((C|c)onstraints), Name::Builtin
             end
 
             def self.keywords

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -22,10 +22,12 @@ module Rouge
                 mixin :comment
                 rule %r([(){}\[\];:,|!^]+), Punctuation
                 rule %r(:=), Punctuation
-                rule %r(\d+), Num::Integer
+                rule %r(\d+), Literal::Number
                 rule %r(\w+) do |m|
                     if self.class.keywords.include?(m[0])
                         token Keyword
+                    elsif self.class.type_keywords.include?(m[0])
+                        token Keyword::Type
                     else
                         token Name
                     end
@@ -33,11 +35,14 @@ module Rouge
                 rule %r([~&#+\-><*=]), Operator
             end
 
+            def self.type_keywords
+                @type_keywords ||= Set.new %w(bool int)
+            end
             def self.keywords
                 @keywords ||= Set.new %w(
                   if then else elif lambda
                   false true True TRUE False FALSE
-                  int bool enum tuple struct signed unsigned
+                  enum tuple struct signed unsigned
                   X I pre PRE
                   cast
                   bin2s

--- a/lib/rouge/lexers/hll.rb
+++ b/lib/rouge/lexers/hll.rb
@@ -32,7 +32,7 @@ module Rouge
                         token Name
                     end
                 end
-                rule %r([~&#+\-><*=]), Operator
+                rule %r([~&#+\-><*=\.]), Operator
             end
 
             def self.type_keywords

--- a/spec/lexers/hll_spec.rb
+++ b/spec/lexers/hll_spec.rb
@@ -1,0 +1,3 @@
+if "guesses by filename" do
+    assert_guess :filename => "foo.hll"
+end

--- a/spec/lexers/hll_spec.rb
+++ b/spec/lexers/hll_spec.rb
@@ -1,3 +1,11 @@
-if "guesses by filename" do
-    assert_guess :filename => "foo.hll"
+describe Rouge::Lexers::HLL do
+    let(:subject) { Rouge::Lexers::HLL.new }
+
+    describe 'guessing' do
+        include Support::Guessing
+
+        it "guesses by filename" do
+            assert_guess :filename => "foo.hll"
+        end
+    end
 end

--- a/spec/visual/samples/hll
+++ b/spec/visual/samples/hll
@@ -1,0 +1,19 @@
+/* The pigeon holes principles
+   Taken from the specification */
+constants:
+  int NOF_PIGEONS := 10;
+  int NOF_HOLES := NOF_PIGEONS - 1;
+
+inputs:
+  bool P[NOF_PIGEONS, NOF_HOLES];
+
+definitions:
+  // For each hole there is at most one pigeon
+  a := ALL i:[0, NOF_HOLES-1], j:[0, NOF_PIGEONS-1] ALL k:[j+1, NOF_PIGEONS-1]
+         (P[j, i] -> ~P[k, i]);
+
+  // For each pigeon there is at least one hole
+  b := ALL i:[0, NOF_PIGEONS-1] SOME j:[0, NOF_HOLES-1] (P[i,j]);
+
+proof obligations:
+  ~(a & b);

--- a/spec/visual/samples/hll
+++ b/spec/visual/samples/hll
@@ -1,28 +1,49 @@
-// Some comment
-
-/* A multiline
-   comment */
+/* This file contains as many HLL syntactic constructions as possible
+   in order to test syntactic analysis tools. */
 
 namespaces: N {
+  inputs:
+    bool a;
+  namespaces: M {
+    inputs:
+      bool a;
   constants:
-    int foo := 5;
-    
-    int 'foo' := 5;
-    int "foo" := 5;
+    int b := 3;
+  }
 }
 
+constants:
+  int "foo" := 5;
+  int 'foo' := 5;
+
 types:
+  // Enumeration
   enum {red, blue} colour;
+  // Sorts
   sort {flower, grass} < herbs;
   sort {larch, oak} < trees;
   sort herbs, trees < plants;
-  int[0,5] five;
+  // integers
+  int [0,5] five;
   int signed 5 int5;
   int unsigned 5 uint5;
-  tuple {bool, bool} bool2;
-  struct {x: int5, y: int5} point5;
-  bool ^ (N::foo, N::"foo", N::'foo') foo_matrix;
+  tuple {bool, bool} bool2; // Tuple
+  struct {x: int5, y: int5} point5; // Structure
+  // Functions and arrays
+  bool ^ (foo, "foo", N::M::b) foo_matrix;
   (int5 * int5 -> int5) fct5;
+  bool comp(int, int);
+  bool m0[3][4];
+
+inputs:
+  // Here we test declarators
+  bool^(3)^(4) ar0;
+  bool ar1[3][4];
+  bool f0(int, int);
+  bool f1(int)(int);
+  (int * int -> bool) f2;
+  (int -> (int -> bool)) f3;
+  int i0(int, int);
 
 declarations:
   bool it;
@@ -30,20 +51,80 @@ declarations:
   bool cohabit(herbs, trees);
   (plants -> bool) edible;
   plants winlose[int5,int5];
-  int5 projx(point5);
-  int5 projy(point5);
+  bool projx(point5, int5);
+  bool projy(point5, int5);
   bool g(bool, bool);
 
 definitions:
-  projx(p) := p.x;
-  projy(p) := p.y;
+  projx(p, x) := p.x = x;
+  projy(p, y) := p.y = y;
+
+// Lambda
+declarations:
+  bool l0[3];
+  int fib(int);
+
+definitions:
+  l0 := lambda[3]: [i] := i = 1;
+  fib := lambda(int): (i) := if i <= 2 then 1 else fib(i - 1) + fib(i - 2);
 
 constraints:
-  ALL x:point5 (projx(x) + noise <> X(noise));
-  SOME x:int5 (projx(point5) == noise);
-  SOME h: herbs ALL p: plants (cohabit(h,p));
+  // Quantifiers
+  ALL i: int, j: int (f0(i)(j));
+  SOME i: int ALL j: int (f0(i)(j));
+  DISJ i: int, j: int (i <> j & f0(i)(j));
+  CONJ i: int (f0(i)(i));
+  SELECT i: int (f0(i)(i + 1));
+  PROD k: int (i0(k, k * 2) < 5);
+  SUM k: int (i0(k,k) = 2);
+  $min k: int (i0(k, k) = 0);
+  $max k: int (i0(k, k + 1) = "foo");
+  // Conditionals
   if it & pre(it, false) then edible(flower) else edible(grass);
-  winlose[3,2] == oak;
-  winlose[2,3] <> X(winlose[2,3]);
-  I(g(false, False));
-  SOME p:point5 (projx(p) = 3 # projy(p) = 3);
+  if true then false elif true then false else false;
+  // Binop expressions
+  true # true & true #! true -> true <-> false;
+  true = true;
+  true == true;
+  true != false;
+  true <> false;
+  fib(5) * fib(3) + fib(1) / 2 /> fib(2) /< fib(3) % "foo" - 3;
+  fib(5) << 3 <= 12;
+  fib(5) >> 3 >= 12;
+  true = ~false;
+  // Integer litterals
+  10 = 9 + 1;
+  0b011 > 0B001;
+  0xdead <> 0XDE0A;
+  // Temporal expressions
+  X(l0[3]) <> l0[3];
+  pre(g(true, false)) = g(true, false);
+  PRE(g(false, false), false) = g(true, true);
+  // Function style expressions
+  $min(3, 4) = $max(2, 3);
+  cast<int5> (3) = 3; // cast
+  (l0 with [0] := true); // With expression
+
+namespaces: Cases {
+  declarations:
+    bool nice(colour, colour);
+  definitions:
+    diff(c1, c2) := (c1, c2
+                    | red, blue => true
+                    | blue, red => true
+                    | red, red => false
+                    | blue, blue => false);
+}
+
+namespaces: TemporalDefinitions {
+  declarations:
+    bool u;
+    bool u1;
+    bool u2;
+  definitions:
+    X(u) := ~u;
+    I(u) := false;
+    u2 := u & ~u, true;
+  constraints:
+    I(u # u1);
+}

--- a/spec/visual/samples/hll
+++ b/spec/visual/samples/hll
@@ -1,19 +1,49 @@
-/* The pigeon holes principles
-   Taken from the specification */
-constants:
-  int NOF_PIGEONS := 10;
-  int NOF_HOLES := NOF_PIGEONS - 1;
+// Some comment
 
-inputs:
-  bool P[NOF_PIGEONS, NOF_HOLES];
+/* A multiline
+   comment */
+
+namespaces: N {
+  constants:
+    int foo := 5;
+    
+    int 'foo' := 5;
+    int "foo" := 5;
+}
+
+types:
+  enum {red, blue} colour;
+  sort {flower, grass} < herbs;
+  sort {larch, oak} < trees;
+  sort herbs, trees < plants;
+  int[0,5] five;
+  int signed 5 int5;
+  int unsigned 5 uint5;
+  tuple {bool, bool} bool2;
+  struct {x: int5, y: int5} point5;
+  bool ^ (N::foo, N::"foo", N::'foo') foo_matrix;
+  (int5 * int5 -> int5) fct5;
+
+declarations:
+  bool it;
+  int5 noise;
+  bool cohabit(herbs, trees);
+  (plants -> bool) edible;
+  plants winlose[int5,int5];
+  int5 projx(point5);
+  int5 projy(point5);
+  bool g(bool, bool);
 
 definitions:
-  // For each hole there is at most one pigeon
-  a := ALL i:[0, NOF_HOLES-1], j:[0, NOF_PIGEONS-1] ALL k:[j+1, NOF_PIGEONS-1]
-         (P[j, i] -> ~P[k, i]);
+  projx(p) := p.x;
+  projy(p) := p.y;
 
-  // For each pigeon there is at least one hole
-  b := ALL i:[0, NOF_PIGEONS-1] SOME j:[0, NOF_HOLES-1] (P[i,j]);
-
-proof obligations:
-  ~(a & b);
+constraints:
+  ALL x:point5 (projx(x) + noise <> X(noise));
+  SOME x:int5 (projx(point5) == noise);
+  SOME h: herbs ALL p: plants (cohabit(h,p));
+  if it & pre(it, false) then edible(flower) else edible(grass);
+  winlose[3,2] == oak;
+  winlose[2,3] <> X(winlose[2,3]);
+  I(g(false, False));
+  SOME p:point5 (projx(p) = 3 # projy(p) = 3);


### PR DESCRIPTION
This pull requests adds a lexer for the _High Level Language_ (a.k.a. HLL), a language used in formal verification for railway systems. The specification is available [here](https://hal.science/hal-03294999v1) or [there](https://hal.science/hal-03356342v1/).