### PR TITLE
Overhaul the python and cython lexers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,9 +23,7 @@ Naming/ConstantName:
 # SupportedStylesForLeadingUnderscores: disallowed, required, optional
 Naming/MemoizedInstanceVariableName:
   Exclude:
-    - 'lib/rouge/lexers/cython.rb'
     - 'lib/rouge/lexers/freefem.rb'
-    - 'lib/rouge/lexers/python.rb'
     - 'lib/rouge/lexers/verilog.rb'
 
 # Offense count: 16
@@ -83,7 +81,6 @@ Rouge/NoBuildingAlternationPatternInRegexp:
     - 'lib/rouge/lexers/pascal.rb'
     - 'lib/rouge/lexers/perl.rb'
     - 'lib/rouge/lexers/postscript.rb'
-    - 'lib/rouge/lexers/python.rb'
     - 'lib/rouge/lexers/r.rb'
     - 'lib/rouge/lexers/rust.rb'
     - 'lib/rouge/lexers/scala.rb'

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -25,13 +25,20 @@ module Rouge
       end
 
       def self.c_keywords
-        @ckeywords ||= %w(
+        @c_keywords ||= Set.new %w(
           public readonly extern api inline enum union
         )
       end
 
+      def self.builtins
+        @builtins ||= super + %w(python_call)
+      end
+
       identifier = /[a-z_]\w*/i
-      dotted_identifier = /[a-z_.][\w.]*/i
+
+      prepend :from_import do
+        rule %r/cimport\b/, Keyword::Namespace, :pop!
+      end
 
       prepend :root do
         rule %r/cp?def|ctypedef/ do
@@ -40,52 +47,14 @@ module Rouge
           push :c_start
         end
 
-        rule %r/(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(cimport)/ do
-          groups Keyword::Namespace,
-                 Text,
-                 Name::Namespace,
-                 Text,
-                 Keyword::Namespace
-        end
-
-        rule %r/(cimport)(\s+)(#{dotted_identifier})/ do
-          groups Keyword::Namespace, Text, Name::Namespace
-        end
+        rule %r/cimport\b/, Keyword::Namespace, :import
 
         rule %r/(struct)((?:\\\s|\s)+)/ do
           groups Keyword, Text
           push :classname
         end
 
-        mixin :func_call_fix
-
         rule %r/[(,]/, Punctuation, :c_start
-      end
-
-      prepend :classname do
-        rule %r/(?:\\\s|\s)+/, Text
-      end
-
-      prepend :funcname do
-        rule %r/(?:\\\s|\s)+/, Text
-      end
-      # This is a fix for the way that function calls are lexed in the Python
-      # lexer. This should be moved to the Python lexer once confirmed that it
-      # does not cause any regressions.
-      state :func_call_fix do
-        rule %r/#{identifier}(?=\()/ do |m|
-          if self.class.keywords.include? m[0]
-            token Keyword
-          elsif self.class.exceptions.include? m[0]
-            token Name::Builtin
-          elsif self.class.builtins.include? m[0]
-            token Name::Builtin
-          elsif self.class.builtins_pseudo.include? m[0]
-            token Name::Builtin::Pseudo
-          else
-            token Name::Function
-          end
-        end
       end
 
       # The Cython lexer adds three states to those already in the Python lexer.
@@ -97,7 +66,7 @@ module Rouge
       # have moved out of a C block.
 
       state :c_start do
-        rule %r/[^\S\n]+/, Text
+        mixin :inline_whitespace
 
         rule %r/cp?def|ctypedef/, Keyword
 
@@ -106,16 +75,16 @@ module Rouge
         # This rule matches identifiers that could be type declarations. The
         # lookahead matches (1) pointers, (2) arrays and (3) variable names.
         rule %r/#{identifier}(?=(?:\*+)|(?:[ \t]*\[)|(?:[ \t]+\w))/ do |m|
-          if self.class.keywords.include? m[0]
+          if self.class.keywords.include?(m[0])
             token Keyword
             pop!
-          elsif %w(def).include? m[0]
+          elsif m[0] == 'def'
             token Keyword
             goto :funcname
-          elsif %w(struct class).include? m[0]
-            token Keyword::Reserved
-            goto :classname
-          elsif self.class.c_keywords.include? m[0]
+          elsif %w(struct class).include?(m[0])
+            token Keyword
+            goto :funcname
+          elsif self.class.c_keywords.include?(m[0])
             token Keyword::Reserved
           else
             token Keyword::Type
@@ -144,7 +113,14 @@ module Rouge
           end
         end
 
-        rule(//) { @indentation = nil; reset_stack }
+        rule(//) do
+          @indentation = nil
+          # pop c_indent
+          pop!
+
+          # replace :c_definitions with :newline
+          goto :newline
+        end
       end
     end
   end

--- a/lib/rouge/lexers/cython.rb
+++ b/lib/rouge/lexers/cython.rb
@@ -83,7 +83,7 @@ module Rouge
             goto :funcname
           elsif %w(struct class).include?(m[0])
             token Keyword
-            goto :funcname
+            goto :classname
           elsif self.class.c_keywords.include?(m[0])
             token Keyword::Reserved
           else

--- a/lib/rouge/lexers/mojo.rb
+++ b/lib/rouge/lexers/mojo.rb
@@ -30,6 +30,10 @@ module Rouge
           register_passable
         )
       end
+
+      prepend :newline do
+        rule %r/fn\b/, Keyword, :funcname
+      end
     end
   end
 end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -17,7 +17,7 @@ module Rouge
       end
 
       def self.keywords
-        @keywords ||= %w(
+        @keywords ||= Set.new %w(
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
           return try while yield as with from import
@@ -26,7 +26,7 @@ module Rouge
       end
 
       def self.builtins
-        @builtins ||= %w(
+        @builtins ||= Set.new %w(
           __import__ abs aiter all anext any apply ascii
           basestring bin bool buffer breakpoint bytearray bytes
           callable chr classmethod cmp coerce compile complex
@@ -42,11 +42,11 @@ module Rouge
       end
 
       def self.builtins_pseudo
-        @builtins_pseudo ||= %w(None Ellipsis NotImplemented False True)
+        @builtins_pseudo ||= Set.new %w(None Ellipsis NotImplemented False True)
       end
 
       def self.exceptions
-        @exceptions ||= %w(
+        @exceptions ||= Set.new %w(
           ArithmeticError AssertionError AttributeError BaseException
           BaseExceptionGroup BlockingIOError BrokenPipeError BufferError
           BytesWarning ChildProcessError ConnectionAbortedError ConnectionError

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -77,52 +77,42 @@ module Rouge
         @string_register ||= StringRegister.new
       end
 
+      operator_words = %r/(in|is|and|or|not)\b/
+      operators = %r{(<<|>>|//|[*][*])=?|!=|[-~+\/*%=<>&^|@]=?|!=}
+
+      start do
+        push :newline
+      end
+
+      state :inline_whitespace do
+        rule %r/[ \t]+/, Text
+        rule %r/\\\n/, Str::Escape
+      end
+
       state :root do
-        rule %r/\n+/m, Text
+        rule %r/\n+/m, Text, :newline
         rule %r/^(:)(\s*)([ru]{,2}""".*?""")/mi do
           groups Punctuation, Text, Str::Doc
         end
 
         rule %r/\.\.\.\B$/, Name::Builtin::Pseudo
 
-        rule %r/[^\S\n]+/, Text
-        rule %r(#(.*)?\n?), Comment::Single
-        rule %r/[\[\]{}:(),;.]/, Punctuation
-        rule %r/\\\n/, Text
-        rule %r/\\/, Text
+        mixin :inline_whitespace
+
+        rule %r(#(.*)?\n?), Comment::Single, :newline
+        rule %r/[\[\]{}:(),;]/, Punctuation
+        rule %r/[.]/, Punctuation, :post_dot
+        rule %r/\\/, Str::Escape
 
         rule %r/@#{dotted_identifier}/i, Name::Decorator
 
-        rule %r/(in|is|and|or|not)\b/, Operator::Word
-        rule %r/(<<|>>|\/\/|\*\*)=?/, Operator
-        rule %r/[-~+\/*%=<>&^|@]=?|!=/, Operator
+        rule operator_words, Operator::Word
+        rule operators, Operator
 
-        rule %r/(from)((?:\\\s|\s)+)(#{dotted_identifier})((?:\\\s|\s)+)(import)/ do
-          groups Keyword::Namespace,
-                 Text,
-                 Name,
-                 Text,
-                 Keyword::Namespace
-        end
+        rule %r/def\b/, Keyword, :funcname
 
-        rule %r/(import)(\s+)(#{dotted_identifier})/ do
-          groups Keyword::Namespace, Text, Name
-        end
+        rule %r/class\b/, Keyword, :classname
 
-        rule %r/(def)((?:\s|\\\s)+)/ do
-          groups Keyword, Text
-          push :funcname
-        end
-
-        rule %r/(class)((?:\s|\\\s)+)/ do
-          groups Keyword, Text
-          push :classname
-        end
-
-        rule %r/([a-z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Function
-        rule %r/([A-Z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Class
-
-        # TODO: not in python 3
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rtfbu]{0,2})('''|"""|['"])/i do |m|
           groups Str::Affix, Str::Heredoc
@@ -130,17 +120,15 @@ module Rouge
           push :generic_string
         end
 
-        mixin :soft_keywords
-
         # using negative lookbehind so we don't match property names
         rule %r/(?<!\.)#{identifier}/ do |m|
-          if self.class.keywords.include? m[0]
+          if self.class.keywords.include?(m[0])
             token Keyword
-          elsif self.class.exceptions.include? m[0]
+          elsif self.class.exceptions.include?(m[0])
+            token Name::Exception
+          elsif self.class.builtins.include?(m[0])
             token Name::Builtin
-          elsif self.class.builtins.include? m[0]
-            token Name::Builtin
-          elsif self.class.builtins_pseudo.include? m[0]
+          elsif self.class.builtins_pseudo.include?(m[0])
             token Name::Builtin::Pseudo
           else
             token Name
@@ -163,34 +151,83 @@ module Rouge
         rule %r/([1-9](_?[0-9])*|0(_?0)*)/, Num::Integer
       end
 
+      state :import do
+        mixin :inline_whitespace
+        rule dotted_identifier, Name::Namespace, :pop!
+        rule(//) { pop! }
+      end
+
+      state :from do
+        mixin :inline_whitespace
+
+        rule dotted_identifier do
+          token Name::Namespace
+          goto :from_import
+        end
+
+        rule(//) { pop! }
+      end
+
+      # import after from, meaning we don't push the :import state
+      state :from_import do
+        mixin :inline_whitespace
+        rule %r/import\b/, Keyword::Namespace, :pop!
+        rule(//) { pop! }
+      end
+
+      state :post_dot do
+        mixin :inline_whitespace
+        rule %r/([a-z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Function
+        rule %r/([A-Z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Class
+        rule(//) { pop! }
+      end
+
+      state :newline do
+        mixin :inline_whitespace
+
+        rule %r/from\b/, Keyword::Namespace, :from
+        rule %r/import\b/, Keyword::Namespace, :import
+
+        inline_ws = /(?:[ \t]|\\\n)*?/
+        inline_content = /(?:[^\n]|\\\n)*?/
+
+        # [jneen] This lookahead is a best-effort hack, since soft keywords are
+        # technically not possible to detect in the lexing stage. If we see an
+        # operator like `and`, `or`, inline `if`, etc which would expect an
+        # expression beforehand, we know that it is almost certainly not a keyword.
+        inline_ops = /#{operator_words}|if\b|#{operators}/
+        rule %r/(?:case|match)(?=#{inline_ws}#{inline_ops})/, Name::Other, :pop!
+
+        rule %r/(?:case|match)(?=#{inline_content}:#{inline_ws}[#\n])/ do |m|
+          token Keyword
+          if m[0] == 'case'
+            goto :case_pattern
+          else
+            pop!
+          end
+        end
+
+        rule(//) { pop! }
+      end
+
       state :funcname do
+        mixin :inline_whitespace
         rule identifier, Name::Function, :pop!
       end
 
       state :classname do
+        mixin :inline_whitespace
         rule identifier, Name::Class, :pop!
       end
 
-      state :soft_keywords do
-        rule %r/
-          (^[ \t]*)
-          (match|case)\b
-          (?![ \t]*
-            (?:[:,;=^&|@~)\]}] |
-              (?:#{Python.keywords.join('|')})\b))
-        /x do |m|
-          token Text::Whitespace, m[1]
-          token Keyword, m[2]
-          push :soft_keywords_inner
-        end
-      end
-
-      state :soft_keywords_inner do
-        rule %r((\s+)([^\n_]*)(_\b)) do |m|
-          groups Text::Whitespace, Text, Keyword
+      state :case_pattern do
+        rule %r/\n/ do
+          token Text
+          goto :newline
         end
 
-        rule(//) { pop! }
+        rule %r/_\b/, Keyword
+        mixin :root
       end
 
       state :raise do
@@ -207,8 +244,8 @@ module Rouge
       end
 
       state :generic_string do
-        rule %r/^\s*(>>>|\.\.\.)\B/, Generic::Prompt, :doctest
-        rule %r/[^'"\\{]+?/, Str
+        rule %r/\n/, Str, :generic_string_newline
+        rule %r/[^'"\\{\n]+/, Str
         rule %r/{{/, Str
 
         rule %r/'''|"""|['"]/ do |m|
@@ -229,6 +266,15 @@ module Rouge
             token Str
           end
         end
+      end
+
+      state :generic_string_newline do
+        rule %r/[ \t]+/, Str
+        rule %r/(>>>|\.\.\.)\B/ do
+          token Generic::Prompt
+          goto :doctest
+        end
+        rule(//) { pop! }
       end
 
       state :generic_escape do

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -74,7 +74,7 @@ module Rouge
       dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
 
       def current_string
-        @string_register ||= StringRegister.new
+        @current_string ||= StringRegister.new
       end
 
       operator_words = %r/(in|is|and|or|not)\b/

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -72,6 +72,8 @@ module Rouge
 
       identifier =        /[[:alpha:]_][[:alnum:]_]*/
       dotted_identifier = /[[:alpha:]_.][[:alnum:]_.]*/
+      inline_ws = /(?:[ \t]|\\\n)*?/
+      inline_content = /(?:[^\\\n]|\\[\n.])*?/
 
       def current_string
         @current_string ||= StringRegister.new
@@ -177,8 +179,8 @@ module Rouge
 
       state :post_dot do
         mixin :inline_whitespace
-        rule %r/([a-z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Function
-        rule %r/([A-Z_]\w*)[ \t]*(?=(\(.*\)))/m, Name::Class
+        rule %r/([A-Z]\w*)(?=#{inline_ws}[(])/m, Name::Class
+        rule %r/(#{identifier})(?=#{inline_ws}[(])/m, Name::Function
         rule(//) { pop! }
       end
 
@@ -187,9 +189,6 @@ module Rouge
 
         rule %r/from\b/, Keyword::Namespace, :from
         rule %r/import\b/, Keyword::Namespace, :import
-
-        inline_ws = /(?:[ \t]|\\\n)*?/
-        inline_content = /(?:[^\n]|\\\n)*?/
 
         # [jneen] This lookahead is a best-effort hack, since soft keywords are
         # technically not possible to detect in the lexing stage. If we see an

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -242,3 +242,23 @@ match command.split():
 case = 1
 match = 1
 match if True else bar
+case = "foo: #bar"
+
+# from https://docs.python.org/3/reference/compound_stmts.html#match
+match (100, 200):
+   case (100, 300):  # Mismatch: 200 != 300
+       print('Case 1')
+   case (100, 200) if flag:  # Successful match, but guard fails
+       print('Case 2')
+   case (100, y):  # Matches and binds y to 200
+       print(f'Case 3, y: {y}')
+   case _:  # Pattern not attempted
+       print('Case 4, I match anything!')
+   case "foo: #bar":
+       baz
+   case "baz": # zot:
+       zam
+   case \
+      thing \
+      :
+      other


### PR DESCRIPTION
This is one of the earliest lexers written in the project, and it definitely shows its age. It was using all manner of large joined regex, and lookaheads that were frankly unnecessary.

I've introduced a special `:newline` state which is pushed at every newline. The Cython lexer has also been adjusted to be compatible with this.

The lookaheads that were kept are for `case` and `match`, which are not *entirely* possible to lex correctly without doing a full parse. This approach works for the most common cases, and a few uncommon ones, but it is possible to break it with a specially crafted string literal inside a case pattern or match statement. In the worst case, though, `case` and `match` will be highlighted as Name, and the lexer will recover.

Mojo was also edited to use the `:funcname` state after its `fn` keyword.