### PR TITLE
Support .tofu for Terraform lexing

### DIFF
--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -11,7 +11,7 @@ module Rouge
 
       tag 'terraform'
       aliases 'tf'
-      filenames '*.tf', '*.tfvars'
+      filenames '*.tf', '*.tfvars', '*.tofu'
 
       def self.keywords
         @keywords ||= Set.new %w(

--- a/spec/lexers/terraform_spec.rb
+++ b/spec/lexers/terraform_spec.rb
@@ -17,6 +17,7 @@ describe Rouge::Lexers::Terraform do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.tf'
       assert_guess :filename => 'foo.tfvars'
+      assert_guess :filename => 'foo.tofu'
       deny_guess   :filename => 'foo'
     end
 


### PR DESCRIPTION
Hi there! This PR adds support for lexing OpenTofu `.tofu` files as Terraform. They're the same format, and AFAICT have no different keywords.

For context:

* https://opentofu.org/docs/language/files/ — a little background on `.tf` vs `.tofu` and how OpenTofu treats them
* https://opentofu.org/docs/language/syntax/ — syntax reference
* https://github.com/github-linguist/linguist/pull/7189 — GitHub `linguist` PR to add support for `.tofu` to existing Terraform support