### PR TITLE
Drop support for EOL Ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: "3.0"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rake check:style
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "head"]
+        ruby-version: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "head"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   DisplayCopNames: true
   Exclude:
     - "tasks/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,7 @@ group :development do
   # for visual tests
   gem 'sinatra'
 
-  # Ruby 3 no longer ships with a web server
-  gem 'puma' if RUBY_VERSION >= '3'
+  gem 'puma'
   gem 'shotgun'
 
   gem "mutex_m" if RUBY_VERSION >= '3.4'

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Rouge's documentation is available at [rouge-ruby.github.io/docs/][docs].
 
 ### Ruby
 
-Rouge is compatible with all versions of Ruby from 2.0.0 onwards. It has no
+Rouge is compatible with all versions of Ruby from 3.0 onwards. It has no
 external dependencies.
 
 ### Encodings

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.0'
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/rouge-ruby/rouge/issues",
     "changelog_uri"     => "https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md",


### PR DESCRIPTION
Drop support for EOL Ruby 2.7. Retaining support for 3.0 and 3.1 for now, for stragglers.

<img width="1663" height="591" alt="image" src="https://github.com/user-attachments/assets/6ed3ccc0-f245-40d9-acad-381f991a0669" />

This PR is a modern take on https://github.com/rouge-ruby/rouge/pull/2129. If we'd rather go with that PR, that's fine. I can close this PR in favour of that one.

References
- https://www.ruby-lang.org/en/downloads/branches/
- https://endoflife.date/ruby