### PR TITLE
c/cpp: Update keywords/builtin types

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -17,9 +17,10 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          auto break case const continue default do else enum extern
-          for goto if register restricted return sizeof static struct
-          switch typedef union volatile virtual while
+          alignas alignof auto break case const constexpr continue
+          default do else enum extern for goto if register return
+          sizeof static static_assert struct switch typedef typeof
+          typeof_unqual union volatile while
 
           _Alignas _Alignof _Atomic _Generic _Imaginary
           _Noreturn _Static_assert _Thread_local
@@ -44,6 +45,8 @@ module Rouge
           uintmax_t
 
           char16_t char32_t
+
+          _BitInt _Decimal128 _Decimal32 _Decimal64 bool nullptr_t
         )
       end
 
@@ -52,7 +55,8 @@ module Rouge
           __asm __int8 __based __except __int16 __stdcall __cdecl
           __fastcall __int32 __declspec __finally __int61 __try __leave
           inline _inline __inline naked _naked __naked restrict _restrict
-          __restrict thread _thread __thread typename _typename __typename
+          __restrict thread _thread __thread thread_local
+          typename _typename __typename
         )
       end
 
@@ -108,7 +112,7 @@ module Rouge
         rule %r([~!%^&*+=\|?:<>/-]), Operator
         rule %r/[()\[\],.;]/, Punctuation
         rule %r/\bcase\b/, Keyword, :case
-        rule %r/(?:true|false|NULL)\b/, Name::Builtin
+        rule %r/(?:true|false|NULL|nullptr)\b/, Name::Builtin
         rule id do |m|
           name = m[0]
 

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -22,21 +22,19 @@ module Rouge
 
       def self.keywords
         @keywords ||= super + Set.new(%w(
-          asm auto catch char8_t concept
-          consteval constexpr constinit const_cast co_await co_return co_yield
-          delete dynamic_cast explicit export friend
-          mutable namespace new operator private protected public
-          reinterpret_cast requires restrict size_of static_cast this throw throws
-          typeid typename using virtual final override import module
-
-          alignas alignof decltype noexcept static_assert
-          thread_local try
+          and and_eq asm bitand bitor catch compl concept consteval
+          constinit const_cast co_await co_return co_yield decltype
+          delete dynamic_cast explicit export final friend import
+          module mutable namespace new noexcept not not_eq operator or
+          or_eq override private protected public reinterpret_cast
+          requires size_of static_cast this throw throws try typeid
+          typename using virtual xor xor_eq
         ))
       end
 
       def self.keywords_type
         @keywords_type ||= super + Set.new(%w(
-          bool
+          char8_t
         ))
       end
 


### PR DESCRIPTION
# C

Update keywords and builtin types of C language.

New keywords:

- `alignas`
- `alignof`
- `constexpr`
- `static_assert`
- `typeof`
- `typeof_unqual`

New types:

- `_BitInt`
- `_Decimal32`
- `_Decimal64`
- `_Decimal128`
- `bool`
- `nullptr_t`

New constants:

- `nullptr`


ref: https://en.cppreference.com/c/keyword

# EDIT: C++

C++ lexer is a subclass of C lexer. Update the overridden `keywords` and `keywords_type` to match with the C lexer's change.

* `keywords`
    * Remove duplicate keywords, such as `asm`, `auto`.
    * Add missing keywords like `and`, `not`.
* `keywords_type`
    * Remove `bool` because C23 supports `bool`.
    * Move `char8_t` from `keywords` to `keywords` as to apply same highlight as `char16_t` and `char32_t`.

ref: https://en.cppreference.com/cpp/keyword