### PR TITLE
Moonscript: add `from` keyword

### DIFF
--- a/lib/rouge/lexers/moonscript.rb
+++ b/lib/rouge/lexers/moonscript.rb
@@ -47,9 +47,9 @@ module Rouge
       end
 
       state :base do
-        rule %r((?i)(\d*\.\d+|\d+\.\d*)(e[+-]?\d+)?'), Num::Float
-        rule %r((?i)\d+e[+-]?\d+), Num::Float
-        rule %r((?i)0x[0-9a-f]*), Num::Hex
+        rule %r((\d*\.\d+|\d+\.\d*)(e[+-]?\d+)?')i, Num::Float
+        rule %r(\d+e[+-]?\d+)i, Num::Float
+        rule %r(0x\h*), Num::Hex
         rule %r(\d+), Num::Integer
         rule %r(@\w+), Name::Variable::Instance
         rule %r([A-Z]\w*), Name::Class
@@ -69,7 +69,7 @@ module Rouge
         rule %r((local|export)\b), Keyword::Declaration
         rule %r((true|false|nil)\b), Keyword::Constant
 
-        rule %r([A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?) do |m|
+        rule %r([a-z_]\w*(\.[a-z_]\w*)?)i do |m|
           name = m[0]
           if keywords.include?(name)
             token Keyword


### PR DESCRIPTION
[Moonscript's docs](https://moonscript.org/reference/) seem to indicate this should be highlighted:
<img width="268" height="102" alt="image" src="https://github.com/user-attachments/assets/92a3709d-6399-4d45-8ef4-14890cbf4fa0" />

Also realized we don't have to override `eager_load!` here, we can just put `Lua.eager_load!` in a `lazy { ... }` block.
