### PR TITLE
Associate *.tm with TCL (tcl module)

### DIFF
--- a/lib/rouge/lexers/tcl.rb
+++ b/lib/rouge/lexers/tcl.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Tcl"
       desc "The Tool Command Language (tcl.tk)"
       tag 'tcl'
-      filenames '*.tcl'
+      filenames '*.tcl', '*.tm'
       mimetypes 'text/x-tcl', 'text/x-script.tcl', 'application/x-tcl'
 
       def self.detect?(text)


### PR DESCRIPTION
Addresses part of #2159.

Specs don't seem to detect any conflict here, I don't know of any other language that uses `*.tm`.