### PR TITLE
php: Support typed class constants

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -280,6 +280,9 @@ module Rouge
       end
 
       state :in_const do
+        rule %r/(\??#{id})(\s+)(#{id})/i do
+          groups Keyword::Type, Text, Name::Constant
+        end
         rule id, Name::Constant
         rule %r/=/, Operator, :in_assign
         mixin :escape

--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -190,6 +190,12 @@ class C {
     public static ?string $a = "";
     public static int $b = 0;
 
+    const bool CONST_1 = true;
+    public const int CONST_2 = 1;
+    protected const float CONST_3 = 1.0;
+    private const string CONST_4 = "foo";
+    const ?array CONST_5 = [];
+
     public function __construct(
         public $foo,
         protected readonly $bar,


### PR DESCRIPTION
Part of https://github.com/rouge-ruby/rouge/issues/2169

Support typed class constants introduced since PHP 8.3.

https://wiki.php.net/rfc/typed_class_constants

```php
class C {
    const bool CONST_1 = true;
    public const int CONST_2 = 1;
    protected const float CONST_3 = 1.0;
    private const string CONST_4 = "foo";
    const ?array CONST_5 = [];
}
```