### PR TITLE
Add support for triple-quoted raw strings in Dart lexer

### DIFF
--- a/lib/rouge/lexers/dart.rb
+++ b/lib/rouge/lexers/dart.rb
@@ -45,6 +45,8 @@ module Rouge
         rule %r(/\*.*?\*/)m, Comment::Multiline
         rule %r/"/, Str, :dqs
         rule %r/'/, Str, :sqs
+        rule %r/r""".*?"""/m, Str::Other
+        rule %r/r'''.*?'''/m, Str::Other
         rule %r/r"[^"]*"/, Str::Other
         rule %r/r'[^']*'/, Str::Other
         rule %r/##{id}*/i, Str::Symbol


### PR DESCRIPTION
## Summary

Dart supports multi-line raw strings using triple quotes:
- `r'''...'''`
- `r"""..."""`

The existing rules only handled single-quoted raw strings (`r'...'` and `r"..."`), causing triple-quoted variants to be incorrectly tokenized.

## The problem

When Rouge encounters `r'''...'''`, the existing rule `r'[^']*'` matches `r''` as an empty raw string, leaving `'...'` to be parsed incorrectly as a regular string.

## The fix

Add rules for triple-quoted raw strings before the single-quoted rules. Order matters because Rouge matches the first matching rule, and we need to match the longer triple-quote pattern before the shorter one.

```ruby
rule %r/r""".*?"""/m, Str::Other
rule %r/r'''.*?'''/m, Str::Other
rule %r/r"[^"]*"/, Str::Other
rule %r/r'[^']*'/, Str::Other
```

## Test case

```dart
var pattern = r'''[<>"']''';  // Was broken, now works
```