### PR TITLE
Fix CI so that it runs on push and PR for `main` branch

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,9 +4,9 @@ name: CI
 on:
   push:
     # The `github-workflow-test` can be used to test changes without making a PR
-    branches: [master, github-workflow-test]
+    branches: [main, github-workflow-test]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   linelint:


### PR DESCRIPTION
### Description

It appears we recently renamed the primary branch from `master` to `main` but did not update the CI configuration and thus CI does not currently automatically run on push/PR for the primary branch i.e. `main`. This should fix that and get CI running again.

> [!NOTE]
> Requires the Gherkin spec fix to be merged first
> - https://github.com/rouge-ruby/rouge/pull/2226

### How?

`master` -> `main` in CI config.