### PR TITLE
Add 'pwsh' as alias to Powershell

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -8,7 +8,7 @@ module Rouge
       title 'powershell'
       desc 'powershell'
       tag 'powershell'
-      aliases 'posh', 'microsoftshell', 'msshell'
+      aliases 'posh', 'microsoftshell', 'msshell', 'pwsh'
       filenames '*.ps1', '*.psm1', '*.psd1', '*.psrc', '*.pssc'
       mimetypes 'text/x-powershell'
 


### PR DESCRIPTION
## Summary

Add `pwsh` as alias for `powershell`.

## Context

`pwsh` is the name of the executable ever since Dotnet Core (cross platform) was created, and PowerShell Core (cross platform) was made on top of it. Before that we had Windows PowerShell, with executable name `powershell`.

* Old Windows PowerShell: `powershell`
* New PowerShell: `pwsh`

Other code highlighters supports `pwsh` as alias for `powershell`.

* GitHub linguist: <https://github.com/github-linguist/linguist/blob/738a27e1e2f26f061a24e94f85cd37ae9be71105/lib/linguist/languages.yml#L5923-L5939>
* Highlight.js: <https://github.com/highlightjs/highlight.js/blob/main/src%2Flanguages%2Fpowershell.js>

Others that might soon:

* Shiki: <https://github.com/shikijs/textmate-grammars-themes/pull/198>
