### PR TITLE
nix: Fix identifier lexing

### DIFF
--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -10,6 +10,8 @@ module Rouge
       aliases 'nixos'
       filenames '*.nix'
 
+      id_boundary = /(?![a-zA-Z0-9_'-])/
+
       state :whitespaces do
         rule %r/^\s*\n\s*$/m, Text
         rule %r/\s+/, Text
@@ -30,15 +32,15 @@ module Rouge
       end
 
       state :null do
-        rule %r/(null)/, Keyword::Constant
+        rule %r/null#{id_boundary}/, Keyword::Constant
       end
 
       state :boolean do
-        rule %r/(true|false)/, Keyword::Constant
+        rule %r/(?:true|false)#{id_boundary}/, Keyword::Constant
       end
 
       state :binding do
-        rule %r/[a-zA-Z_][a-zA-Z0-9-]*/, Name::Variable
+        rule %r/[a-zA-Z_][a-zA-Z0-9_'-]*/, Name::Variable
       end
 
       state :path do
@@ -161,22 +163,22 @@ module Rouge
 
       state :keywords_namespace do
         keywords = %w(with in inherit)
-        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Namespace
+        rule %r/(?:#{keywords.join('|')})#{id_boundary}/, Keyword::Namespace
       end
 
       state :keywords_declaration do
         keywords = %w(let)
-        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Declaration
+        rule %r/(?:#{keywords.join('|')})#{id_boundary}/, Keyword::Declaration
       end
 
       state :keywords_conditional do
         keywords = %w(if then else)
-        rule %r/(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/(?:#{keywords.join('|')})#{id_boundary}/, Keyword
       end
 
       state :keywords_reserved do
         keywords = %w(rec assert map)
-        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Reserved
+        rule %r/(?:#{keywords.join('|')})#{id_boundary}/, Keyword::Reserved
       end
 
       state :keywords_builtin do
@@ -192,7 +194,7 @@ module Rouge
           throw
           toString
         )
-        rule %r/(?:#{keywords.join('|')})\b/, Keyword::Reserved
+        rule %r/(?:#{keywords.join('|')})#{id_boundary}/, Keyword::Reserved
       end
 
       state :ignore do

--- a/spec/lexers/nix_spec.rb
+++ b/spec/lexers/nix_spec.rb
@@ -6,5 +6,9 @@ describe Rouge::Lexers::Nix do
 
   describe 'lexing' do
     include Support::Lexing
+
+    it 'recognizes Nix identifier boundaries (#2176)' do
+      assert_tokens_equal "let\n  if' = -1;\n  trueTest = 1;\n  falseTest = 0;\nin { }", ["Keyword.Declaration", "let"], ["Text", "\n  "], ["Name.Variable", "if'"], ["Text", " "], ["Operator", "="], ["Text", " "], ["Operator", "-"], ["Literal.Number.Integer", "1"], ["Punctuation", ";"], ["Text", "\n  "], ["Name.Variable", "trueTest"], ["Text", " "], ["Operator", "="], ["Text", " "], ["Literal.Number.Integer", "1"], ["Punctuation", ";"], ["Text", "\n  "], ["Name.Variable", "falseTest"], ["Text", " "], ["Operator", "="], ["Text", " "], ["Literal.Number.Integer", "0"], ["Punctuation", ";"], ["Text", "\n"], ["Keyword.Namespace", "in"], ["Text", " "], ["Punctuation", "{"], ["Text", " "], ["Punctuation", "}"]
+    end
   end
 end


### PR DESCRIPTION
Fix #2176

Nix identifiers can contain `'` and `-`, which are not "word" characters in Ruby regexp. Thus, the pattern `/if\b/` (literal "if" followed by a word boundary) will match with `if` within `if'`.

This pull request defines `id_boundary` pattern as `/(?![a-zA-Z_0-9'-])/`, "not followed by Nix identifier characters" and replaces `\b` with it.

Nix manual:
https://nix.dev/manual/nix/2.28/language/identifiers.html

> Syntax
>
> identifier ~ `[A-Za-z_][A-Za-z0-9_'-]*`