### PR TITLE
Ensure `rake check:style` lints the same files as standard RuboCop runs

### DIFF
--- a/tasks/check/style.rake
+++ b/tasks/check/style.rake
@@ -1,7 +1,6 @@
 namespace :check do
   desc "Run RuboCop on bin/, lib/ and spec/"
   RuboCop::RakeTask.new(:style) do |task|
-    task.patterns = ["bin/**/*", "lib/**/*.rb", "spec/**/*.rb"]
     task.fail_on_error = false
   end
 end


### PR DESCRIPTION
Proposing we removed `task.patterns` from the rake style task so that it behaves and lints the exact same as standard `bundle exec rubocop` runs.

References and prior PRs
- https://docs.rubocop.org/rubocop/latest/usage/cli_reference.html
- https://github.com/rouge-ruby/rouge/pull/2234
- https://github.com/rouge-ruby/rouge/pull/2231
- https://github.com/rouge-ruby/rouge/pull/2205

<img width="3840" height="2096" alt="Screenshot From 2026-02-27 14-19-15" src="https://github.com/user-attachments/assets/ba805747-f948-4be5-afaa-64adf5693a1d" />