### PR TITLE
php: Support property hooks

### DIFF
--- a/spec/visual/samples/php
+++ b/spec/visual/samples/php
@@ -409,3 +409,46 @@ class C {
 }
 
 ?>
+
+/* Property Hooks */
+
+<?php
+
+class A {
+    public string $x1 {
+        get {
+            return $this->x1;
+        }
+        set (string $value) {
+            $this->x1 = trim($value);
+        }
+    }
+
+    public string $x2 {
+        get => strtolower($this->x2);
+        set => trim($value);
+    }
+
+    public array $x3 {
+        &get => $this->data;
+    }
+
+    public string $x4 {
+        final get => $this->x6;
+        set => strtolower($value);
+    }
+
+    public function __construct(
+        public string $x5 { get => strtoupper($this->x5); },
+        protected int $x6 {
+            set {
+                if ($value < 0) {
+                    throw new \ValueError('Must be non-negative');
+                }
+                $this->x6 = $value;
+            }
+        },
+    ) {}
+}
+
+?>


### PR DESCRIPTION
Part of https://github.com/rouge-ruby/rouge/issues/2169

Support  property hooks since PHP 8.4.

https://www.php.net/manual/en/language.oop5.property-hooks.php

# Changes

New states:

- `:in_property`
    - Parsing property definition (including normal property).
- `:in_property_hooks`
    - Parsing property hook definition between braces. Recognize `set`/`get` keywords and hook bodies.
- `:in_property_hook_params`
    - Parsing parameter list of property `set` hook. Recognize type annotations of parameters.
