### PR TITLE
Add a lexer for Apache Thrift

### DIFF
--- a/lib/rouge/demos/thrift
+++ b/lib/rouge/demos/thrift
@@ -1,0 +1,15 @@
+namespace * tutorial
+
+include "shared.thrift"
+
+struct Work {
+  1: i32 num1 = 0,
+  2: i32 num2,
+  3: Operation op,
+  4: optional string comment,
+}
+
+service Calculator extends shared.SharedService {
+  i32 add(1: i32 num1, 2: i32 num2),
+  oneway void zip()
+}

--- a/lib/rouge/lexers/thrift.rb
+++ b/lib/rouge/lexers/thrift.rb
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+module Rouge
+  module Lexers
+    class Thrift < RegexLexer
+      title "Thrift"
+      desc "Apache Thrift interface definition language"
+      tag 'thrift'
+      aliases 'apache-thrift'
+      filenames '*.thrift'
+      mimetypes 'text/x-thrift', 'application/x-thrift'
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          include cpp_include namespace const typedef enum struct union
+          exception service
+        )
+      end
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          async cpp_type extends oneway optional required throws
+          xsd_all xsd_attrs xsd_nillable xsd_optional
+        )
+      end
+
+      def self.types
+        @types ||= Set.new %w(
+          binary bool byte double i8 i16 i32 i64 list map set string uuid void
+        )
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(false true)
+      end
+
+      id = /[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)*/
+      namespace_name = /[a-zA-Z_][a-zA-Z0-9_.-]*/
+      double = /[+-]?(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+[eE][+-]?\d+)/
+
+      state :comments_and_whitespace do
+        rule %r/\s+/, Text
+        rule %r/#.*$/, Comment::Single
+        rule %r{//.*$}, Comment::Single
+        rule %r{/\*}, Comment::Multiline, :comment
+      end
+
+      state :comment do
+        rule %r/[^*]+/, Comment::Multiline
+        rule %r/\*+\//, Comment::Multiline, :pop!
+        rule %r/\*+/, Comment::Multiline
+      end
+
+      state :namespace_scope do
+        mixin :comments_and_whitespace
+
+        rule %r/\*/ do
+          token Punctuation
+          goto :namespace_name
+        end
+
+        rule id do
+          token Keyword::Namespace
+          goto :namespace_name
+        end
+
+        rule(//) { pop! }
+      end
+
+      state :namespace_name do
+        mixin :comments_and_whitespace
+
+        rule namespace_name do
+          token Name::Namespace
+          pop!
+        end
+
+        rule(//) { pop! }
+      end
+
+      state :root do
+        mixin :comments_and_whitespace
+
+        rule %r/(namespace)(\s+)/ do
+          groups Keyword::Declaration, Text
+          push :namespace_scope
+        end
+
+        rule %r/((?:enum|exception|service|struct|union))(\s+)(#{id})/ do
+          groups Keyword::Declaration, Text, Name::Class
+        end
+
+        rule %r/"(?:\\.|[^"\\\n])*"/, Str::Double
+        rule %r/'(?:\\.|[^'\\\n])*'/, Str::Single
+
+        rule %r/[+-]?0x[0-9a-f]+/i, Num::Hex
+        rule double, Num::Float
+        rule %r/[+-]?\d+/, Num::Integer
+
+        rule id do |m|
+          if self.class.declarations.include?(m[0])
+            token Keyword::Declaration
+          elsif self.class.keywords.include?(m[0])
+            token Keyword
+          elsif self.class.types.include?(m[0])
+            token Keyword::Type
+          elsif self.class.constants.include?(m[0])
+            token Keyword::Constant
+          else
+            token Name
+          end
+        end
+
+        rule %r/[&=+\-]/, Operator
+        rule %r/[:;,{}\(\)<>\[\]]/, Punctuation
+      end
+    end
+  end
+end

--- a/spec/lexers/thrift_spec.rb
+++ b/spec/lexers/thrift_spec.rb
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+describe Rouge::Lexers::Thrift do
+  let(:subject) { Rouge::Lexers::Thrift.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'service.thrift'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-thrift'
+      assert_guess :mimetype => 'application/x-thrift'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes header forms' do
+      assert_tokens_equal 'namespace py.twisted thrift.test',
+        ['Keyword.Declaration', 'namespace'],
+        ['Text', ' '],
+        ['Keyword.Namespace', 'py.twisted'],
+        ['Text', ' '],
+        ['Name.Namespace', 'thrift.test']
+
+      assert_tokens_equal 'namespace * thrift.test',
+        ['Keyword.Declaration', 'namespace'],
+        ['Text', ' '],
+        ['Punctuation', '*'],
+        ['Text', ' '],
+        ['Name.Namespace', 'thrift.test']
+
+      assert_tokens_equal 'include "shared.thrift"',
+        ['Keyword.Declaration', 'include'],
+        ['Text', ' '],
+        ['Literal.String.Double', '"shared.thrift"']
+    end
+
+    it 'recognizes definitions and core IDL terminals' do
+      assert_tokens_includes 'service Calculator extends Shared { oneway void zip() throws (1: InvalidOperation ouch) }',
+        ['Keyword.Declaration', 'service'],
+        ['Name.Class', 'Calculator'],
+        ['Keyword', 'extends'],
+        ['Keyword', 'oneway'],
+        ['Keyword.Type', 'void'],
+        ['Keyword', 'throws']
+    end
+
+    it 'recognizes base and container types' do
+      assert_tokens_includes '1: required map<string, list<uuid>> values',
+        ['Keyword', 'required'],
+        ['Keyword.Type', 'map'],
+        ['Keyword.Type', 'string'],
+        ['Keyword.Type', 'list'],
+        ['Keyword.Type', 'uuid']
+    end
+
+    it 'recognizes cpp_type container clauses' do
+      assert_tokens_includes 'typedef list cpp_type "std::vector<double>" <double> doubles',
+        ['Keyword.Declaration', 'typedef'],
+        ['Keyword.Type', 'list'],
+        ['Keyword', 'cpp_type'],
+        ['Literal.String.Double', '"std::vector<double>"'],
+        ['Keyword.Type', 'double']
+
+      assert_tokens_includes 'typedef list<double> cpp_type "std::vector<double>" old_doubles',
+        ['Keyword.Type', 'list'],
+        ['Keyword.Type', 'double'],
+        ['Keyword', 'cpp_type']
+    end
+
+    it 'recognizes constants without splitting valid numbers' do
+      assert_tokens_includes 'const list<double> values = [1, -0x10, 3.14, .5, 1e9, -1.7e+308]',
+        ['Literal.Number.Integer', '1'],
+        ['Literal.Number.Hex', '-0x10'],
+        ['Literal.Number.Float', '3.14'],
+        ['Literal.Number.Float', '.5'],
+        ['Literal.Number.Float', '1e9'],
+        ['Literal.Number.Float', '-1.7e+308']
+    end
+
+    it 'does not treat exponent-looking identifiers as floats' do
+      assert_tokens_equal 'e10',
+        ['Name', 'e10']
+    end
+
+    it 'recognizes boolean constants' do
+      assert_tokens_includes '1: optional bool enabled = true; 2: optional bool hidden = false',
+        ['Keyword.Constant', 'true'],
+        ['Keyword.Constant', 'false']
+    end
+
+    it 'recognizes recursive field references' do
+      assert_tokens_equal '1: optional RecursiveStruct & recurse',
+        ['Literal.Number.Integer', '1'],
+        ['Punctuation', ':'],
+        ['Text', ' '],
+        ['Keyword', 'optional'],
+        ['Text', ' '],
+        ['Name', 'RecursiveStruct'],
+        ['Text', ' '],
+        ['Operator', '&'],
+        ['Text', ' '],
+        ['Name', 'recurse']
+    end
+
+    it 'recognizes all Thrift comment forms' do
+      assert_tokens_equal '# shell comment',
+        ['Comment.Single', '# shell comment']
+
+      assert_tokens_equal '// line comment',
+        ['Comment.Single', '// line comment']
+
+      assert_tokens_equal '/** doc */ /* block */',
+        ['Comment.Multiline', '/** doc */'],
+        ['Text', ' '],
+        ['Comment.Multiline', '/* block */']
+    end
+
+    it 'recognizes escaped literals and annotations' do
+      thrift = %q(1: optional string comment = "has \"quotes\"" (go.tag = 'json:"comment"', deprecated))
+
+      assert_no_errors thrift
+      assert_tokens_includes thrift,
+        ['Literal.String.Double', '"has \"quotes\""'],
+        ['Name', 'go.tag'],
+        ['Literal.String.Single', '\'json:"comment"\''],
+        ['Name', 'deprecated']
+    end
+
+    it 'recognizes valid annotation-heavy Thrift' do
+      thrift = <<~THRIFT
+        typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+        struct foo {
+          1: i32 bar ( presence = "required" );
+          2: optional list<i64> values = [1, 2] (cpp.ref = "")
+        } (
+          cpp.type = "DenseFoo",
+          annotation.without.value,
+        )
+
+        service deprecate_everything {
+          void Foo() ( deprecated = "This method has neither 'x' nor \\"y\\"" )
+          async void Old()
+        }
+      THRIFT
+
+      assert_no_errors thrift
+    end
+  end
+end

--- a/spec/visual/samples/thrift
+++ b/spec/visual/samples/thrift
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+# Thrift Tutorial
+# Mark Slee (mcslee@facebook.com)
+#
+# This file aims to teach you how to use Thrift, in a .thrift file. Neato. The
+# first thing to notice is that .thrift files support standard shell comments.
+# This lets you make your thrift file executable and include your Thrift build
+# step on the top line. And you can place comments like this anywhere you like.
+#
+# Before running this file, you will need to have installed the thrift compiler
+# into /usr/local/bin.
+
+/**
+ * The first thing to know about are types. The available types in Thrift are:
+ *
+ *  bool        Boolean, one byte
+ *  i8 (byte)   Signed 8-bit integer
+ *  i16         Signed 16-bit integer
+ *  i32         Signed 32-bit integer
+ *  i64         Signed 64-bit integer
+ *  double      64-bit floating point value
+ *  string      String
+ *  binary      Blob (byte array)
+ *  map<t1,t2>  Map from one type to another
+ *  list<t1>    Ordered list of one type
+ *  set<t1>     Set of unique elements of one type
+ *
+ * Did you also notice that Thrift supports C style comments?
+ */
+
+// Just in case you were wondering... yes. We support simple C comments too.
+
+/**
+ * Thrift files can reference other Thrift files to include common struct
+ * and service definitions. These are found using the current path, or by
+ * searching relative to any paths specified with the -I compiler flag.
+ *
+ * Included objects are accessed using the name of the .thrift file as a
+ * prefix. i.e. shared.SharedObject
+ */
+include "shared.thrift"
+
+/**
+ * Thrift files can namespace, package, or prefix their output in various
+ * target languages.
+ */
+
+namespace cl tutorial
+namespace cpp tutorial
+namespace d tutorial
+namespace dart tutorial
+namespace java tutorial
+namespace php tutorial
+namespace perl tutorial
+namespace haxe tutorial
+namespace netstd tutorial
+
+/**
+ * Thrift lets you do typedefs to get pretty names for your types. Standard
+ * C style here.
+ */
+typedef i32 MyInteger
+
+/**
+ * Thrift also lets you define constants for use across languages. Complex
+ * types and structs are specified using JSON notation.
+ */
+const i32 INT32CONSTANT = 9853
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+/**
+ * You can define enums, which are just 32 bit integers. Values are optional
+ * and start at 1 if not supplied, C style again.
+ */
+enum Operation {
+  ADD = 1,
+  SUBTRACT = 2,
+  MULTIPLY = 3,
+  DIVIDE = 4
+}
+
+/**
+ * Structs are the basic complex data structures. They are comprised of fields
+ * which each have an integer identifier, a type, a symbolic name, and an
+ * optional default value.
+ *
+ * Fields can be declared "optional", which ensures they will not be included
+ * in the serialized output if they aren't set.  Note that this requires some
+ * manual management in some languages.
+ */
+struct Work {
+  1: i32 num1 = 0,
+  2: i32 num2,
+  3: Operation op,
+  4: optional string comment,
+}
+
+/**
+ * Structs can also be exceptions, if they are nasty.
+ */
+exception InvalidOperation {
+  1: i32 whatOp,
+  2: string why
+}
+
+/**
+ * Ahh, now onto the cool part, defining a service. Services just need a name
+ * and can optionally inherit from another service using the extends keyword.
+ */
+service Calculator extends shared.SharedService {
+
+  /**
+   * A method definition looks like C code. It has a return type, arguments,
+   * and optionally a list of exceptions that it may throw. Note that argument
+   * lists and exception lists are specified using the exact same syntax as
+   * field lists in struct or exception definitions.
+   */
+
+   void ping(),
+
+   i32 add(1:i32 num1, 2:i32 num2),
+
+   i32 calculate(1:i32 logid, 2:Work w) throws (1:InvalidOperation ouch),
+
+   /**
+    * This method has a oneway modifier. That means the client only makes
+    * a request and does not listen for any response at all. Oneway methods
+    * must be void.
+    */
+   oneway void zip()
+
+}
+
+/**
+ * That just about covers the basics. Take a look in the test/ folder for more
+ * detailed examples. After you run this file, your generated code shows up
+ * in folders with names gen-<language>. The generated code isn't too scary
+ * to look at. It even has pretty indentation.
+ */


### PR DESCRIPTION
This check picks up https://github.com/rouge-ruby/rouge/pull/787, and adds:

* missing keywords like `include`, `namespace`, `oneway`, etc
* fixed floating point numbers and exponents
* shell comments `# ...`
* annotations support
* updated visual sample from the thrift tutorial https://github.com/apache/thrift/blob/master/tutorial/tutorial.thrift

<table>
<tr><th>Light</th><th>Dark</th></tr>
<tr>
<td>
<img width="1688" height="702" alt="CleanShot 2026-05-02 at 09 34 46@2x" src="https://github.com/user-attachments/assets/7d9a9988-8367-4931-9f79-a6362e86191a" />
</td>
<td>
<img width="1682" height="702" alt="CleanShot 2026-05-02 at 09 34 25@2x" src="https://github.com/user-attachments/assets/bb777701-557d-4a61-8b56-85e8d038dd1a" />
</td>
</tr>
</table>

Closes #784