### PR TITLE
Fix custom demos

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -124,14 +124,14 @@ module Rouge
       def demo_file(arg=:absent)
         return @demo_file = Pathname.new(arg) unless arg == :absent
 
-        @demo_file = Pathname.new(File.join(__dir__, 'demos', tag))
+        @demo_file ||= Pathname.new(File.join(__dir__, 'demos', tag))
       end
 
       # Specify or get a small demo string for this lexer
       def demo(arg=:absent)
         return @demo = arg unless arg == :absent
 
-        @demo = File.read(demo_file, mode: 'rt:bom|utf-8')
+        @demo ||= File.read(demo_file, mode: 'rt:bom|utf-8')
       end
 
       # @return a list of all lexers.

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -243,4 +243,12 @@ describe Rouge::Lexer do
     assert { php.instance_variable_get(:@start_inline) == :guess }
     assert { inline_php.instance_variable_get(:@start_inline) == true }
   end
+
+  it 'supports custom demos' do
+    lexer = Class.new(Rouge::Lexer) do
+      demo 'my cool demo'
+    end
+
+    assert { lexer.demo == 'my cool demo' }
+  end
 end


### PR DESCRIPTION
In working on the new Rouge plugin example codebase, I discovered that demo handling has been broken for some time, on account of a missed `||=`. This should work, but is broken on master:

```ruby
class MyCoolLexer < Rouge::RegexLexer
  demo <<~MY_DEMO
    here is my demo text
  MY_DEMO
end
```

This will try to load a file from the Rouge install location itself, ignoring the directive in the class.