### PR TITLE
Fix Gherkin spec post-whitespace cleanup

### DIFF
--- a/spec/lexers/gherkin_spec.rb
+++ b/spec/lexers/gherkin_spec.rb
@@ -34,14 +34,15 @@ describe Rouge::Lexers::Gherkin do
     it 'highlights placeholders correctly' do
       tokens = subject.lex('When <foo> (<bar>, <baz>)< garbage').to_a
 
-      assert { tokens.size == 7 }
+      assert { tokens.size == 8 }
       assert { tokens[0][0] == Token['Name.Function'] }
-      assert { tokens[1][0] == Token['Name.Variable'] }
-      assert { tokens[2][0] == Token['Text'] }
-      assert { tokens[3][0] == Token['Name.Variable'] }
-      assert { tokens[4][0] == Token['Text'] }
-      assert { tokens[5][0] == Token['Name.Variable'] }
-      assert { tokens[6][0] == Token['Text'] }
+      assert { tokens[1][0] == Token['Text'] }
+      assert { tokens[2][0] == Token['Name.Variable'] }
+      assert { tokens[3][0] == Token['Text'] }
+      assert { tokens[4][0] == Token['Name.Variable'] }
+      assert { tokens[5][0] == Token['Text'] }
+      assert { tokens[6][0] == Token['Name.Variable'] }
+      assert { tokens[7][0] == Token['Text'] }
     end
   end
 end


### PR DESCRIPTION
### Description

Proposing a quick follow up to fix the Gherkin spec so that it properly runs and passes, as it's currently failing on `main`, with the whitespace cleanup changes merged in 109b497bb4b9c7645e385be0254958628a97deaf (https://github.com/rouge-ruby/rouge/pull/2222). Side note, I noticed CI is not running or else that PR would've failed CI. Opened a fix here: https://github.com/rouge-ruby/rouge/pull/2227.

### How?

Disclaimer, I fed this test failure into an LLM as I'm not familiar with lexers and whatnot and it noted the following and made the change. If it makes sense to you all I'm fine to move forward with this PR.

> PR #2222 stripped trailing whitespace from Gherkin keywords (e.g. `"When "` → `"When"`). Previously the keyword `"When "` consumed the trailing space as part of the `Name.Function` token, so `'When <foo> ...'` produced 7 tokens. After stripping, `"When"` matches without the space, and the space becomes a separate `Text` token — 8 total.

### Testing

`main`

<img width="3840" height="2096" alt="Screenshot From 2026-02-26 13-47-48" src="https://github.com/user-attachments/assets/130a3b29-9aee-4075-9ccf-2e7d227fcf0e" />

this branch

<img width="3840" height="2096" alt="Screenshot From 2026-02-26 13-44-34" src="https://github.com/user-attachments/assets/139f7ccc-cb88-4956-bdf3-7367964bf53d" />