### PR TITLE
enable aria-hidden for line numbers in html_table

### DIFF
--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -36,7 +36,7 @@ module Rouge
 
         buffer = [%(<table class="#@table_class"><tbody><tr>)]
         # the "gl" class applies the style for Generic.Lineno
-        buffer << %(<td class="#@gutter_class gl">)
+        buffer << %(<td class="#@gutter_class gl" aria-hidden="true">)
         buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
         buffer << '</td>'
         buffer << %(<td class="#@code_class"><pre><code>)

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -45,7 +45,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
 
     it 'should delegate to linewise formatter' do
-      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></code></pre></td></tr></tbody></table>) }
+      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></code></pre></td></tr></tbody></table>) }
     end
   end
 end


### PR DESCRIPTION
Using assistive technologies such as screen readers to read code blocks can be negatively impacted by the line numbers. Disabling them for accessibility seems reasonable to me.