### PR TITLE
Add `rackup` gem for visual spec checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development do
 
   # for visual tests
   gem 'sinatra'
+  gem 'rackup'
 
   gem 'puma'
   gem 'shotgun'


### PR DESCRIPTION
### Description

Adds `rackup` gem so we can perform visual spec checks. I _think_ this used to be unnecessary when we had `webrick` built into Ruby but in modern Ruby trying `bundle exec rackup` simply errors out.

> For a long time, rackup (the executable and implementation) was part of rack, and webrick was the default server, included with Ruby. It made it easy to run a Rack application without having to worry about the details of the server - great for documentation and demos.
> https://github.com/rack/rackup/blob/f3fa1d6ada90e9e7aa1f712488ddde87ea2a2075/readme.md?plain=1#L47

```console
rouge on  main [$] via 💎 v4.0.1 
❯ bundle exec rackup
bundler: failed to load command: rackup (/home/larouxn/.gem/ruby/4.0.1/bin/rackup)
/home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/rubygems_integration.rb:236:in 'block in Gem.replace_bin_path': can't find executable rackup for gem rack (Gem::Exception)
        from /home/larouxn/.rubies/ruby-4.0.1/lib/ruby/site_ruby/4.0.0/rubygems.rb:238:in 'Gem.find_and_activate_spec_for_exe'
        from /home/larouxn/.rubies/ruby-4.0.1/lib/ruby/site_ruby/4.0.0/rubygems.rb:283:in 'Gem.activate_and_load_bin_path'
        from /home/larouxn/.gem/ruby/4.0.1/bin/rackup:25:in '<top (required)>'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli/exec.rb:61:in 'Kernel.load'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli/exec.rb:61:in 'Bundler::CLI::Exec#kernel_load'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli/exec.rb:24:in 'Bundler::CLI::Exec#run'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli.rb:500:in 'Bundler::CLI#exec'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/exe/bundle:28:in 'block in <top (required)>'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
        from /home/larouxn/.gem/ruby/4.0.1/gems/bundler-4.0.6/exe/bundle:20:in '<top (required)>'
        from /home/larouxn/.rubies/ruby-4.0.1/lib/ruby/site_ruby/4.0.0/rubygems.rb:304:in 'Kernel#load'
        from /home/larouxn/.rubies/ruby-4.0.1/lib/ruby/site_ruby/4.0.0/rubygems.rb:304:in 'Gem.activate_and_load_bin_path'
        from /home/larouxn/.gem/ruby/4.0.1/bin/bundle:25:in '<main>'
```

### How?

Simply adds `rackup` to `development` gems.

### Testing

<img width="3840" height="2096" alt="image" src="https://github.com/user-attachments/assets/0418e9b6-7648-411f-aaaf-b891ba84d103" />
