### PR TITLE
Fix overeager Hack.detect?

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,6 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'lib/rouge/lexers/cython.rb'
     - 'lib/rouge/lexers/freefem.rb'
-    - 'lib/rouge/lexers/hack.rb'
     - 'lib/rouge/lexers/python.rb'
     - 'lib/rouge/lexers/verilog.rb'
 
@@ -49,12 +48,6 @@ Naming/VariableName:
     - 'lib/rouge/lexers/igorpro.rb'
     - 'lib/rouge/lexers/kotlin.rb'
     - 'lib/rouge/lexers/xpath.rb'
-
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/StringInclude:
-  Exclude:
-    - 'lib/rouge/lexers/hack.rb'
 
 # Offense count: 113
 Rouge/NoBuildingAlternationPatternInRegexp:

--- a/lib/rouge/lexers/hack.rb
+++ b/lib/rouge/lexers/hack.rb
@@ -13,16 +13,14 @@ module Rouge
       filenames '*.php', '*.hh'
 
       def self.detect?(text)
-        return true if /<\?hh/ =~ text
+        return true if text.start_with?('<?hh')
         return true if text.shebang?('hhvm')
-        return true if /async function [a-zA-Z]/ =~ text
-        return true if /\): Awaitable</ =~ text
 
         return false
       end
 
       def self.keywords
-        @hh_keywords ||= super.merge Set.new %w(
+        @keywords ||= super.merge Set.new %w(
           type newtype enum
           as super
           async await Awaitable

--- a/spec/lexers/markdown_spec.rb
+++ b/spec/lexers/markdown_spec.rb
@@ -40,7 +40,7 @@ describe Rouge::Lexers::Markdown do
     end
 
     it 'picks a sub-lexer when the code-block-content is ambiguous' do
-      source = "Index: ): Awaitable<\n"
+      source = "#!/usr/bin/env bash\n<html></html>"
       assert_raises Rouge::Guesser::Ambiguous do
         Rouge::Lexer.find_fancy(nil, source)
       end


### PR DESCRIPTION
`RegexLexer.detect?` is intended for high-confidence detection, like shebangs and doctypes. The document *starting* with `<?hh` is an indicator, but merely containing it or a couple other common patterns should not be.

Also fixed a wrong ivar name.