### PR TITLE
Add SPL lexer

### DIFF
--- a/lib/rouge/demos/spl
+++ b/lib/rouge/demos/spl
@@ -1,0 +1,12 @@
+``` This is a block comment in SPL ```
+index=main sourcetype=access_combined earliest=-24h@h latest=now
+| search status>=400 NOT status=200
+| eval error_type=case(status>=500, "Server Error", status>=400, "Client Error", true(), "Other")
+| stats count AS error_count, values(uri_path) AS paths BY error_type, host
+| where error_count > 10
+| eval message=if(error_count>100, "CRITICAL", "WARNING")
+| eval hash=md5(host)
+| rename error_count AS "Total Errors"
+| sort -error_count
+| table error_type, host, "Total Errors", paths, message
+| head 20

--- a/lib/rouge/lexers/spl.rb
+++ b/lib/rouge/lexers/spl.rb
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class SPL < RegexLexer
+      title "SPL"
+      desc "Splunk Search Processing Language (SPL)"
+      tag 'spl'
+      aliases 'splunk', 'splunk-spl'
+      filenames '*.spl', '*.splunk'
+      mimetypes 'text/x-spl'
+
+      def self.detect?(text)
+        return true if text =~ /^\s*\|\s*(stats|eval|table|search|where|rex|rename|fields|sort|dedup|timechart|chart|head|tail)\b/i
+        return true if text =~ /\bindex\s*=\s*\w+/i && text =~ /\bsourcetype\s*=\s*/i
+      end
+
+      # SPL commands (from Splunk command quick reference)
+      def self.commands
+        @commands ||= Set.new %w(
+          abstract accum addcoltotals addinfo addtotals analyzefields
+          anomalies anomalousvalue anomalydetection append appendcols
+          appendpipe arules associate autoregress bin bucket bucketdir
+          chart cluster cofilter collect concurrency contingency convert
+          correlate datamodel dbinspect dedup delete delta diff erex eval
+          eventcount eventstats extract filldown fillnull findtypes
+          folderize foreach format from gauge gentimes geom geomfilter
+          geostats head highlight history iconify inputcsv inputlookup
+          iplocation join kmeans kvform loadjob localize localop lookup
+          makecontinuous makemv makeresults map mcollect metadata
+          metasearch meventcollect mpreview msearch mstats multikv
+          multisearch mvcombine mvexpand nomv outlier outputcsv
+          outputlookup outputtext overlap pivot predict rangemap rare
+          redistribute regex reltime rename replace require rest return
+          reverse rex rtorder savedsearch script run scrub search
+          searchtxn selfjoin sendalert sendemail set setfields sichart
+          sirare sistats sitimechart sitop sort spath stats strcat
+          streamstats table tags tail timechart timewrap tojson top
+          transaction transpose trendline tscollect tstats typeahead
+          typelearner typer union uniq untable walklex where x11 xmlkv
+          xmlunescape xpath xyseries kv
+        )
+      end
+
+      # Evaluation functions (from Splunk evaluation functions reference)
+      def self.eval_functions
+        @eval_functions ||= Set.new %w(
+          abs acos acosh asin asinh atan atan2 atanh avg
+          bit_and bit_or bit_not bit_xor bit_shift_left bit_shift_right
+          case cidrmatch ceiling coalesce commands cos cosh exact exp
+          false floor hypot if in ipmask isarray isbool isdouble isint
+          ismv isnotnull isnull isnum isobject isstr json json_append
+          json_array json_array_to_mv json_delete json_entries
+          json_extend json_extract json_extract_exact json_has_key_exact
+          json_keys json_object json_set json_set_exact json_valid len
+          like ln log lower ltrim match max md5 min mvappend mvcount
+          mvdedup mvfilter mvfind mvindex mvjoin mvmap mvrange mvsort
+          mvzip mv_to_json_array now null nullif pi pow printf random
+          relative_time replace round rtrim searchmatch sha1 sha256
+          sha512 sigfig sin sinh split sqrt strftime strptime substr sum
+          tan tanh time toarray tobool todouble toint tomv tonumber
+          toobject tostring trim true typeof upper urldecode validate
+        )
+      end
+
+      # Statistical and charting functions (from Splunk stats functions reference)
+      def self.stats_functions
+        @stats_functions ||= Set.new %w(
+          avg count distinct_count dc estdc estdc_error exactperc max
+          mean median min mode perc percentile range stdev stdevp sum
+          sumsq upperperc var varp first last list values earliest
+          earliest_time latest latest_time per_day per_hour per_minute
+          per_second rate rate_avg rate_sum sparkline
+        )
+      end
+
+      # Operator keywords
+      def self.operator_words
+        @operator_words ||= Set.new %w(
+          AND OR NOT XOR IN LIKE BY AS OVER OUTPUT OUTPUTNEW WHERE
+        )
+      end
+
+      # Constants
+      def self.constants
+        @constants ||= Set.new %w(
+          true false TRUE FALSE null NULL
+        )
+      end
+
+      # Built-in / internal fields
+      def self.builtin_fields
+        @builtin_fields ||= Set.new %w(
+          _time _raw _indextime _cd _serial _bkt _si _sourcetype
+          _subsecond _kv host source sourcetype index splunk_server
+          linecount punct timeendpos timestartpos eventtype tag
+          date_hour date_mday date_minute date_month date_second
+          date_wday date_year date_zone
+        )
+      end
+
+      state :root do
+        # Whitespace
+        rule %r/\s+/m, Text
+
+        # Block comments (triple backtick)
+        rule %r/```/, Comment::Multiline, :block_comment
+
+        # Single-line comments (starting with ` followed by content)
+        # SPL doesn't have single-line comments in the traditional sense
+
+        # Double-quoted strings
+        rule %r/"/, Str::Double, :double_string
+
+        # Single-quoted strings (field names)
+        rule %r/'/, Str::Single, :single_string
+
+        # Backtick-quoted macros/saved searches (not triple)
+        rule %r/`(?!``)/, Name::Function, :backtick_string
+
+        # Numeric literals
+        rule %r/-?\d+\.\d+(?:e[+-]?\d+)?/i, Num::Float
+        rule %r/-?\d+(?:e[+-]?\d+)?/i, Num::Integer
+
+        # Time modifiers (e.g., -24h@h, +7d@d, -30m, now)
+        rule %r/[+-]\d+[smhdwqy](?:@[smhdwqy])?/i, Literal::Date
+
+        # Subsearch brackets
+        rule %r/[\[\]]/, Punctuation
+
+        # Pipe operator
+        rule %r/\|/, Punctuation
+
+        # Comparison and assignment operators
+        rule %r/[<>!=]=?/, Operator
+        rule %r/==/, Operator
+
+        # Arithmetic and string concatenation operators
+        rule %r/[+\-*\/%]/, Operator
+        rule %r/\.\./, Operator
+        rule %r/\.(?!\w)/, Operator
+
+        # Other punctuation
+        rule %r/[(),;]/, Punctuation
+
+        # Equals sign (assignment / field=value)
+        rule %r/=/, Operator
+
+        # Wildcard
+        rule %r/\*/, Operator
+
+        # Words — classify by set membership
+        rule %r/\w+/ do |m|
+          word = m[0]
+          word_upper = word.upcase
+          word_lower = word.downcase
+          if self.class.constants.include? word
+            token Keyword::Constant
+          elsif self.class.operator_words.include? word_upper
+            token Keyword::Pseudo
+          elsif self.class.commands.include? word_lower
+            token Keyword
+          elsif self.class.eval_functions.include? word_lower
+            token Name::Builtin
+          elsif self.class.stats_functions.include? word_lower
+            token Name::Builtin
+          elsif self.class.builtin_fields.include? word_lower
+            token Name::Variable::Magic
+          else
+            token Name
+          end
+        end
+      end
+
+      state :block_comment do
+        rule %r/```/, Comment::Multiline, :pop!
+        rule %r/[^`]+/, Comment::Multiline
+        rule %r/`/, Comment::Multiline
+      end
+
+      state :double_string do
+        rule %r/\\./, Str::Escape
+        rule %r/"/, Str::Double, :pop!
+        rule %r/[^\\"]+/, Str::Double
+      end
+
+      state :single_string do
+        rule %r/\\./, Str::Escape
+        rule %r/'/, Str::Single, :pop!
+        rule %r/[^\\']+/, Str::Single
+      end
+
+      state :backtick_string do
+        rule %r/`/, Name::Function, :pop!
+        rule %r/[^`]+/, Name::Function
+      end
+    end
+  end
+end

--- a/spec/lexers/spl_spec.rb
+++ b/spec/lexers/spl_spec.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::SPL do
+  let(:subject) { Rouge::Lexers::SPL.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.spl'
+      assert_guess :filename => 'foo.splunk'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-spl'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => '| stats count BY host'
+      assert_guess :source => '| eval x=if(status>=400, "error", "ok")'
+    end
+  end
+end

--- a/spec/visual/samples/spl
+++ b/spec/visual/samples/spl
@@ -1,0 +1,248 @@
+```
+This is a block comment in SPL.
+It can span multiple lines.
+Use triple backticks to start and end.
+```
+
+``` Short block comment ```
+
+index=main sourcetype=syslog host=webserver01
+
+index=firewall sourcetype=cisco:asa action=blocked src_ip=10.0.0.*
+
+sourcetype=access_combined status>=400
+
+error OR fail OR critical
+
+status=200 AND method=GET
+
+source="/var/log/messages" NOT debug
+
+index=main sourcetype=access_combined earliest=-24h@h latest=now
+| search status>=400
+| stats count BY status, host
+
+index=main earliest=-7d@d latest=now
+| timechart span=1h count BY sourcetype
+
+index=main earliest=-30m latest=now
+| eval duration=round(response_time, 2)
+
+| eval severity=case(
+    status>=500, "critical",
+    status>=400, "error",
+    status>=300, "redirect",
+    status>=200, "success",
+    true(), "unknown"
+  )
+
+| eval is_local=if(cidrmatch("10.0.0.0/8", src_ip), "yes", "no")
+
+| eval combined=mvjoin(mvappend(field1, field2), ",")
+
+| eval extracted=replace(uri_path, "^/api/v\d+/", "")
+
+| eval request_time=strftime(_time, "%Y-%m-%d %H:%M:%S")
+| eval epoch=strptime("2024-01-15 08:30:00", "%Y-%m-%d %H:%M:%S")
+
+| eval checksum=md5(raw_data)
+| eval hash=sha256(username)
+
+| eval avg_val=avg(field1, field2, field3)
+| eval max_val=max(bytes_in, bytes_out)
+| eval min_val=min(response_time)
+
+| eval item_count=mvcount(values)
+| eval unique_vals=mvdedup(myfield)
+| eval filtered=mvfilter(match(mvfield, "error"))
+| eval first_three=mvindex(myfield, 0, 2)
+| eval combined=mvzip(names, scores, ":")
+
+| eval field_len=len(message)
+| eval lower_host=lower(host)
+| eval upper_method=upper(method)
+| eval trimmed=trim(raw, " \t")
+| eval part=substr(uri_path, 1, 10)
+
+| eval x=abs(-42)
+| eval area=pi() * pow(radius, 2)
+| eval log_val=log(bytes, 10)
+| eval root=sqrt(variance)
+
+| eval angle_rad=acos(0.5)
+| eval sine=sin(3.14159)
+| eval tangent=atan2(y, x)
+
+| eval is_number=isnum(field1)
+| eval not_empty=isnotnull(field2)
+| eval field_type=typeof(myfield)
+
+| eval obj=json_object("name", host, "status", status)
+| eval val=json_extract(payload, "user.name")
+| eval keys=json_keys(my_json)
+| eval is_valid=json_valid(raw_json)
+
+| eval int_val=tonumber("42")
+| eval str_val=tostring(status)
+| eval bool_val=tobool("true")
+
+| eval t=time()
+| eval search_start=now()
+| eval adjusted=relative_time(now(), "-1d@d")
+
+| eval safe_val=coalesce(field1, field2, "default")
+| eval result=nullif(field1, field2)
+| eval val=null()
+
+| eval rand_num=random()
+
+index=main sourcetype=access_combined
+| stats count AS total_requests,
+    avg(response_time) AS avg_response,
+    max(response_time) AS max_response,
+    min(response_time) AS min_response,
+    dc(clientip) AS unique_clients,
+    sum(bytes) AS total_bytes,
+    stdev(response_time) AS std_dev,
+    median(response_time) AS median_response,
+    range(response_time) AS response_range,
+    mode(status) AS common_status,
+    var(response_time) AS variance,
+    first(clientip) AS first_client,
+    last(clientip) AS last_client,
+    list(uri_path) AS all_paths,
+    values(method) AS methods,
+    earliest(_time) AS first_seen,
+    latest(_time) AS last_seen,
+    perc95(response_time) AS p95
+  BY host, sourcetype
+
+index=main
+| timechart span=1h count BY status
+| timechart per_hour(bytes) BY host
+
+index=main
+| chart count OVER status BY host
+
+index=main sourcetype=access_combined
+| eventstats avg(response_time) AS global_avg BY host
+
+index=main sourcetype=access_combined
+| streamstats window=10 avg(response_time) AS rolling_avg
+
+| rex field=_raw "user=(?<username>\w+)"
+| rex field=uri_path "^/api/(?<api_version>v\d+)/(?<endpoint>\w+)"
+| regex _raw="error|fail|exception"
+
+index=main
+| append [search index=summary sourcetype=report]
+| join type=outer host [search index=assets | fields host, location, owner]
+
+index=main
+| eval category=case(status>=500, "error", status>=200, "ok")
+| stats count BY category
+| append [
+    search index=summary report_type=baseline
+    | stats avg(count) AS baseline BY category
+  ]
+
+`my_saved_macro`
+`generate_report(host, "2024-01-01", "2024-12-31")`
+
+| search index=main `my_index_macro`
+
+index=main sourcetype=access_combined
+| fields host, source, sourcetype, _time, _raw, status
+| table host source sourcetype status
+
+| rename old_field AS new_field
+| rename "Long Field Name" AS short_name, count AS total
+
+| sort -count, +host
+| sort 0 -num(bytes)
+
+| dedup host, sourcetype
+
+| head 100
+| tail 50
+| reverse
+
+| fillnull value=0 count response_time
+| filldown hostname
+
+| where isnotnull(error_message)
+| where like(uri_path, "/api/%")
+| where status IN (200, 301, 404, 500)
+
+| convert timeformat="%Y-%m-%d" ctime(_time) AS event_date
+| convert rmunit(percent_cpu)
+
+status!=200 AND (method="POST" OR method="PUT") NOT url="*/health*"
+
+| eval rate=round(bytes/1024/1024, 2)
+| eval ratio=if(total>0, success/total*100, 0)
+| eval flag=if(count>threshold AND severity="high", 1, 0)
+
+| eval msg="Hello \"world\""
+
+sourcetype="access_*" index=web_logs
+host='prod-web-*'
+
+| eval x=10 + 20 - 5 * 3 / 2 % 4
+
+true false TRUE FALSE null NULL
+
+_time _raw host source sourcetype index
+
+| transaction host maxspan=5m maxpause=30s
+| iplocation clientip
+| geostats latfield=lat longfield=lon count BY status
+
+| predict response_time AS predicted_response future_timespan=24
+| trendline sma5(response_time) AS trend
+| anomalydetection field=response_time
+
+| makeresults count=10
+| eval random_val=random() % 100
+| outputlookup my_lookup.csv
+
+| inputlookup my_reference.csv
+| lookup geo_lookup ip AS src_ip OUTPUT city, country
+
+index=main
+| stats count BY host
+| where count > [search index=summary | stats avg(count) AS threshold | return $threshold]
+
+| map search="search index=main host=$host$ | stats count"
+
+| multikv forceheader=1
+| makemv delim="," values
+| mvexpand values
+
+| foreach * [eval <<FIELD>>=if(isnull(<<FIELD>>), 0, <<FIELD>>)]
+| eval result=printf("%s has %d errors (%.2f%%)", host, count, pct)
+| strcat source ":" sourcetype full_source
+
+| spath input=json_data path=results{}
+
+earliest=-24h@h latest=now
+earliest=-7d@d latest=@d
+earliest=-30d@d latest=now
+earliest=1704067200 latest=1706745600
+
+42 3.14159 -100 1e6 0xFF 0b1010 1.5e-3
+
+| eval x=2+3
+| eval y=10-4
+| eval z=6*7
+| eval w=100/3
+| eval r=17%5
+| eval s="hello" . " " . "world"
+status>200 count<=1000 field!=value
+flag=true OR flag=false
+data AND NOT empty
+host XOR backup
+field IN ("a", "b", "c")
+name LIKE "web%"
+| stats count BY host AS hostname OVER status
+| stats count OUTPUT totalcount OUTPUTNEW newcount


### PR DESCRIPTION
Created by Claude Opus 4.6 and the following prompt

# Rouge Lexer: Splunk Processing Language (SPL)

## Language config

- **Lexer name:** spl
- **Class name:** SPL
- **Title:** SPL
- **Description:** Splunk Search Processing Language (SPL)
- **Tag:** spl
- **Aliases:** splunk, splunk-spl
- **Filenames:** `*.spl`, `*.splunk`
- **Mimetype:** text/x-spl

## Official references (use ONLY these — do not guess syntax)

- Command quick reference: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/quick-reference/command-quick-reference>
- Commands by category: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/quick-reference/commands-by-category>
- Evaluation functions: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/evaluation-functions/evaluation-functions>
- Statistical and charting functions: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/statistical-and-charting-functions/statistical-and-charting-functions>
- Eval command (operators): <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/search-commands/eval>
- Time modifiers: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/time-format-variables-and-modifiers/time-modifiers>
- Understanding SPL syntax: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/introduction/understanding-spl-syntax>
- Quick reference guide: <https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/quick-reference/splunk-quick-reference-guide>

## Rouge references

- Lexer development guide: <https://github.com/rouge-ruby/rouge/blob/main/docs/LexerDevelopment.md>
- Existing lexers for reference: <https://github.com/rouge-ruby/rouge/tree/main/lib/rouge/lexers>
- JSON lexer (recommended simple example): <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/lexers/json.rb>
- SQL lexer (closest analog): <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/lexers/sql.rb>
- Token types: <https://github.com/rouge-ruby/rouge/blob/main/lib/rouge/token.rb>

## Task

Create a Rouge lexer for the language described above. Work inside my local fork of the rouge-ruby/rouge repo.

### Phase 0: Setup

1. Confirm you're in the root of a Rouge repo checkout (look for `lib/rouge/lexers/`, `spec/lexers/`, `Gemfile`).
2. Run `git checkout -b lexer/spl main` to create a dedicated branch.
3. Run `bundle install` if `vendor/` or `.bundle/` is missing.
4. Run `bundle exec rake` once to confirm the existing test suite passes before you touch anything.

### Phase 1: Research

Before writing any code, fetch and read the official references listed above. Extract:

- The **complete list of commands** (from the command quick reference).
- The **complete list of eval functions** organized by category (bitwise, comparison/conditional, conversion, cryptographic, date/time, informational, JSON, mathematical, multivalue, statistical, text, trig/hyperbolic).
- The **complete list of statistical and charting functions** (aggregate, event order, multivalue, time).
- All **operators** (arithmetic: `+ - * / %`, string concatenation: `.`, comparison: `< > <= >= != = ==`, boolean: `AND OR NOT XOR`, and keyword operators: `IN LIKE BY AS OVER OUTPUT OUTPUTNEW`).
- **Comment syntax** (triple backticks for block comments).
- **String syntax** (double-quoted, single-quoted for field names, backtick-quoted for macros/saved searches).
- **Time modifier syntax** (e.g. `earliest=-24h@h latest=now`).
- **Built-in/internal field names** (e.g. `_time`, `_raw`, `host`, `sourcetype`, `index`).
- **Constants** (`true`, `false`, `TRUE`, `FALSE`, `null`, `NULL`).

Do not invent or assume any syntax elements. If something is ambiguous in the docs, web-search to verify before including it.

### Phase 2: Write the lexer

Create `lib/rouge/lexers/spl.rb` following Rouge conventions:

- Subclass `Rouge::RegexLexer`.
- Declare `title`, `desc`, `tag`, `aliases`, `filenames`, `mimetypes`.
- Implement `self.detect?(text)` for source-based guessing.
- Use class methods with `Set.new %w(...)` for keyword/function lists (commands, eval functions, stats functions, operator words, built-in fields, constants).
- Define states: `:root`, `:block_comment`, `:double_string`, `:single_string` at minimum.
- Use complex rules with blocks for word classification (command → `Keyword`, eval/stats function → `Name::Builtin`, operator word → `Keyword::Pseudo`, constant → `Keyword::Constant`, built-in field → `Name::Variable::Magic`, other → `Name`).
- Match commands and functions case-insensitively.
- Do NOT interpolate keyword lists into regex patterns — use a generic `\w+` rule with a block that checks set membership.

Reference the SQL lexer and JSON lexer for structural patterns.

### Phase 3: Write test files

Create these three files:

**`lib/rouge/demos/spl`** (no file extension):

- Under 20 lines.
- A realistic, representative SPL query that exercises comments, commands, eval functions, strings, operators, time modifiers, pipes, and field references.

**`spec/visual/sample/spl`** (no file extension):

- A longer sample (~100-200 lines) covering all major syntax categories: basic search terms, field=value pairs, pipes, multiple commands, eval with nested functions, stats/timechart, rex/regex, subsearches `[...]`, macros in backticks, block comments, time modifiers, constants, string types, numeric literals, wildcards, and rename/table/sort.

**`spec/lexers/spl_spec.rb`**:

- Test `assert_guess :filename =>` for each filename glob.
- Test `assert_guess :mimetype =>` for the declared mimetype.
- Test `assert_guess :source =>` for patterns that `self.detect?` should match.

### Phase 4: Test and iterate

This is the critical phase. Use the visual preview server as a feedback loop.

1. Run `bundle exec rake`. Fix any failures.
2. Start the visual preview server: `bundle exec puma -d -p 9292`.
3. Fetch the visual sample output:

   ```bash
   curl -s http://localhost:9292/spl | grep -o 'class="err"' | wc -l
   ```

   This counts Error tokens — places where the lexer failed to match input.
4. If there are Error tokens, fetch the full page and find what text is wrapped in `<span class="err">`:

   ```bash
   curl -s http://localhost:9292/spl | grep -oP '<span class="err">[^<]*</span>' | sort -u
   ```

5. For each Error token:
   a. Identify what SPL syntax element the unmatched text represents.
   b. Web-search the Splunk docs to confirm the syntax is valid.
   c. Add or fix the lexer rule to handle it.
   d. Re-run `bundle exec rake` to confirm no regressions.
   e. Re-fetch localhost:9292/spl to check if the Error token is gone.
6. Repeat steps 3-5 until the Error token count is **zero**.
7. Also check the demo renders cleanly:

   ```bash
   curl -s http://localhost:9292/spl | grep -c 'class="err"'
   ```

   Should output `0`.
8. Do a final visual sanity check — fetch the HTML and confirm that:
   - Commands (like `stats`, `eval`, `table`) are highlighted as keywords.
   - Functions (like `count`, `avg`, `if`, `case`) are highlighted as builtins.
   - Operator words (`AND`, `OR`, `NOT`, `BY`, `AS`) are highlighted distinctly.
   - Strings, numbers, and comments are each highlighted in their own style.
   - Pipes `|` are highlighted as punctuation.
   - No plain text is incorrectly highlighted, and no syntax is left unhighlighted.
9. Kill the puma server: `pkill -f puma` or find and kill the PID.

### Phase 5: Finalize

1. Run `bundle exec rake` one final time — full pass, zero failures.
2. Review the diff: `git diff --stat`. You should have exactly these new files:
   - `lib/rouge/lexers/spl.rb`
   - `lib/rouge/demos/spl`
   - `spec/lexers/spl_spec.rb`
   - `spec/visual/sample/spl`
3. Commit: `git add -A && git commit -m "Add SPL (Splunk) lexer"`.
4. Report what you've done: list the command count, function count, token types used, and confirm zero Error tokens in both the demo and visual sample.

### Constraints (applies to all phases)

- **No hallucinated syntax.** Every command, function, operator, and language construct in the lexer must come from the official Splunk documentation listed above. If you're unsure whether something is valid SPL, web-search the docs before adding it.
- **Follow Rouge conventions exactly.** Read existing lexers (especially JSON and SQL) for patterns. Don't invent novel approaches.
- **The Error token count is the ground truth.** The visual preview server is the authoritative test. `bundle exec rake` passing is necessary but not sufficient — you must also have zero `class="err"` spans.
- **Iterate until clean.** Do not declare the task complete until both `bundle exec rake` passes AND the Error token count is zero for both demo and visual sample.

