### PR TITLE
BUGFIX: highlight colour names in sass/scss

### DIFF
--- a/lib/rouge/lexers/sass/common.rb
+++ b/lib/rouge/lexers/sass/common.rb
@@ -67,7 +67,7 @@ module Rouge
         rule(id) do |m|
           if CSS.builtins.include? m[0]
             token Name::Builtin
-          elsif CSS.constants.include? m[0]
+          elsif CSS.colors.include? m[0]
             token Name::Constant
           else
             token Name

--- a/spec/lexers/sass_spec.rb
+++ b/spec/lexers/sass_spec.rb
@@ -1,0 +1,25 @@
+describe Rouge::Lexers::Sass do
+  let(:subject) { Rouge::Lexers::Sass.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.sass'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+    it 'lexes colors' do
+      assert_tokens_equal(
+        '$foo: aliceblue',
+        ['Name.Variable', '$foo'],
+        ['Punctuation', ':'],
+        ['Text', ' '],
+        ['Name.Constant', 'aliceblue'],
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
#2118 changed the method `CSS.constants` to `CSS.colors`, which continued to silently "work", because `Module#constants` does in fact return an array. This updates SassCommon (superclass of Sass and Scss) to use the updated method name. Added a spec which fails on main.