### PR TITLE
Overhaul HTML Formatter Delegation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,3 +123,7 @@ Performance/ConstantRegexp:
 
 Performance/UnfreezeString:
   Enabled: false
+
+Performance/StringInclude:
+  Exclude:
+    - "spec/**/*.rb"

--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -14,6 +14,12 @@ module Rouge
 
       ESCAPE_REGEX = /[&<>\r]/.freeze
 
+      def self.assert_html_formatter!(formatter)
+        return formatter if formatter.respond_to?(:span)
+
+        raise ArgumentError.new("Expected an instance of Rouge::Formatters::HTML, got #{formatter.class}. Try HTML, HTMLDebug, or HTMLInline.")
+      end
+
       tag 'html'
 
       # @yield the html output.

--- a/lib/rouge/formatters/html_legacy.rb
+++ b/lib/rouge/formatters/html_legacy.rb
@@ -27,7 +27,7 @@ module Rouge
       # Content will be wrapped in a tag (`div` if tableized, `pre` if
       # not) with the given `:css_class` unless `:wrap` is set to `false`.
       def initialize(opts={})
-        warn '[DEPRECATION] Rouge::Formatters::HTMLLegacy is deprecated and will be removed soon. Please use one of the other formatters, or write your own.'
+        warn '[DEPRECATED] Rouge::Formatters::HTMLLegacy is deprecated and will be removed soon. Please use one of the other formatters, or write your own.'
         @formatter = opts[:inline_theme] ? HTMLInline.new(opts[:inline_theme])
                    : HTML.new
 

--- a/lib/rouge/formatters/html_legacy.rb
+++ b/lib/rouge/formatters/html_legacy.rb
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
 module Rouge
   module Formatters
     # Transforms a token stream into HTML output.

--- a/lib/rouge/formatters/html_legacy.rb
+++ b/lib/rouge/formatters/html_legacy.rb
@@ -35,13 +35,21 @@ module Rouge
         @formatter = HTMLTable.new(@formatter, opts) if opts[:line_numbers]
 
         if opts.fetch(:wrap, true)
-          @formatter = HTMLPygments.new(@formatter, opts.fetch(:css_class, 'codehilite'))
+          @pygments_wrap = opts.fetch(:css_class, 'codehilite')
         end
       end
 
       # @yield the html output.
       def stream(tokens, &b)
+        if @pygments_wrap
+          yield %(<div class="highlight"><pre class="#{@pygments_wrap}"><code>)
+        end
+
         @formatter.stream(tokens, &b)
+
+        if @pygments_wrap
+          yield "</code></pre></div>"
+        end
       end
     end
   end

--- a/lib/rouge/formatters/html_legacy.rb
+++ b/lib/rouge/formatters/html_legacy.rb
@@ -27,6 +27,7 @@ module Rouge
       # Content will be wrapped in a tag (`div` if tableized, `pre` if
       # not) with the given `:css_class` unless `:wrap` is set to `false`.
       def initialize(opts={})
+        warn '[DEPRECATION] Rouge::Formatters::HTMLLegacy is deprecated and will be removed soon. Please use one of the other formatters, or write your own.'
         @formatter = opts[:inline_theme] ? HTMLInline.new(opts[:inline_theme])
                    : HTML.new
 

--- a/lib/rouge/formatters/html_legacy_table.rb
+++ b/lib/rouge/formatters/html_legacy_table.rb
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*- #
+# frozen_string_literal: true
+
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
+module Rouge
+  module Formatters
+    class HTMLLegacyTable < Formatter
+      def initialize(inner, opts={})
+        warn '[DEPRECATED] using a wrapped or line-managed delegator for HTMLTable is deprecated, and will be removed soon. Please use HTML, HTMLInline, or HTMLDebug, or write your own formatter.'
+
+        @inner = inner
+        @start_line = opts.fetch(:start_line, 1)
+        @line_format = opts.fetch(:line_format, '%i')
+        @table_class = opts.fetch(:table_class, 'rouge-table')
+        @gutter_class = opts.fetch(:gutter_class, 'rouge-gutter')
+        @code_class = opts.fetch(:code_class, 'rouge-code')
+      end
+
+      def style(scope)
+        yield "#{scope} .#{@table_class} { border-spacing: 0 }"
+        yield "#{scope} .#{@gutter_class} { text-align: right }"
+      end
+
+      def stream(tokens, &b)
+        last_val = nil
+        num_lines = tokens.reduce(0) {|count, (_, val)| count + (last_val = val).count("\n") }
+        formatted = @inner.format(tokens)
+
+        unless last_val && last_val.end_with?("\n")
+          num_lines += 1
+          formatted << "\n" unless formatted.end_with?("\n")
+        end
+
+        # generate a string of newline-separated line numbers for the gutter
+        formatted_line_numbers = (@start_line..(@start_line + num_lines - 1)).map do |i|
+          sprintf(@line_format, i)
+        end.join("\n") << "\n"
+
+        buffer = [%(<table class="#@table_class"><tbody><tr>)]
+        # the "gl" class applies the style for Generic.Lineno
+        buffer << %(<td class="#@gutter_class gl" aria-hidden="true">)
+        buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
+        buffer << '</td>'
+        buffer << %(<td class="#@code_class"><pre><code>)
+        buffer << formatted
+        buffer << '</code></pre></td>'
+        buffer << '</tr></tbody></table>'
+
+        yield buffer.join
+      end
+    end
+  end
+end

--- a/lib/rouge/formatters/html_line_highlighter.rb
+++ b/lib/rouge/formatters/html_line_highlighter.rb
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
 module Rouge
   module Formatters
     class HTMLLineHighlighter < Formatter
@@ -14,9 +19,11 @@ module Rouge
 
       def stream(tokens)
         token_lines(tokens).with_index(1) do |line_tokens, lineno|
-          line = %(#{@delegate.format(line_tokens)}\n)
-          line = %(<span class="#{@highlight_line_class}">#{line}</span>) if @highlight_lines.include? lineno
-          yield line
+          should_highlight = @highlight_lines.include?(lineno)
+          yield %(<span class=#{@highlight_line_class.inspect}>) if should_highlight
+          line_tokens.each { |tok, val| yield @delegate.span(tok, val) }
+          yield "\n"
+          yield %(</span>) if should_highlight
         end
       end
     end

--- a/lib/rouge/formatters/html_line_highlighter.rb
+++ b/lib/rouge/formatters/html_line_highlighter.rb
@@ -12,7 +12,7 @@ module Rouge
       tag 'html_line_highlighter'
 
       def initialize(delegate, opts = {})
-        @delegate = delegate
+        @delegate = HTML.assert_html_formatter!(delegate)
         @highlight_line_class = opts.fetch(:highlight_line_class, 'hll')
         @highlight_lines = opts[:highlight_lines] || []
       end

--- a/lib/rouge/formatters/html_line_table.rb
+++ b/lib/rouge/formatters/html_line_table.rb
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
 module Rouge
   module Formatters
     class HTMLLineTable < Formatter

--- a/lib/rouge/formatters/html_line_table.rb
+++ b/lib/rouge/formatters/html_line_table.rb
@@ -22,7 +22,7 @@ module Rouge
       # @option opts [String] :code_class Class name for rendered code cell.
       #   Defaults to `"rouge-code"`.
       def initialize(formatter, opts={})
-        @formatter    = formatter
+        @formatter    = HTML.assert_html_formatter!(formatter)
         @start_line   = opts.fetch :start_line,   1
         @table_class  = opts.fetch :table_class,  'rouge-line-table'
         @gutter_class = opts.fetch :gutter_class, 'rouge-gutter'

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
-# [jneen] This is an example implementation only. Please do not submit patches that
-# alter the behaviour or options of this formatter. You are highly encouraged to
-# write your own formatter for your application instead.
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
 
 module Rouge
   module Formatters
@@ -19,9 +20,10 @@ module Rouge
       def stream(tokens, &b)
         token_lines(tokens).with_index(1) do |line_tokens, lineno|
           yield %(<#{@tag_name} class="#{sprintf @class_format, lineno}">)
-          line.each do |tok, val|
+          line_tokens.each do |tok, val|
             yield @formatter.span(tok, val)
           end
+          yield %(</#{@tag_name}>)
         end
       end
     end

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. Please do not submit patches that
+# alter the behaviour or options of this formatter. You are highly encouraged to
+# write your own formatter for your application instead.
+
 module Rouge
   module Formatters
     class HTMLLinewise < Formatter
@@ -15,8 +19,9 @@ module Rouge
       def stream(tokens, &b)
         token_lines(tokens).with_index(1) do |line_tokens, lineno|
           yield %(<#{@tag_name} class="#{sprintf @class_format, lineno}">)
-          @formatter.stream(line_tokens) {|formatted| yield formatted }
-          yield %(\n</#{@tag_name}>)
+          line.each do |tok, val|
+            yield @formatter.span(tok, val)
+          end
         end
       end
     end

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -12,7 +12,7 @@ module Rouge
       tag 'html_linewise'
 
       def initialize(formatter, opts={})
-        @formatter = formatter
+        @formatter = HTML.assert_html_formatter!(formatter)
         @tag_name = opts.fetch(:tag_name, 'div')
         @class_format = opts.fetch(:class, 'line-%i')
       end

--- a/lib/rouge/formatters/html_linewise.rb
+++ b/lib/rouge/formatters/html_linewise.rb
@@ -23,7 +23,7 @@ module Rouge
           line_tokens.each do |tok, val|
             yield @formatter.span(tok, val)
           end
-          yield %(</#{@tag_name}>)
+          yield %(\n</#{@tag_name}>)
         end
       end
     end

--- a/lib/rouge/formatters/html_pygments.rb
+++ b/lib/rouge/formatters/html_pygments.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
 module Rouge
   module Formatters
     class HTMLPygments < Formatter

--- a/lib/rouge/formatters/html_pygments.rb
+++ b/lib/rouge/formatters/html_pygments.rb
@@ -4,7 +4,7 @@ module Rouge
   module Formatters
     class HTMLPygments < Formatter
       def initialize(inner, css_class='codehilite')
-        @inner = inner
+        @inner = HTML.assert_html_formatter!(inner)
         @css_class = css_class
       end
 

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -12,7 +12,7 @@ module Rouge
       tag 'html_table'
 
       def initialize(inner, opts={})
-        @inner = inner
+        @inner = HTML.assert_html_formatter!(inner)
         @start_line = opts.fetch(:start_line, 1)
         @line_format = opts.fetch(:line_format, '%i')
         @table_class = opts.fetch(:table_class, 'rouge-table')

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -11,6 +11,15 @@ module Rouge
     class HTMLTable < Formatter
       tag 'html_table'
 
+      def self.new(inner, opts={})
+        if !inner.is_a?(HTML) && inner.is_a?(Formatter)
+          require_relative 'html_legacy_table'
+          return HTMLLegacyTable.new(inner, opts)
+        end
+
+        super(inner, opts)
+      end
+
       def initialize(inner, opts={})
         @inner = HTML.assert_html_formatter!(inner)
         @start_line = opts.fetch(:start_line, 1)

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -21,8 +21,8 @@ module Rouge
       end
 
       def style(scope)
-        yield "#{scope} .rouge-table { border-spacing: 0 }"
-        yield "#{scope} .rouge-gutter { text-align: right }"
+        yield "#{scope} .#{@table_class} { border-spacing: 0 }"
+        yield "#{scope} .#{@gutter_class} { text-align: right }"
       end
 
       def stream(tokens, &b)

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*- #
 # frozen_string_literal: true
 
+# [jneen] This is an example implementation only. You may use it as-is, but please do
+# not submit patches that alter the behaviour or options of this formatter for the
+# convenience of your application. You are highly encouraged to write your own
+# formatter for your application instead.
+
 module Rouge
   module Formatters
     class HTMLTable < Formatter
@@ -34,11 +39,12 @@ module Rouge
         # add an extra line for non-newline-terminated strings
         if last_val[-1] != "\n"
           num_lines += 1
-          @inner.span(Token::Tokens::Text::Whitespace, "\n") { |str| formatted << str }
+          yield @inner.span(Token::Tokens::Text::Whitespace, "\n")
         end
 
         # generate a string of newline-separated line numbers for the gutter>
-        formatted_line_numbers = (@start_line..num_lines+@start_line-1).map do |i|
+        last_line = num_lines + @start_line
+        formatted_line_numbers = (@start_line...last_line).map do |i|
           sprintf("#{@line_format}", i) << "\n"
         end.join('')
 

--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -16,35 +16,46 @@ module Rouge
       end
 
       def style(scope)
-        yield %(#{scope} .rouge-table { border-spacing: 0 })
-        yield %(#{scope} .rouge-gutter { text-align: right })
+        yield "#{scope} .rouge-table { border-spacing: 0 }"
+        yield "#{scope} .rouge-gutter { text-align: right }"
       end
 
       def stream(tokens, &b)
-        last_val = nil
-        num_lines = tokens.reduce(0) {|count, (_, val)| count + (last_val = val).count(?\n) }
-        formatted = @inner.format(tokens)
-        unless last_val && last_val.end_with?(?\n)
+        num_lines = 0
+        last_val = ''
+        formatted = String.new('')
+
+        tokens.each do |tok, val|
+          last_val = val
+          num_lines += val.scan(/\n/).size
+          formatted << @inner.span(tok, val)
+        end
+
+        # add an extra line for non-newline-terminated strings
+        if last_val[-1] != "\n"
           num_lines += 1
-          formatted << ?\n unless formatted.end_with?(?\n)
+          @inner.span(Token::Tokens::Text::Whitespace, "\n") { |str| formatted << str }
         end
 
         # generate a string of newline-separated line numbers for the gutter>
-        formatted_line_numbers = (@start_line..(@start_line + num_lines - 1)).map do |i|
-          sprintf(@line_format, i)
-        end.join(?\n) << ?\n
+        formatted_line_numbers = (@start_line..num_lines+@start_line-1).map do |i|
+          sprintf("#{@line_format}", i) << "\n"
+        end.join('')
 
-        buffer = [%(<table class="#@table_class"><tbody><tr>)]
+        numbers = %(<pre class="lineno">#{formatted_line_numbers}</pre>)
+
+        yield %(<table class="#@table_class"><tbody><tr>)
+
         # the "gl" class applies the style for Generic.Lineno
-        buffer << %(<td class="#@gutter_class gl" aria-hidden="true">)
-        buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
-        buffer << '</td>'
-        buffer << %(<td class="#@code_class"><pre><code>)
-        buffer << formatted
-        buffer << '</code></pre></td>'
-        buffer << '</tr></tbody></table>'
+        yield %(<td class="#@gutter_class gl" aria-hidden="true">)
+        yield numbers
+        yield '</td>'
 
-        yield buffer.join
+        yield %(<td class="#@code_class"><pre>)
+        yield formatted
+        yield '</pre></td>'
+
+        yield "</tr></tbody></table>"
       end
     end
   end

--- a/lib/rouge/plugins/redcarpet.rb
+++ b/lib/rouge/plugins/redcarpet.rb
@@ -25,12 +25,13 @@ module Rouge
         end
 
         formatter = rouge_formatter(lexer)
-        formatter.format(lexer.lex(code))
+        formatted = formatter.format(lexer.lex(code))
+        %(<pre class="highlight #{lexer.tag}"><code>#{formatted}</code></pre>)
       end
 
       # override this method for custom formatting behavior
       def rouge_formatter(lexer)
-        Formatters::HTMLLegacy.new(:css_class => "highlight #{lexer.tag}")
+        Rouge::Formatters::HTML.new
       end
     end
   end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -31,4 +31,14 @@ describe Rouge::Formatters::HTMLLinewise do
       assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }
     end
   end
+
+  describe 'with an improper inner formatter' do
+    it 'raises an error' do
+      assert do
+        rescuing(ArgumentError, /got Rouge::Formatters::HTMLLinewise\b/) do
+          Rouge::Formatters::HTMLTable.new(Rouge::Formatters::HTMLLinewise.new(Rouge::Formatters::HTML.new))
+        end
+      end
+    end
+  end
 end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -12,7 +12,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], 'foo']] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span></div>) }
     end
   end
 
@@ -20,7 +20,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
+      assert { output == %(<div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div>) }
     end
   end
 
@@ -28,16 +28,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], "foo\nbar"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
-    end
-  end
-
-  describe 'alternate tag name' do
-    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
-    let(:options) { { tag_name: 'span' } }
-
-    it 'should use tag name specified by :tag_name option' do
-      assert { output == %(<span class="line-1">foo\n</span><span class="line-2"><span class="n">bar</span>\n</span>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }
     end
   end
 end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -35,10 +35,40 @@ describe Rouge::Formatters::HTMLLinewise do
   describe 'with an improper inner formatter' do
     it 'raises an error' do
       assert do
-        rescuing(ArgumentError, /got Rouge::Formatters::HTMLLinewise\b/) do
-          Rouge::Formatters::HTMLTable.new(Rouge::Formatters::HTMLLinewise.new(Rouge::Formatters::HTML.new))
+        rescuing(ArgumentError, /got Rouge::Formatters::HTMLTable\b/) do
+          Rouge::Formatters::HTMLLinewise.new(Rouge::Formatters::HTMLTable.new(Rouge::Formatters::HTML.new))
         end
       end
+    end
+  end
+
+  describe 'inside html table formatter' do
+    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
+
+    it 'should delegate to linewise formatter' do
+      warnings, formatter = capture_warnings do
+        Rouge::Formatters::HTMLTable.new(subject)
+      end
+
+      assert { warnings.size == 1}
+      warning = warnings.first
+      assert { warning.match?(/DEPRECATED/) }
+
+      expected = %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div></code></pre></td></tr></tbody></table>)
+
+      actual = formatter.format(input_stream)
+
+      assert { actual == expected }
+    end
+  end
+
+
+  describe 'alternate tag name' do
+    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
+    let(:options) { { tag_name: 'florbis' } }
+
+    it 'should use tag name specified by :tag_name option' do
+      assert { output == %(<florbis class="line-1">foo</florbis><florbis class="line-2"><span class="n">bar</span></florbis>) }
     end
   end
 end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -40,12 +40,4 @@ describe Rouge::Formatters::HTMLLinewise do
       assert { output == %(<span class="line-1">foo\n</span><span class="line-2"><span class="n">bar</span>\n</span>) }
     end
   end
-
-  describe 'inside html table formatter' do
-    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
-
-    it 'should delegate to linewise formatter' do
-      assert { Rouge::Formatters::HTMLTable.new(subject).format(input_stream) == %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></code></pre></td></tr></tbody></table>) }
-    end
-  end
 end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -12,7 +12,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], 'foo']] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span></div>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div>) }
     end
   end
 
@@ -20,7 +20,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div>) }
+      assert { output == %(<div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
     end
   end
 
@@ -28,7 +28,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:input_stream) { [[Token['Name'], "foo\nbar"]] }
 
     it 'formats' do
-      assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }
+      assert { output == %(<div class="line-1"><span class="n">foo</span>\n</div><div class="line-2"><span class="n">bar</span>\n</div>) }
     end
   end
 
@@ -54,7 +54,7 @@ describe Rouge::Formatters::HTMLLinewise do
       warning = warnings.first
       assert { warning.match?(/DEPRECATED/) }
 
-      expected = %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div></code></pre></td></tr></tbody></table>)
+      expected = %(<table class="rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1\n2\n</pre></td><td class="rouge-code"><pre><code><div class="line-1">foo\n</div><div class="line-2"><span class="n">bar</span>\n</div></code></pre></td></tr></tbody></table>)
 
       actual = formatter.format(input_stream)
 
@@ -68,7 +68,7 @@ describe Rouge::Formatters::HTMLLinewise do
     let(:options) { { tag_name: 'florbis' } }
 
     it 'should use tag name specified by :tag_name option' do
-      assert { output == %(<florbis class="line-1">foo</florbis><florbis class="line-2"><span class="n">bar</span></florbis>) }
+      assert { output == %(<florbis class="line-1">foo\n</florbis><florbis class="line-2"><span class="n">bar</span>\n</florbis>) }
     end
   end
 end

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -2,7 +2,17 @@
 # frozen_string_literal: true
 
 describe Rouge::Formatters::HTML do
-  let(:subject) { Rouge::Formatters::HTMLLegacy.new(options) }
+  let(:subject) do
+    warnings, formatter = capture_warnings do
+      Rouge::Formatters::HTMLLegacy.new(options)
+    end
+
+    assert { warnings.size == 1 }
+    assert { warnings[0].match?(/DEPRECATED/) }
+
+    formatter
+  end
+
   let(:options) { {} }
 
   describe 'skipping the wrapper' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,20 @@ Token = Rouge::Token
 Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each {|f|
   require f
 }
+
+class Minitest::Test
+  def rescuing(*assertions, &b)
+    yield
+    nil
+  rescue => e
+    assertions.each do |a|
+      if a.is_a?(Class)
+        raise e unless a === e
+      else
+        raise e unless a === e.message
+      end
+    end
+
+    e
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,19 @@ Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each {|f|
   require f
 }
 
+class Object
+  alias __original_warn warn
+
+  def warn(message)
+    capture = Thread.current[:WARN_CAPTURE]
+    if capture
+      capture << message
+    else
+      raise "Warned during specs: #{message.inspect}"
+    end
+  end
+end
+
 class Minitest::Test
   def rescuing(*assertions, &b)
     yield
@@ -30,5 +43,19 @@ class Minitest::Test
     end
 
     e
+  end
+
+  def capture_warnings(&b)
+    raise "double capture" if Thread.current[:WARN_CAPTURE]
+
+    captured = []
+
+    Thread.current[:WARN_CAPTURE] = captured
+    out = yield
+
+  ensure
+    Thread.current[:WARN_CAPTURE] = nil
+
+    return [captured, out]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,9 +53,8 @@ class Minitest::Test
     Thread.current[:WARN_CAPTURE] = captured
     out = yield
 
+    [captured, out]
   ensure
     Thread.current[:WARN_CAPTURE] = nil
-
-    return [captured, out]
   end
 end

--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -31,8 +31,7 @@ class VisualTestApp < Sinatra::Application
     line_numbers = as_boolean params.fetch(:line_numbers, false)
 
     # parameters enabled by default
-    wrapped    = as_boolean params.fetch(:wrap, true)
-    line_table = as_boolean params.fetch(:line_table, true)
+    line_table = as_boolean params.fetch(:line_table, false)
 
     # base HTML formatter
     formatter = inline ?
@@ -40,14 +39,12 @@ class VisualTestApp < Sinatra::Application
                   Rouge::Formatters::HTMLDebug.new
 
     if line_numbers
-      formatter = line_table ?
-                    Rouge::Formatters::HTMLLineTable.new(formatter) :
-                    Rouge::Formatters::HTMLTable.new(formatter)
+      line_table \
+        ? Rouge::Formatters::HTMLLineTable.new(formatter, table_class: 'highlight')
+        : Rouge::Formatters::HTMLTable.new(formatter, table_class: 'highlight no-wrap')
+    else
+      Rouge::Formatters::HTMLPygments.new(formatter, 'highlight')
     end
-
-    return Rouge::Formatters::HTMLPygments.new(formatter) if wrapped
-
-    formatter
   end
 
   def as_boolean(value)
@@ -72,7 +69,7 @@ class VisualTestApp < Sinatra::Application
     theme_class = Rouge::Theme.find(params[:theme] || 'thankful_eyes')
     halt 404 unless theme_class
 
-    @theme         = theme_class.new(scope: '.codehilite')
+    @theme         = theme_class.new(scope: '.highlight')
     @comment_color = theme_class.get_style(Rouge::Token::Tokens::Comment).fg
     @formatter     = setup_formatter(params)
   end

--- a/spec/visual/templates/layout.erb
+++ b/spec/visual/templates/layout.erb
@@ -8,38 +8,67 @@
     <%= @theme.render_base('a') %>
 
     * { box-sizing: border-box }
+
     html { font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif }
+
     body, main, h2 { margin: 0 }
+
     pre, code {
       font-family: 'Source Code Pro', 'Menlo', 'Ubuntu Mono', 'Monaco', monospace;
       font-size: 14px;
       white-space: pre-wrap;
     }
+
+    .no-wrap pre, .no-wrap code {
+      white-space: pre;
+    }
+
     a { text-decoration: none }
+
     header {
       color: <%= @comment_color %>;
-      border-bottom: 1px dotted
+      border-bottom: 1px dotted;
     }
+
     #page-header, #page-footer {
       padding: 15px;
       text-align: center;
     }
+
     #page-header h1 {
       margin: 0.25em;
       font-size: 1.5em;
     }
+
     .section-header {
       margin-bottom: 20px;
       padding-bottom: 8px;
     }
+
     #page-footer {
       color: <%= @comment_color %>;
       border-top: 1px dotted
     }
-    .rouge-line-table { border-collapse: collapse }
-    .rouge-line-table tr > td { padding: 0 5px }
-    .rouge-line-table .rouge-gutter { text-align: right; vertical-align: top }
-    .rouge-line-table .rouge-gutter pre { margin: 0 }
+
+    table { border-collapse: collapse }
+    table pre { margin: 0; }
+    table tr > td { padding: 0 5px; }
+
+    .rouge-gutter {
+      text-align: right;
+      vertical-align: top;
+      border-right: 1px solid <%= @comment_color %>;
+      margin-right: 10px;
+      padding-right: 10px;
+    }
+
+    table .rouge-code {
+      padding-left: 10px;
+    }
+
+    .highlight {
+      margin: 10px;
+    }
   </style>
 </head>
 


### PR DESCRIPTION
Fixes #2279.

Reverts #1156 and #1083, and adds warning comments to all the HTML* formatters that take delegators.

In the above patches, there was a strict assumption that *all* HTML formatters were capable of being wrapped, which they are not, which caused all manner of confusion, extra newlines, extra wrapping tags, etc. In general, it is only safe to call the `#span(tok, val)` method of a delegator, which will yield precisely a span for that token. Calling `#stream` directly *can* be safe, but only for the non-nesting HTML formatters, which are HTML, HTMLInline, and HTMLDebug, which guarantee no newline-handling or wrapping of their input.

I have also added a temporary polyfill for #1082, with a deprecation warning. `HTMLTable.new(...)`, when passed a Formatter other than one of the three non-nesting HTML formatters, will become an `HTMLLegacyTable` and warn. Those using that kind of nesting should maintain their own formatters for their application going into the future. Other unsupported combinations will raise. Users who have written their own formatters should not be affected by any of these changes.

If there is a desire for a more packaged approach, then others are welcome to publish a plugin with fancier HTML formatters. As it is, this stack is far too complicated for Rouge core.

Request for comment from @UlyssesZh, @mojavelinux, and @ashmaroli.