### PR TITLE
Fix deprecated Git::Log#each call

### DIFF
--- a/tasks/update/changelog.rake
+++ b/tasks/update/changelog.rake
@@ -64,7 +64,7 @@ module Rouge
       class Log
         def initialize(remote, commits)
           @remote = remote
-          @msgs = commits.map { |c| Message.new(c.message, c.author.name) }
+          @msgs = commits.execute.map { |c| Message.new(c.message, c.author.name) }
         end
 
         def converted


### PR DESCRIPTION
This fixes a deprecated `Git::Log#each` call.

```bash
❮ bundle exec rake update:changelog[4e3f6989,ed2ae687]            
DEPRECATION WARNING: Calling Git::Log#each is deprecated. Call #execute and then #each on the result object. (calle
d from Enumerable#map at /Users/tle/code/open-source/rouge-ruby/rouge/tasks/update/changelog.rake:67)  
```