### PR TITLE
Fix Elixir Lexer Sigil Handling

### DIFF
--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -99,27 +99,27 @@ module Rouge
 
       state :sigil_strings do
         # ~-sigiled strings
-        # ~(abc), ~[abc], ~<abc>, ~|abc|, ~r/abc/, etc
+        # ~r(abc), ~r[abc], ~r<abc>, ~r|abc|, ~r/abc/, etc
         # Cribbed and adjusted from Ruby lexer
         delimiter_map = { '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
-        # Match a-z for custom sigils too
         sigil_opens = Regexp.union(delimiter_map.keys + %w(| / ' "))
-        rule %r/~([A-Za-z])?(#{sigil_opens})/ do |m|
+        # Match [a-z] or [A-Z][A-Z0-9]* for custom sigils too
+        rule %r/~([a-z]|[A-Z][A-Z0-9]*)(#{sigil_opens})/ do |m|
           open = Regexp.escape(m[2])
           close = Regexp.escape(delimiter_map[m[2]] || m[2])
-          interp = /[srcw]/ === m[1]
+          interp = /^[srcw]$/ === m[1]
           toktype = Str::Other
 
           puts "    open: #{open.inspect}" if @debug
           puts "    close: #{close.inspect}" if @debug
 
           # regexes
-          if 'Rr'.include? m[1]
+          if m[1] == 'r' || m[1] == 'R'
             toktype = Str::Regex
             push :regex_flags
           end
 
-          if 'Ww'.include? m[1]
+          if m[1] == 'w' || m[1] == 'W'
             push :list_flags
           end
 

--- a/spec/visual/samples/elixir
+++ b/spec/visual/samples/elixir
@@ -71,6 +71,11 @@ string |> String.split(~r/[ -]/) |> Enum.map(&abbreviate_word/1) |> Enum.join()
 ~s|inter #{pol <> "ati#{o}"} n|
 ~s/inter #{pol <> "ati#{o}"} n/
 
+# custom sigils
+~i(13)
+~CUSTOM(custom uppercase)
+~ABC123(with digits)
+
 # first is Operator, second is &1 variable
 &(&1)
 


### PR DESCRIPTION
This PR fixes several issues in the Elixir lexer's sigil processing to match the Elixir language specification.

## Changes

### Fixed interpolation detection

- Lowercase sigils (`~s`, `~r`, `~c`, `~w`) support interpolation
- Uppercase sigils (`~S`, `~R`, `~C`, `~W`) do not support interpolation

> In particular, uppercase letters sigils do not perform interpolation nor escaping. For example, although both `~s` and `~S` will return strings, the former allows escape codes and interpolation while the latter does not:
> 
> Ref: [Interpolation and escaping in string sigils](https://hexdocs.pm/elixir/sigils.html#interpolation-and-escaping-in-string-sigils)

### Fixed sigil pattern regex

- Changed from `~([a-zA-Z])?` to `~([a-z]|[A-Z][A-Z0-9]*)`
- The sigil letter is now required (not optional), preventing errors when processing invalid patterns like `~()`
- Properly matches custom sigils like `~CUSTOM` or `~ABC123`

> Custom sigils may be either a single lowercase character, or an uppercase character followed by more uppercase characters and digits.
> 
> Ref: [Custom sigils](https://hexdocs.pm/elixir/sigils.html#custom-sigils)

## Reference

- https://hexdocs.pm/elixir/sigils.html