### PR TITLE
Attempt to fix IecST numeric literals

### DIFF
--- a/lib/rouge/lexers/iecst.rb
+++ b/lib/rouge/lexers/iecst.rb
@@ -64,7 +64,8 @@ module Rouge
         rule %r/\b(?:D|DT|T|TOD)#[\d_shmd:]*/i, Literal::Date
         rule %r/\b(?:16#[\d_a-f]+|0x[\d_a-f]+)\b/i, Literal::Number::Hex
         rule %r/\b2#[01_]+/, Literal::Number::Bin
-        rule %r/(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e[+-]?\d+)?/i, Literal::Number::Float
+        rule %r/BYTE(#[\h_]+)+/, Literal::Number
+        rule %r/(?:\b[\d_]+(?:\.\d*)?|\B\.\d+)(?:e[+-]?\d+)?/i, Literal::Number::Float
         rule %r/\b[\d.,_]+/, Literal::Number
 
         rule %r/\b[A-Z_]+\b/i do |m|


### PR DESCRIPTION
Before:
<img width="337" height="170" alt="image" src="https://github.com/user-attachments/assets/0c82366e-9643-4941-bb6b-bb63bdddaf13" />

After:
<img width="337" height="170" alt="image" src="https://github.com/user-attachments/assets/606955e1-82b1-44c4-a04d-d6f5ada2b763" />

@tali @bufferoverflow, are these changes correct? The sample file seems to indicate that these are valid literals, but the current lexer renders them as Error tokens.

Also, is there publicly available documentation on this syntax? I could only find this: https://webstore.iec.ch/en/publication/68533

which costs nearly CAD$900, far out of my budget for this project.
