### PR TITLE
Remove duplicate `ostruct` entry from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development do
 
   gem 'rubocop', '~> 1.0', '<= 1.11'
   gem 'rubocop-performance'
-  gem 'ostruct'
 
   # docs
   gem 'github-markup'


### PR DESCRIPTION
It appears https://github.com/rouge-ruby/rouge/pull/2202 added a second `ostruct` entry to the Gemfile which leads to the following warning. We should remove it as we only need the single pre-existing entry.

<img width="2030" height="330" alt="image" src="https://github.com/user-attachments/assets/60939925-03b3-4388-a117-59f64c4b735a" />

See lines 28 and 42. :point_down: 

https://github.com/rouge-ruby/rouge/blob/474be87e57904341835cacd3d1071b998f4a21c4/Gemfile#L19-L44