### PR TITLE
nest <code> in <pre>

### DIFF
--- a/lib/rouge/formatters/html_line_table.rb
+++ b/lib/rouge/formatters/html_line_table.rb
@@ -39,9 +39,9 @@ module Rouge
           buffer << %(style="-moz-user-select: none;-ms-user-select: none;)
           buffer << %(-webkit-user-select: none;user-select: none;">)
           buffer << %(<pre>#{lineno}</pre></td>)
-          buffer << %(<td class="#@code_class"><pre>)
+          buffer << %(<td class="#@code_class"><pre><code>)
           @formatter.stream(line_tokens) { |formatted| buffer << formatted }
-          buffer << "\n</pre></td></tr>"
+          buffer << "\n</code></pre></td></tr>"
         end
         buffer << %(</tbody></table>)
         yield buffer.join

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -39,9 +39,9 @@ module Rouge
         buffer << %(<td class="#@gutter_class gl">)
         buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
         buffer << '</td>'
-        buffer << %(<td class="#@code_class"><pre>)
+        buffer << %(<td class="#@code_class"><pre><code>)
         buffer << formatted
-        buffer << '</pre></td>'
+        buffer << '</code></pre></td>'
         buffer << '</tr></tbody></table>'
 
         yield buffer.join

--- a/spec/formatters/html_line_table_spec.rb
+++ b/spec/formatters/html_line_table_spec.rb
@@ -20,12 +20,12 @@ describe Rouge::Formatters::HTMLLineTable do
   <tbody>
     <tr id="line-1" class="lineno">
       <td class="rouge-gutter gl" style="#{cell_style}"><pre>1</pre></td>
-      <td class="rouge-code"><pre><span class="n">foo</span>\n</pre></td>
+      <td class="rouge-code"><pre><code><span class="n">foo</span>\n</code></pre></td>
     </tr>
   </tbody>
 </table>
 HTML
-      expected = expected.gsub(%r{>\s+<(?!/pre)}, '><').rstrip
+      expected = expected.gsub(%r{>\s+<(?!/code|/pre)}, '><').rstrip
 
       assert_includes output, 'id="line-1"'
       assert { output == expected }
@@ -41,24 +41,24 @@ HTML
   <tbody>
     <tr id="line-1" class="lineno">
       <td class="rouge-gutter gl" style="#{cell_style}"><pre>1</pre></td>
-      <td class="rouge-code"><pre>foo\n</pre></td>
+      <td class="rouge-code"><pre><code>foo\n</code></pre></td>
     </tr>
     <tr id="line-2" class="lineno">
       <td class="rouge-gutter gl" style="#{cell_style}"><pre>2</pre></td>
-      <td class="rouge-code"><pre><span class="n">bar</span>\n</pre></td>
+      <td class="rouge-code"><pre><code><span class="n">bar</span>\n</code></pre></td>
     </tr>
     <tr id="line-3" class="lineno">
       <td class="rouge-gutter gl" style="#{cell_style}"><pre>3</pre></td>
-      <td class="rouge-code"><pre>foo\n</pre></td>
+      <td class="rouge-code"><pre><code>foo\n</code></pre></td>
     </tr>
     <tr id="line-4" class="lineno">
       <td class="rouge-gutter gl" style="#{cell_style}"><pre>4</pre></td>
-      <td class="rouge-code"><pre>bar\n</pre></td>
+      <td class="rouge-code"><pre><code>bar\n</code></pre></td>
     </tr>
   </tbody>
 </table>
 HTML
-      expected = expected.gsub(%r{>\s+<(?!/pre)}, '><').rstrip
+      expected = expected.gsub(%r{>\s+<(?!/code|/pre)}, '><').rstrip
 
       assert_includes output, 'id="line-4"'
       assert { output == expected }
@@ -85,7 +85,7 @@ HTML
     <tr id="L15" class="line-no">
       <td class="code-gutter gl" style="#{cell_style}"><pre>15</pre></td>
       <td class="fenced-code">
-        <pre><span class="n">foo</span>bar\n</pre>
+        <pre><code><span class="n">foo</span>bar\n</code></pre>
       </td>
     </tr>
   </tbody>

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -45,7 +45,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
 
     it 'should delegate to linewise formatter' do
-      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></pre></td></tr></tbody></table>) }
+      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></code></pre></td></tr></tbody></table>) }
     end
   end
 end


### PR DESCRIPTION
Reason:

- Semantically, `pre` only means preformatted text, not code, but `code` means code.
- It improves accessibility because `code` correctly sets the [WAI-ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/structural_roles).
- It is more consistent with the Markdown specification.
https://github.com/rouge-ruby/rouge/blob/d26ea4506c55631f5e976bc83e38bc8a2460e5c8/spec/visual/samples/markdown#L556-L561
- It is consistent with `HTMLPygments` formatter:
https://github.com/rouge-ruby/rouge/blob/d26ea4506c55631f5e976bc83e38bc8a2460e5c8/lib/rouge/formatters/html_pygments.rb#L12-L14