### PR TITLE
Support annotated strings in Gherkin lexer

### DIFF
--- a/lib/rouge/demos/gherkin
+++ b/lib/rouge/demos/gherkin
@@ -15,3 +15,52 @@ Feature: Addition
     | 20      | 30      | add    | 50     |
     | 2       | 5       | add    | 7      |
     | 0       | 40      | add    | 40     |
+
+  Scenario: Code samples
+    Given I have some code examples
+    """ruby
+    class Calculator
+      def multiply(x, y)
+        x * y
+      end
+    end
+    """
+    And I have some code examples
+    """rust
+    fn safe_divide(x: f64, y: f64) -> Result<f64, &'static str> {
+        match y {
+            0.0 => Err("Division by zero"),
+            _ => Ok(x / y),
+        }
+    }
+    """
+    And I have some code examples
+    """ocaml
+    let rec factorial = function
+      | 0 -> 1
+      | n -> n * factorial (n - 1)
+    
+    let () = Printf.printf "%d\n" (factorial 5)
+    """
+    And I have some code examples
+    """json
+    {
+      "calculator": {
+        "operations": ["add", "subtract", "multiply", "divide"],
+        "precision": 2,
+        "enabled": true
+      }
+    }
+    """
+    And I have some code examples
+    """nonexistent-lang
+    proc divide(x, y) {
+      return x / y;
+    }
+    """
+    And I have some code examples
+    """
+    def add(a, b)
+      a + b
+    end
+    """

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -46,9 +46,24 @@ module Rouge
         rule %r/[ \r\t]+/, Text
       end
 
+      state :annotated_string do
+        rule %r(("""(\S+)\n)(.*?)("""))m do |m|
+        first_line, lang, content, last_line = m.captures
+          token Str, first_line
+          sublexer = Rouge::Lexer.find(lang.strip)
+          if sublexer
+            delegate sublexer, content
+          else
+            token Str, content
+          end
+          token Str, last_line
+        end
+      end
+
       state :root do
         mixin :basic
         rule %r(\n), Text
+        mixin :annotated_string
         rule %r(""".*?""")m, Str
         rule %r(@[^\s@]+), Name::Tag
         mixin :has_table

--- a/spec/lexers/gherkin_spec.rb
+++ b/spec/lexers/gherkin_spec.rb
@@ -43,5 +43,38 @@ describe Rouge::Lexers::Gherkin do
       assert { tokens[5][0] == Token['Name.Variable'] }
       assert { tokens[6][0] == Token['Text'] }
     end
+
+    it 'highlights annotated strings correctly' do
+      source = <<~GHERKIN
+        Given I have some code
+        """ruby
+        class Calculator
+        end
+        """
+      GHERKIN
+      
+      find_calls = []
+      original_find = Rouge::Lexer.method(:find)
+      Rouge::Lexer.define_singleton_method(:find) do |lang|
+        find_calls << lang
+        original_find.call(lang)
+      end
+      
+      tokens = subject.lex(source).to_a
+        
+      assert { tokens.size == 11 }
+      assert { tokens[0][0] == Token['Name.Function'] }
+      assert { tokens[2][0] == Token['Literal.String'] }
+      assert { tokens[1][0] == Token['Text'] }
+      assert { tokens[3][0] == Token['Keyword'] }
+      assert { tokens[4][0] == Token['Text'] }
+      assert { tokens[5][0] == Token['Name.Class'] }
+      assert { tokens[6][0] == Token['Text'] }
+      assert { tokens[7][0] == Token['Keyword'] }
+      assert { tokens[8][0] == Token['Text'] }
+      assert { tokens[9][0] == Token['Literal.String'] }
+      assert { tokens[10][0] == Token['Text'] }
+      assert { find_calls.include?('ruby') }
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/rouge-ruby/rouge/issues/2178

This commit delegates lexing of annotated block strings in Gherkin to the lexer specified by the annotation:

| Before             |  After |
:-------------------------:|:-------------------------:
<img width="555" height="808" alt="before" src="https://github.com/user-attachments/assets/0d53e7f2-5020-473c-8358-c6d877bdf65e" /> | <img width="555" height="808" alt="after" src="https://github.com/user-attachments/assets/33523b53-f8eb-4cd2-9032-75ff5641714c" />

Thanks for maintaining such an awesome project! Let me know if you have any comments!

