### PR TITLE
Fix ConsoleLexer ignoring comments=false option

### DIFF
--- a/lib/rouge/lexers/console.rb
+++ b/lib/rouge/lexers/console.rb
@@ -144,7 +144,7 @@ module Rouge
           yield Text::Whitespace, $& unless $&.empty?
 
           lang_lexer.continue_lex($', &output)
-        elsif comment_regex =~ input[0].strip
+        elsif allow_comments? && comment_regex =~ input[0].strip
           puts "console: matched comment #{input[0].inspect}" if @debug
           output_lexer.reset!
           lang_lexer.reset!

--- a/spec/lexers/console_spec.rb
+++ b/spec/lexers/console_spec.rb
@@ -56,6 +56,12 @@ describe Rouge::Lexers::ConsoleLexer do
       ['Text', 'this is not a comment']
   end
 
+  it 'does not lex comments when comments=false with a custom prompt' do
+    subject_with_options = klass.new({ prompt: '>', comments: false })
+    assert_tokens_equal '##MS_PolicyEventProcessingLogin##', subject_with_options,
+      ['Generic.Output', '##MS_PolicyEventProcessingLogin##']
+  end
+
   describe 'guessing' do
     include Support::Guessing
 


### PR DESCRIPTION
## Summary

- Guard the `comment_regex` check in `process_line` with `allow_comments?` so that `comments=false` actually prevents lines starting with `#` from being lexed as comments
- Add a test verifying that `comments=false` with a custom prompt treats `#`-prefixed lines as output

Fixes #2200

## Test plan

- [x] Existing `console_spec.rb` tests pass
- [x] New test confirms `##MS_PolicyEventProcessingLogin##` is lexed as `Generic.Output` (not `Comment`) when `comments=false`