### PR TITLE
Add YARA-L 2.0 lexer

### DIFF
--- a/lib/rouge/demos/yaral
+++ b/lib/rouge/demos/yaral
@@ -1,0 +1,22 @@
+rule SuspiciousLogin {
+  meta:
+    author = "security-team"
+    description = "Detects failed logins from unusual IPs"
+    severity = "HIGH"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $e.security_result.action = "FAIL"
+    net.ip_in_range_cidr($e.principal.ip, "10.0.0.0/8")
+    $user = $e.target.user.userid
+
+  match:
+    $user over 5m
+
+  outcome:
+    $fail_count = count($e.metadata.id)
+    $first_ip = array_distinct($e.principal.ip)
+
+  condition:
+    $fail_count > 3
+}

--- a/lib/rouge/lexers/yaral.rb
+++ b/lib/rouge/lexers/yaral.rb
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class YARAL < RegexLexer
+      title 'YARA-L'
+      desc 'YARA-L 2.0 language for Google Security Operations'
+      tag 'yaral'
+      aliases 'yara-l', 'chronicle'
+      filenames '*.yaral', '*.yara-l'
+      mimetypes 'text/x-yaral'
+
+      def self.detect?(text)
+        return true if text =~ /^\s*rule\s+\w+\s*\{/m
+        return true if text =~ /\bevents\s*:/
+        return true if text =~ /\bmatch\s*:/
+        return true if text =~ /\boutcome\s*:/
+        return true if text =~ /\bcondition\s*:/
+      end
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          rule meta events match outcome condition options
+          and or not nocase in over by
+          before after true false
+          select unselect dedup order limit
+          asc desc
+          any all for of
+          if else
+          udm graph
+        )
+      end
+
+      def self.keywords_time
+        @keywords_time ||= Set.new %w(
+          day hour minute week month year
+        )
+      end
+
+      def self.aggregation_functions
+        @aggregation_functions ||= Set.new %w(
+          count count_distinct sum avg min max stddev
+          array array_distinct
+        )
+      end
+
+      def self.builtin_functions
+        @builtin_functions ||= Set.new %w(
+          arrays.concat arrays.index_to_float arrays.index_to_int
+          arrays.index_to_str arrays.join_string arrays.length
+          arrays.max arrays.min arrays.size arrays.contains
+          bytes.to_base64
+          cast.as_bool cast.as_float cast.as_string
+          group
+          hash.fingerprint2011 hash.sha256
+          math.abs math.ceil math.floor math.geo_distance
+          math.is_increasing math.log math.pow math.random
+          math.round math.sqrt
+          metrics.functionName
+          net.ip_in_range_cidr
+          optimization.sample_rate
+          re.regex re.capture re.capture_all re.replace
+          strings.base64_decode strings.coalesce strings.concat
+          strings.contains strings.count_substrings strings.ends_with
+          strings.extract_domain strings.extract_hostname
+          strings.from_base64 strings.from_hex
+          strings.ltrim strings.reverse strings.rtrim
+          strings.split strings.starts_with
+          strings.to_lower strings.to_upper strings.trim
+          strings.url_decode
+          timestamp.as_unix_seconds timestamp.current_seconds
+          timestamp.get_date timestamp.get_minute timestamp.get_hour
+          timestamp.get_day_of_week timestamp.get_timestamp
+          timestamp.get_week timestamp.now
+          window.avg window.first window.last window.median
+          window.mode window.range window.stddev window.variance
+        )
+      end
+
+      def self.function_namespaces
+        @function_namespaces ||= Set.new %w(
+          arrays bytes cast hash math metrics net optimization
+          re strings timestamp window
+        )
+      end
+
+      state :root do
+        rule %r/\s+/m, Text::Whitespace
+        rule %r(//.*$), Comment::Single
+        rule %r(/\*), Comment::Multiline, :multiline_comment
+
+        # Section headers (meta:, events:, match:, outcome:, condition:, options:)
+        rule %r/(meta|events|match|outcome|condition|options|select|unselect|dedup|order|limit)(\s*)(:)/ do
+          groups Keyword, Text::Whitespace, Punctuation
+        end
+
+        # Rule declaration
+        rule %r/(rule)(\s+)(\w+)(\s*)(\{)/ do
+          groups Keyword::Declaration, Text::Whitespace, Name::Class, Text::Whitespace, Punctuation
+        end
+
+        # Duration literals: 5m, 1h, 1d, 10m, 24h, etc.
+        rule %r/\b(\d+)\s*(m|h|d|s)\b/ do
+          groups Num::Integer, Keyword::Type
+        end
+
+        # Strings
+        rule %r/"/, Str::Double, :double_string
+        rule %r/`/, Str::Backtick, :backtick_string
+
+        # Regex literals
+        rule %r(/), Str::Regex, :regex
+
+        # Reference list variables %name
+        rule %r/%[a-zA-Z_]\w*/, Name::Variable::Global
+
+        # Count references #name
+        rule %r/#[a-zA-Z_]\w*/, Name::Variable::Instance
+
+        # Event/placeholder variables $name with optional field path
+        rule %r/\$[a-zA-Z_]\w*/, Name::Variable
+
+        # Numbers
+        rule %r/\b\d+\.\d+\b/, Num::Float
+        rule %r/\b\d+\b/, Num::Integer
+
+        # Namespaced function calls (strings.concat, re.regex, etc.)
+        rule %r/\b[a-zA-Z_]\w*\.[a-zA-Z_]\w*(?=\s*\()/ do |m|
+          if self.class.builtin_functions.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Function
+          end
+        end
+
+        # UDM field paths: sequences like principal.hostname, metadata.event_type
+        # Distinguished from keywords by the dot path
+        rule %r/\b[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)+\b/ do |m|
+          # Check if it's a namespaced function used without parens
+          if self.class.builtin_functions.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Property
+          end
+        end
+
+        # Operators
+        rule %r/[!=<>]=?/, Operator
+        rule %r/[+\-*]/, Operator
+
+        # Punctuation
+        rule %r/[{}()\[\]:;,.]/, Punctuation
+
+        # Words: keywords, functions, or identifiers
+        rule %r/\b\w+\b/ do |m|
+          if self.class.keywords.include? m[0].downcase
+            token Keyword
+          elsif self.class.keywords_time.include? m[0].downcase
+            token Keyword::Type
+          elsif self.class.aggregation_functions.include?(m[0].downcase) ||
+                self.class.function_namespaces.include?(m[0].downcase)
+            token Name::Builtin
+          else
+            token Name
+          end
+        end
+      end
+
+      state :multiline_comment do
+        rule %r([^*/]+), Comment::Multiline
+        rule %r(/\*), Comment::Multiline, :multiline_comment
+        rule %r(\*/), Comment::Multiline, :pop!
+        rule %r([*/]), Comment::Multiline
+      end
+
+      state :double_string do
+        rule %r/[^\\"]+/, Str::Double
+        rule %r/\\./, Str::Escape
+        rule %r/"/, Str::Double, :pop!
+      end
+
+      state :backtick_string do
+        rule %r/[^`]+/, Str::Backtick
+        rule %r/`/, Str::Backtick, :pop!
+      end
+
+      state :regex do
+        rule %r([^/\\]+), Str::Regex
+        rule %r(\\.),     Str::Regex
+        rule %r(/),       Str::Regex, :pop!
+      end
+    end
+  end
+end

--- a/spec/lexers/yaral_spec.rb
+++ b/spec/lexers/yaral_spec.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::YARAL do
+  let(:subject) { Rouge::Lexers::YARAL.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.yaral'
+      assert_guess :filename => 'bar.yara-l'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-yaral'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => 'rule TestRule {'
+      assert_guess :source => "events:\n  \$e.metadata.event_type = \"USER_LOGIN\""
+    end
+  end
+end

--- a/spec/visual/samples/yaral
+++ b/spec/visual/samples/yaral
@@ -1,0 +1,685 @@
+// =====================================================
+// YARA-L 2.0 Visual Sample
+// Comprehensive syntax coverage for Rouge lexer testing
+// =====================================================
+
+/*
+ * Multi-line comment block
+ * This file exercises every YARA-L 2.0 syntax element
+ * across detection rules, search queries, and dashboards.
+ */
+
+// =====================================================
+// DETECTION RULE: All section types
+// =====================================================
+rule ComprehensiveSections {
+  meta:
+    author = "security-team"
+    description = "Demonstrates all rule sections"
+    severity = "HIGH"
+    priority = "P1"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $e.security_result.action = "FAIL"
+    $e.principal.user.userid != ""
+    $user = $e.principal.user.userid
+    $host = $e.principal.hostname
+
+  match:
+    $user over 10m
+
+  outcome:
+    $login_count = count($e.metadata.id)
+    $unique_hosts = count_distinct($e.principal.hostname)
+    $max_ts = max($e.metadata.event_timestamp.seconds)
+
+  condition:
+    $login_count > 5 and $unique_hosts > 1
+
+  options:
+    allow_zero_values = true
+}
+
+// =====================================================
+// DETECTION RULE: Boolean and logical operators
+// =====================================================
+rule BooleanOperators {
+  meta:
+    author = "analyst"
+    description = "Tests all boolean/logical keywords and operators"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    (
+      $e.principal.ip != "127.0.0.1"
+      and $e.target.port = 443
+    ) or (
+      $e.principal.ip != "::1"
+      and $e.target.port = 80
+    )
+    not $e.principal.hostname = "localhost"
+
+  match:
+    $e.principal.ip over 1h
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: Comparison and string-matching operators
+// =====================================================
+rule ComparisonOperators {
+  meta:
+    description = "Tests comparison and matching operators"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $e.principal.user.userid != ""
+    $e.network.sent_bytes > 0
+    $e.network.sent_bytes >= 100
+    $e.network.received_bytes < 50000
+    $e.network.received_bytes <= 99999
+    $e.principal.hostname = "workstation-01" nocase
+    $e.target.hostname = /^prod-.*/ nocase
+    $e.security_result.description = /error|fail/
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: Temporal keywords
+// =====================================================
+rule TemporalEvents {
+  meta:
+    description = "Uses before and after temporal keywords"
+
+  events:
+    $login.metadata.event_type = "USER_LOGIN"
+    $logout.metadata.event_type = "USER_LOGOUT"
+    $login.metadata.event_timestamp.seconds <
+      $logout.metadata.event_timestamp.seconds
+    $user = $login.target.user.userid
+    $user = $logout.target.user.userid
+    $login.metadata.event_timestamp.seconds before
+      $logout.metadata.event_timestamp.seconds
+
+  match:
+    $user over 24h
+
+  condition:
+    $login and $logout
+}
+
+// =====================================================
+// DETECTION RULE: All variable types
+// =====================================================
+rule VariableTypes {
+  meta:
+    description = "Tests $event, $placeholder, %reference_list, #count"
+
+  events:
+    $e1.metadata.event_type = "USER_LOGIN"
+    $e2.metadata.event_type = "PROCESS_LAUNCH"
+    $user = $e1.principal.user.userid
+    $user = $e2.principal.user.userid
+    $e1.principal.ip in %suspicious_ips
+    $e2.target.file.sha256 in %known_malware_hashes
+    not $e1.principal.hostname in %whitelisted_hosts
+
+  match:
+    $user over 5m
+
+  condition:
+    #e1 > 0 and #e2 > 0
+}
+
+// =====================================================
+// DETECTION RULE: Aggregation functions
+// =====================================================
+rule AggregationFunctions {
+  meta:
+    description = "Tests every aggregation function"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    $host = $e.principal.hostname
+
+  match:
+    $host over 1h
+
+  outcome:
+    $event_count = count($e.metadata.id)
+    $distinct_ips = count_distinct($e.target.ip)
+    $total_bytes = sum($e.network.sent_bytes)
+    $avg_bytes = avg($e.network.sent_bytes)
+    $min_bytes = min($e.network.sent_bytes)
+    $max_bytes = max($e.network.sent_bytes)
+    $deviation = stddev($e.network.sent_bytes)
+    $all_ips = array_distinct($e.target.ip)
+    $ip_list = array($e.target.ip)
+
+  condition:
+    $event_count > 10
+}
+
+// =====================================================
+// DETECTION RULE: strings namespace functions
+// =====================================================
+rule StringFunctions {
+  meta:
+    description = "Tests strings.* functions"
+
+  events:
+    $e.metadata.event_type = "EMAIL_TRANSACTION"
+    $lower_from = strings.to_lower($e.network.email.from)
+    $upper_to = strings.to_upper($e.network.email.to)
+    $combined = strings.concat($e.principal.hostname, ":", $e.principal.port)
+    $domain = strings.extract_domain($e.network.email.from)
+    $hostname = strings.extract_hostname($e.principal.url)
+    strings.contains($e.network.email.subject, "urgent")
+    strings.ends_with($e.network.email.from, ".ru")
+    $trimmed = strings.trim($e.principal.hostname, " ")
+    $ltrimmed = strings.ltrim($e.principal.hostname, "www.")
+    $rtrimmed = strings.rtrim($e.principal.hostname, ".com")
+    $decoded = strings.base64_decode($e.network.http.user_agent)
+    $from_b64 = strings.from_base64("dGVzdA==")
+    $url_dec = strings.url_decode($e.target.url)
+    $reversed = strings.reverse($e.principal.hostname)
+    $coalesced = strings.coalesce($e.principal.ip, $e.src.ip, "0.0.0.0")
+    $parts = strings.split($e.principal.hostname, ".")
+    $from_hex = strings.from_hex("48656c6c6f")
+    $sub_count = strings.count_substrings($e.target.url, "/")
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: re namespace functions
+// =====================================================
+rule RegexFunctions {
+  meta:
+    description = "Tests re.* functions"
+
+  events:
+    $e.metadata.event_type = "NETWORK_HTTP"
+    re.regex($e.principal.hostname, `.*\.evil\.com$`)
+    $captured = re.capture($e.network.email.from, "@(.*)")
+    $replaced = re.replace($e.target.url, "http://", "https://")
+    $all_ips = re.capture_all($e.network.http.user_agent, `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: network functions
+// =====================================================
+rule NetworkFunctions {
+  meta:
+    description = "Tests net.* functions"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    net.ip_in_range_cidr($e.principal.ip, "192.168.0.0/16")
+    net.ip_in_range_cidr($e.target.ip, "2001:db8::/32")
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: timestamp functions
+// =====================================================
+rule TimestampFunctions {
+  meta:
+    description = "Tests timestamp.* functions"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $ts = $e.metadata.event_timestamp.seconds
+    $date = timestamp.get_date($ts)
+    $hour = timestamp.get_hour($ts, "America/Los_Angeles")
+    $minute = timestamp.get_minute($ts)
+    $dow = timestamp.get_day_of_week($ts)
+    $week = timestamp.get_week($ts, "UTC")
+    $formatted = timestamp.get_timestamp($ts, "%F %T", "GMT")
+    $now = timestamp.now()
+    $current = timestamp.current_seconds()
+    $unix = timestamp.as_unix_seconds("2024-01-01 00:00:00")
+    86400 < math.abs($ts - timestamp.now())
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: math functions
+// =====================================================
+rule MathFunctions {
+  meta:
+    description = "Tests math.* functions"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    math.log($e.network.sent_bytes) > 20
+    $abs_val = math.abs($e.network.sent_bytes - 1000)
+    $ceil_val = math.ceil(2.5)
+    $floor_val = math.floor(2.9)
+    $sqrt_val = math.sqrt(144)
+    $pow_val = math.pow(2, 10)
+    $random = math.random()
+    $distance = math.geo_distance(-122.0, 37.4, -122.02, 37.4)
+    math.is_increasing(1, 2, 3)
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: arrays functions
+// =====================================================
+rule ArrayFunctions {
+  meta:
+    description = "Tests arrays.* functions"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    arrays.length($e.principal.ip) > 1
+    $elem_str = arrays.index_to_str($e.principal.ip, 0)
+    $elem_int = arrays.index_to_int($e.principal.ip, 0)
+    $elem_float = arrays.index_to_float($e.principal.ip, 0)
+    $joined = arrays.join_string($e.principal.ip, ",")
+    $arr_max = arrays.max($e.network.sent_bytes)
+    $arr_min = arrays.min($e.network.sent_bytes)
+    $arr_size = arrays.size($e.principal.ip)
+    $merged = arrays.concat($e.principal.ip, $e.target.ip)
+    arrays.contains($e.principal.ip, "10.0.0.1")
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: hash, cast, bytes functions
+// =====================================================
+rule HashCastBytesFunctions {
+  meta:
+    description = "Tests hash.*, cast.*, bytes.* functions"
+
+  events:
+    $e.metadata.event_type = "PROCESS_LAUNCH"
+    $sha = hash.sha256($e.target.file.full_path)
+    $fp = hash.fingerprint2011($e.principal.user.userid)
+    $is_true = cast.as_bool("true")
+    $as_float = cast.as_float("3.14")
+    $as_str = cast.as_string(42)
+    $b64 = bytes.to_base64($e.target.file.md5)
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: window functions
+// =====================================================
+rule WindowFunctions {
+  meta:
+    description = "Tests window.* functions"
+
+  events:
+    $e.metadata.event_type = "FILE_COPY"
+    $user = $e.principal.user.userid
+
+  match:
+    $user over 5m
+
+  outcome:
+    $w_avg = window.avg($e.target.file.size)
+    $w_median = window.median($e.target.file.size)
+    $w_mode = window.mode($e.target.file.size)
+    $w_stddev = window.stddev($e.target.file.size)
+    $w_variance = window.variance($e.target.file.size)
+    $w_range = window.range($e.target.file.size)
+    $w_first = window.first($e.metadata.event_timestamp.seconds, $e.metadata.vendor_name)
+    $w_last = window.last($e.metadata.event_timestamp.seconds, $e.metadata.vendor_name)
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: Regex patterns and backtick strings
+// =====================================================
+rule RegexPatterns {
+  meta:
+    description = "Tests regex literals and backtick strings"
+
+  events:
+    $e.metadata.event_type = "NETWORK_HTTP"
+    $e.principal.hostname = /^prod-\d{3}$/
+    $e.target.url = /https?:\/\/.+/
+    $e.network.http.user_agent = /(?i)mozilla/
+    re.regex($e.principal.hostname, `^web-server-\d+$`)
+    re.regex($e.target.url, `.*altostrat\.com`)
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: UDM field paths at depth
+// =====================================================
+rule DeepFieldPaths {
+  meta:
+    description = "Tests deep UDM field paths"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    $e.principal.asset.asset_id != ""
+    $e.target.application = "chrome"
+    $e.intermediary.ip != ""
+    $e.network.http.response_code = 200
+    $e.security_result.action = "ALLOW"
+    $e.security_result.severity = "HIGH"
+    $e.additional.fields["pod_name"] = "scheduler"
+    $e.metadata.ingestion_labels["source"] = "syslog"
+    $e.network.tls.certificate.not_after > 0
+    $e.target.file.sha256 != ""
+    $e.principal.process.command_line != ""
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: Multi-event composite detection
+// =====================================================
+rule MultiEventComposite {
+  meta:
+    author = "soc-analyst"
+    description = "Composite multi-event detection"
+
+  events:
+    $login.metadata.event_type = "USER_LOGIN"
+    $login.security_result.action = "ALLOW"
+    $process.metadata.event_type = "PROCESS_LAUNCH"
+    $process.target.process.command_line = /.*powershell.*/
+    $user = $login.principal.user.userid
+    $user = $process.principal.user.userid
+    $login.metadata.event_timestamp.seconds <
+      $process.metadata.event_timestamp.seconds
+
+  match:
+    $user over 15m
+
+  outcome:
+    $login_count = count($login.metadata.id)
+    $process_count = count($process.metadata.id)
+
+  condition:
+    $login and $process and $process_count >= 1
+}
+
+// =====================================================
+// DETECTION RULE: optimization.sample_rate
+// =====================================================
+rule SampledRule {
+  meta:
+    description = "Uses optimization.sample_rate"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    $asset_id = $e.principal.asset.asset_id
+    optimization.sample_rate($e.metadata.id, 1, 5)
+
+  match:
+    $asset_id over 1h
+
+  outcome:
+    $event_count = count_distinct($e.metadata.id)
+    $usage = sum(5.0 * $e.network.sent_bytes)
+
+  condition:
+    $e and $usage > 1000000000 and $event_count >= 100
+}
+
+// =====================================================
+// DETECTION RULE: for/any/all/of quantifiers
+// =====================================================
+rule QuantifierExample {
+  meta:
+    description = "Tests any and all quantifiers"
+
+  events:
+    $e.metadata.event_type = "NETWORK_CONNECTION"
+    any $e.security_result.action = "BLOCK"
+    all $e.target.ip != "0.0.0.0"
+
+  condition:
+    $e
+}
+
+// =====================================================
+// DETECTION RULE: graph entity context
+// =====================================================
+rule EntityContext {
+  meta:
+    description = "Uses graph for entity context"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $g.graph.entity.user.userid = $e.target.user.userid
+    $g.graph.entity.user.attribute.labels["department"] = "finance"
+
+  match:
+    $e.target.user.userid over 1h
+
+  condition:
+    $e and $g
+}
+
+// =====================================================
+// DETECTION RULE: Unbounded / non-existence condition
+// =====================================================
+rule NonExistence {
+  meta:
+    description = "Detects threat without a mitigation event"
+
+  events:
+    $threat.metadata.event_type = "PROCESS_LAUNCH"
+    $threat.security_result.severity = "CRITICAL"
+    $mitigate.metadata.event_type = "STATUS_UPDATE"
+    $user = $threat.principal.user.userid
+    $user = $mitigate.principal.user.userid
+
+  match:
+    $user over 10m
+
+  condition:
+    $threat and !$mitigate
+}
+
+// =====================================================
+// SEARCH QUERY: Statistical aggregation
+// =====================================================
+// select, group, order, limit, asc/desc
+metadata.event_type = "USER_LOGIN"
+security_result.action = "FAIL"
+$user = principal.user.userid
+$ip = principal.ip
+
+match:
+  $user, $ip
+
+outcome:
+  $fail_count = count(metadata.id)
+  $unique_hosts = count_distinct(principal.hostname)
+
+order:
+  $fail_count desc
+
+limit:
+  100
+
+// =====================================================
+// SEARCH QUERY: unselect and dedup
+// =====================================================
+metadata.event_type = "NETWORK_CONNECTION"
+target.port = 443
+
+dedup:
+  target.ip
+
+unselect:
+  metadata.collected_timestamp
+
+// =====================================================
+// SEARCH QUERY: group() function
+// =====================================================
+$ip = group(principal.ip, about.ip, target.ip)
+$ip != ""
+
+match:
+  $ip
+
+outcome:
+  $count = count_distinct(metadata.id)
+
+order:
+  $count desc
+
+// =====================================================
+// SEARCH QUERY: over every for time-based grouping
+// =====================================================
+metadata.event_type = "USER_LOGIN"
+$user = principal.user.userid
+
+match:
+  $user over every 1h
+
+outcome:
+  $hourly_logins = count(metadata.id)
+
+// =====================================================
+// SEARCH QUERY: select specific fields
+// =====================================================
+metadata.event_type = "PROCESS_LAUNCH"
+principal.hostname != ""
+
+select:
+  principal.hostname, principal.process.command_line, metadata.event_timestamp
+
+// =====================================================
+// SEARCH QUERY: tumbling window with by
+// =====================================================
+metadata.event_type = "USER_LOGIN"
+$user = principal.user.userid
+
+match:
+  $user by day
+
+outcome:
+  $daily_count = count(metadata.id)
+
+// =====================================================
+// DASHBOARD QUERY: dashboard-specific functions
+// =====================================================
+detection.detection.severity != "UNKNOWN_SEVERITY"
+$severity = detection.detection.severity
+
+match:
+  $severity by hour
+
+outcome:
+  $detection_count = count_distinct(detection.id)
+  $avg_score = avg(detection.detection.risk_score)
+  $std_dev = stddev(detection.detection.risk_score)
+  $log_count = math.log($detection_count)
+  $rounded = math.round($avg_score, 2)
+
+// =====================================================
+// DASHBOARD QUERY: match section with time window
+// =====================================================
+events:
+  metadata.event_type = "USER_LOGIN"
+
+match:
+  target.user.userid
+
+outcome:
+  $login_count = count(metadata.id)
+
+// =====================================================
+// ALL LITERAL TYPES
+// =====================================================
+// Double-quoted string
+// "hello world"
+// "escape sequences: \t \n \\ \""
+
+// Backtick string (raw, no escaping)
+// `raw\nstring`
+// `no escape here`
+
+// Integer literals
+// 0 1 42 1000000 86400
+
+// Float literals
+// 0.0 3.14 1.0123456 2.5
+
+// Boolean literals
+// true false
+
+// Duration literals
+// 5m 1h 24h 1d 10s
+
+// Regex literal
+// /^pattern$/ /[a-z]+/ /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
+
+// =====================================================
+// ALL OPERATORS
+// =====================================================
+// Comparison: = != < <= > >=
+// Boolean: and or not
+// Modifier: nocase
+// Membership: in
+// Temporal: over by before after
+
+// =====================================================
+// Enumerated types
+// =====================================================
+rule EnumTypes {
+  meta:
+    description = "Tests enumerated type comparisons"
+
+  events:
+    $e.metadata.event_type >= "USER_UNCATEGORIZED"
+    $e.metadata.event_type <= "USER_RESOURCE_DELETION"
+
+  condition:
+    $e
+}
+
+// =====================================================
+// Nested conditionals
+// =====================================================
+rule NestedConditions {
+  meta:
+    description = "Tests if/else in outcomes"
+
+  events:
+    $e.metadata.event_type = "USER_LOGIN"
+    $user = $e.target.user.userid
+
+  match:
+    $user over 1h
+
+  outcome:
+    $risk = if($user = "admin", "HIGH", if(count($e.metadata.id) > 10, "MEDIUM", "LOW"))
+
+  condition:
+    $e
+}


### PR DESCRIPTION
Add a new lexer for YARA-L 2.0, the detection and search query language used by Google Security Operations (Chronicle).

Supports:
- Detection rules (rule/meta/events/match/outcome/condition sections)
- UDM search queries (select/group/order/limit/dedup)
- Dashboard queries with aggregation functions
- All 70+ built-in functions across 12 namespaces
- UDM dot-path field access, variables ($, %, #)
- Regex literals, duration literals, string escapes
- Case-insensitive keywords per the YARA-L specification

Disclaimer: This was created by the Claude Opus 4.6 AI model using the following prompt:

## Language config

- **Lexer name:** yaral
- **Class name:** YARAL
- **Title:** YARA-L
- **Description:** YARA-L 2.0 language for Google Security Operations
- **Tag:** yaral
- **Aliases:** yara-l, chronicle
- **Filenames:** `*.yaral`, `*.yara-l`
- **Mimetype:** text/x-yaral

## Official references (use ONLY these — do not guess syntax)

### Core language

- YARA-L 2.0 language syntax: <https://cloud.google.com/chronicle/docs/detection/yara-l-2-0-syntax>
- YARA-L overview: <https://docs.cloud.google.com/chronicle/docs/yara-l/yara-l-overview>
- Expressions, operators, and constructs: <https://docs.cloud.google.com/chronicle/docs/yara-l/expressions>
- Functions reference: <https://docs.cloud.google.com/chronicle/docs/yara-l/functions>
- Condition section syntax: <https://docs.cloud.google.com/chronicle/docs/yara-l/condition-syntax>
- YARA-L 2.0 examples: <https://docs.cloud.google.com/chronicle/docs/yara-l/yara-l-2-0-examples>

### Detection rules

- YARA-L best practices: <https://cloud.google.com/chronicle/docs/detection/yara-l-best-practices>
- Composite detection rules: <https://docs.cloud.google.com/chronicle/docs/yara-l/composite-detection-rules>
- Default detection rules (examples): <https://docs.cloud.google.com/chronicle/docs/detection/default-rules>
- Chronicle detection-rules GitHub: <https://github.com/chronicle/detection-rules>

### Search queries

- UDM search: <https://docs.cloud.google.com/chronicle/docs/investigation/udm-search>
- Statistics and aggregations in search: <https://docs.cloud.google.com/chronicle/docs/investigation/statistics-aggregations-in-udm-search>
- Conditions in search and dashboards: <https://docs.cloud.google.com/chronicle/docs/investigation/yara-l-2-0-conditions>
- Multi-stage queries: <https://docs.cloud.google.com/chronicle/docs/investigation/multi-stage-yaral>

### Dashboards

- Dashboard-specific functions: <https://docs.cloud.google.com/chronicle/docs/reference/yaral-functions-native-dashboards>
- Sample dashboard queries: <https://docs.cloud.google.com/chronicle/docs/reference/sample-yaral-for-native-dashboard>
- Dashboards overview: <https://docs.cloud.google.com/chronicle/docs/reports/native-dashboards>

## Rouge references

- Lexer development guide: <https://github.com/rouge-ruby/rouge/blob/main/docs/LexerDevelopment.md>
- Existing lexers for reference: <https://github.com/rouge-ruby/rouge/tree/main/lib/rouge/lexers>
- JSON lexer (simple example): <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/lexers/json.rb>
- SQL lexer (closest analog): <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/lexers/sql.rb>
- Token types: <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/token.rb>

## Task

Create a Rouge lexer for YARA-L 2.0. Work inside my local fork of the rouge-ruby/rouge repo.

**Important context:** YARA-L 2.0 is used in three contexts within Google SecOps, and the lexer must handle all of them:

1. **Detection rules** — structured rules with `rule name { meta: ... events: ... condition: ... }` syntax.
2. **Search queries** — UDM search with statistical/aggregation keywords (`select`, `unselect`, `group`, `order`, `limit`, `dedup`, `join`, `outer`, `cross`, `asc`, `desc`, `by`, `over every`) and multi-stage pipelines.
3. **Dashboard queries** — similar to search queries but with dashboard-specific functions (`math.log`, `math.round`, `avg`, `stddev`, `group()`) and a required `match` section.

### Phase 0: Setup

1. Confirm you're in the root of a Rouge repo checkout (look for `lib/rouge/lexers/`, `spec/lexers/`, `Gemfile`).
2. Run `git checkout -b yara-l` to create a dedicated branch.
3. Run `bundle install` if `vendor/` or `.bundle/` is missing.
4. Run `bundle exec rake` once to confirm the existing test suite passes before you touch anything.

### Phase 1: Research

Before writing any code, fetch and read **every** official reference listed above — core language, detection rules, search queries, AND dashboards. Your goal is to build a **complete** inventory of the language's syntax across all three usage contexts.

Extract and organize:

1. **All rule/query structure keywords** — every keyword that defines structure in any context: rule sections (`rule`, `meta`, `events`, `match`, `outcome`, `condition`, `options`), and search/dashboard sections or keywords.
2. **All search and aggregation keywords** — `select`, `unselect`, `group`, `order`, `limit`, `dedup`, `join`, `outer`, `cross`, `asc`, `desc`, `by`, `over`, `every`, and any others found in the search/dashboard docs.
3. **All operator keywords** — boolean, comparison, matching, temporal, quantifier keywords, etc.
4. **All built-in functions** — every function name across all contexts, organized by namespace. Include the full namespace path. Check every doc page including the dashboard-specific functions page; functions are scattered across multiple references.
5. **All variable types and sigils** — `$` variables, `%` reference lists, `#` count references, and any other sigil-prefixed identifiers.
6. **All literal types** — strings, numbers, time durations, regex patterns, enum-like constants.
7. **All operators and punctuation** — comparison operators, assignment, dot notation, brackets, braces, colons, commas, pipes for multi-stage queries, etc.
8. **Comment syntax** — single-line and multi-line formats.
9. **Any other syntax** — UDM field paths, IP/CIDR literals, special patterns in `match`/`outcome` sections, `for` loops or quantifiers in conditions, multi-stage pipeline syntax, etc.

Cross-reference the detection-rules GitHub repo AND the sample dashboard queries page for real-world syntax patterns not prominent in the reference docs.

**Do not assume any list you build is complete until you have checked every reference.** If something is ambiguous, web-search to verify.

### Phase 2: Write the lexer

Create `lib/rouge/lexers/yaral.rb` following Rouge conventions:

- Subclass `Rouge::RegexLexer`.
- Declare `title`, `desc`, `tag`, `aliases`, `filenames`, `mimetypes` per the language config above.
- Implement `self.detect?(text)` for source-based guessing.
- Use class methods with `Set.new %w(...)` for keyword and function lists.
- Define states: `:root` plus any additional states needed for strings, comments, and nested constructs.
- Choose appropriate token types by studying how the SQL and JSON lexers handle analogous constructs. Refer to `lib/rouge/token.rb` for the full token hierarchy.
- Do NOT interpolate keyword lists into regex patterns — use a generic `\w+` rule with a block that checks set membership.
- The lexer must handle detection rules, search queries, and dashboard queries — all three share the same token vocabulary, so a single lexer with comprehensive keyword/function coverage is the right approach.

### Phase 3: Write test files

#### `lib/rouge/demos/yaral` (no file extension)

A realistic, compact example (under 20 lines) that exercises key syntax: rule structure, events with UDM field access, variables, a condition, and at least one function call.

#### `spec/visual/sample/yaral` (no file extension)

**This file is critical.** It must exercise every syntax element you discovered in Phase 1 across all three usage contexts (detection rules, search queries, dashboards). Structure it as a series of examples:

**Detection rules:**

- A rule demonstrating all section types (`meta`, `events`, `match`, `outcome`, `condition`, `options`)
- A rule using every boolean/logical keyword and operator
- A rule using every comparison and string-matching operator
- A rule using temporal keywords (`before`, `after`, time windows)
- A rule demonstrating all variable types (`$event`, `$placeholder`, `%reference_list`, `#count`)
- A rule exercising aggregation functions (every one from your inventory)
- Rules exercising every function namespace (strings, network, timestamp, math, arrays, hash, re, and any others)
- A rule demonstrating regex patterns and backtick strings
- A rule demonstrating UDM field paths at various depths
- A rule demonstrating composite/multi-event detection

**Search queries:**

- A statistical/aggregation query using `select`, `group`, `order`, `limit`, `asc`/`desc`
- A query using `unselect` and `dedup`
- A query demonstrating `join`, `outer join`, and/or `cross join`
- A multi-stage query showing pipeline syntax
- A query using `over every` for time-based grouping

**Dashboard queries:**

- A dashboard query using dashboard-specific functions (`math.log`, `math.round`, `avg`, `stddev`, `group()`)
- A dashboard query with the required `match` section and time window

**General:**

- Comments (single-line and multi-line if applicable)
- All literal types (strings, numbers, durations, etc.)

Every keyword, function, operator, and syntax construct from your Phase 1 inventory MUST appear at least once. After writing, cross-check against your inventory and add anything missing.

#### `spec/lexers/yaral_spec.rb`

- Test `assert_guess :filename =>` for each filename glob.
- Test `assert_guess :mimetype =>` for the declared mimetype.
- Test `assert_guess :source =>` for patterns that `self.detect?` should match.

### Phase 4: Test and iterate

Use the visual preview server as a feedback loop.

1. Run `bundle exec rake`. Fix any failures.
2. Start the visual preview server: `bundle exec puma -d -p 9292`.
3. Count Error tokens:

   ```bash
   curl -s http://localhost:9292/yaral | grep -o 'class="err"' | wc -l
   ```

4. If there are Error tokens, identify what's causing them:

   ```bash
   curl -s http://localhost:9292/yaral | grep -oP '<span class="err">[^<]*</span>' | sort -u
   ```

5. For each Error token:
   a. Identify what syntax element the unmatched text represents.
   b. Verify against the official docs that the syntax is valid.
   c. Fix the lexer rule to handle it.
   d. Re-run `bundle exec rake` to confirm no regressions.
   e. Re-fetch to check if the Error token is gone.
6. Repeat until the Error token count is **zero** for both the visual sample and the demo.
7. Do a final visual sanity check — fetch the HTML and confirm that keywords, functions, operators, strings, numbers, comments, and variables are each distinctly highlighted.
8. Kill the puma server when done.

### Phase 5: Finalize

1. Run `bundle exec rake` one final time — full pass, zero failures.
2. Review the diff: `git diff --stat`. You should have exactly these new files:
   - `lib/rouge/lexers/yaral.rb`
   - `lib/rouge/demos/yaral`
   - `spec/lexers/yaral_spec.rb`
   - `spec/visual/sample/yaral`
3. Commit: `git add -A && git commit -m "Add YARA-L lexer"`.
4. Report what you've done: list the keyword count, function count, token types used, and confirm zero Error tokens in both the demo and visual sample.

### Constraints (applies to all phases)

- **No hallucinated syntax.** Every keyword, function, operator, and language construct in the lexer must come from the official documentation listed above. If you're unsure whether something is valid, web-search the docs before adding it.
- **Follow Rouge conventions exactly.** Study existing lexers (especially JSON and SQL) for patterns. Don't invent novel approaches.
- **The Error token count is the ground truth.** The visual preview server is the authoritative test. `bundle exec rake` passing is necessary but not sufficient — you must also have zero `class="err"` spans.
- **Iterate until clean.** Do not declare the task complete until both `bundle exec rake` passes AND the Error token count is zero for both demo and visual sample.

