### PR TITLE
Prevent character literals spanning lines

### DIFF
--- a/lib/rouge/lexers/crystal.rb
+++ b/lib/rouge/lexers/crystal.rb
@@ -80,7 +80,7 @@ module Rouge
         rule %r/\b[\p{Ll}_]\p{Word}*?[?!]?:\s+/, Str::Symbol, :expr_start
         rule %r/"/, Str::Double, :simple_string
         rule %r/(?<!\.)`/, Str::Backtick, :simple_backtick
-        rule %r/(')(\\u[a-fA-F0-9]{4}|\\u\{[a-fA-F0-9]{1,6}\}|\\[abefnrtv])?(\\\\|\\'|[^'])*(')/ do
+        rule %r/(')(\\u[a-fA-F0-9]{4}|\\u\{[a-fA-F0-9]{1,6}\}|\\[abefnrtv])?(\\\\|\\'|[^'\n])*(')/ do
           groups Str::Single, Str::Escape, Str::Single, Str::Single
         end
       end

--- a/spec/lexers/crystal_spec.rb
+++ b/spec/lexers/crystal_spec.rb
@@ -20,4 +20,17 @@ describe Rouge::Lexers::Crystal do
       assert_guess :source => '#!/usr/local/bin/crystal'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'rejects string literal than spans multiple lines' do
+      assert_tokens_equal "'a\nb'",
+                          ['Error', "'"],
+                          ["Name", "a"],
+                          ["Text", "\n"],
+                          ["Name", "b"],
+                          ["Error", "'"]
+    end
+  end
 end


### PR DESCRIPTION
The single-quote character literal regex was using `[^']*` which would match any character including newlines. This caused character literals to incorrectly span multiple lines when there were unmatched quotes in the input.

```bash
❮ cat /tmp/valid_test.cr 
first_letter = a'
second_letter = 'b'

puts "#{first_letter} #{second_letter}"
```

| Before | After |
| -- | -- |
| <img width="404" height="88" alt="Screenshot 2026-02-16 at 2 45 06 pm" src="https://github.com/user-attachments/assets/62017f29-03a4-47ba-81ab-26df0b6b8cf8" /> | <img width="404" height="103" alt="Screenshot 2026-02-16 at 2 45 34 pm" src="https://github.com/user-attachments/assets/abc1ac4d-8366-47ac-a202-742a2308a07d" /> | 
