### PR TITLE
Add a fallthrough! method for continuing to check later rules

### DIFF
--- a/docs/LexerDevelopment.md
+++ b/docs/LexerDevelopment.md
@@ -255,6 +255,9 @@ end
 
 Make sure you don't forget to include *all* of the matched text in the output!
 
+They may also use {Rouge::RegexLexer#fallthrough!} to fall through to later
+rules, as if the regular expression had not matched.
+
 You can see an example of these more complex rules in [the Ruby lexer][ruby-lexer].
 
 ### Additional Features

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -371,13 +371,6 @@ module Rouge
           if (size = stream.skip(rule.re))
             puts "    got: #{stream[0].inspect}" if @debug
 
-            begin
-              instance_exec(stream, &rule.callback)
-            rescue Fallthrough
-              stream.unscan
-              next
-            end
-
             if size.zero?
               @null_steps += 1
               if @null_steps > MAX_NULL_SCANS
@@ -386,6 +379,13 @@ module Rouge
               end
             else
               @null_steps = 0
+            end
+
+            begin
+              instance_exec(stream, &rule.callback)
+            rescue Fallthrough
+              stream.unscan
+              next
             end
 
             return true

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -446,6 +446,9 @@ module Rouge
       delegate(self.class, text)
     end
 
+    # Breaks out of the current rule block and continues to match later
+    # rules, as if the current regex had not matched. Does not affect
+    # the stack.
     def fallthrough!
       raise Fallthrough
     end

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -442,6 +442,8 @@ module Rouge
       end
     end
 
+    # Re-lexes the given text (or the most recently matched string if
+    # none is given) with the current lexer.
     def recurse(text=nil)
       delegate(self.class, text)
     end

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -251,4 +251,31 @@ describe Rouge::Lexer do
 
     assert { lexer.demo == 'my cool demo' }
   end
+
+  it 'falls through' do
+    new_lexer = Class.new(Rouge::RegexLexer) do
+      state :root do
+        rule %r/\w+\b/ do |m|
+          fallthrough! unless %w(testy1 testy2).include?(m[0])
+
+          token 'builtin'
+        end
+
+        rule %r/\w+\b/ do |m|
+          token 'function'
+        end
+
+        rule %r/\s+/, 'text'
+      end
+    end
+
+    result = new_lexer.lex('testy1 foobar testy2').to_a
+
+    assert { result.size == 5 }
+    assert { result[0] == ['builtin', 'testy1'] }
+    assert { result[1] == ['text', ' '] }
+    assert { result[2] == ['function', 'foobar'] }
+    assert { result[3] == ['text', ' '] }
+    assert { result[4] == ['builtin', 'testy2'] }
+  end
 end


### PR DESCRIPTION
Usage:

```ruby
class MyLexer < Rouge::RegexLexer
  state :root do
    rule %r/\w+\b/ do |m|
      # aborts the current block and continues as if the regex for this rule did not match
      fallthrough! unless SOME_SET.include?(m[0].downcase)
      token Name::Builtin
    end

    rule %r/\w+\b/ do
      # will end up here if the previous rule called #fallthrough!
      # ...
    end
  end
end
```