### PR TITLE
Add support for the Python 3.15+ `lazy` keyword

### DIFF
--- a/lib/rouge/demos/python
+++ b/lib/rouge/demos/python
@@ -1,6 +1,19 @@
+lazy import re
+
+
 def fib(n):    # write Fibonacci series up to n
     """Print a Fibonacci series up to n."""
     a, b = 0, 1
     while a < n:
         print a,
         a, b = b, a+b
+
+
+_ANSI_RE = None
+
+def strip_ansi(s: str) -> str:
+    """Remove ANSI escapes from a string."""
+    if _ANSI_RE is None:
+        global _ANSI_RE
+        _ANSI_RE = re.compile(r"\033\[[;?0-9]*[a-zA-Z]")
+    return _ANSI_RE.sub("", s)

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -21,7 +21,7 @@ module Rouge
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
           return try while yield as with from import
-          async await nonlocal lazy
+          async await nonlocal
         )
       end
 
@@ -114,6 +114,11 @@ module Rouge
         rule %r/def\b/, Keyword, :funcname
 
         rule %r/class\b/, Keyword, :classname
+
+        # handle `lazy import` and `from ... lazy import ...` soft keyword usage
+        # since `import` and `from` are hard keywords, we know that this usage
+        # has to be the soft-keyword case
+        rule %r/lazy(?=#{inline_ws}(from|import))/, Keyword
 
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rtfbu]{0,2})('''|"""|['"])/i do |m|

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -115,10 +115,10 @@ module Rouge
 
         rule %r/class\b/, Keyword, :classname
 
-        # handle `lazy import` and `from ... lazy import ...` soft keyword usage
-        # since `import` and `from` are hard keywords, we know that this usage
-        # has to be the soft-keyword case
-        rule %r/lazy(?=#{inline_ws}(from|import))/, Keyword
+        # handle `lazy import` soft keyword usage
+        # since `import` is a hard keyword, we know that this usage has to be
+        # the soft-keyword case
+        rule %r/lazy(?=#{inline_ws}import)/, Keyword
 
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rtfbu]{0,2})('''|"""|['"])/i do |m|
@@ -178,6 +178,7 @@ module Rouge
       # import after from, meaning we don't push the :import state
       state :from_import do
         mixin :inline_whitespace
+        rule %r/lazy\b/, Keyword::Namespace
         rule %r/import\b/, Keyword::Namespace, :pop!
         rule(//) { pop! }
       end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -21,7 +21,7 @@ module Rouge
           assert break continue del elif else except exec
           finally for global if lambda pass print raise
           return try while yield as with from import
-          async await nonlocal
+          async await nonlocal lazy
         )
       end
 

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -118,7 +118,7 @@ module Rouge
         # handle `lazy import` soft keyword usage
         # since `import` is a hard keyword, we know that this usage has to be
         # the soft-keyword case
-        rule %r/lazy(?=#{inline_ws}import)/, Keyword
+        rule %r/lazy\b(?=#{inline_ws}import\b)/, Keyword
 
         rule %r/`.*?`/, Str::Backtick
         rule %r/([rtfbu]{0,2})('''|"""|['"])/i do |m|

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -262,3 +262,13 @@ match (100, 200):
       thing \
       :
       other
+
+
+lazy = "deferred"
+lazy import requests
+lazy \
+    import \
+    re
+from typing lazy import Iterator
+from typing lazy \
+    import Generator


### PR DESCRIPTION
New in Python 3.15, there is a `lazy` keyword which allows for deferred
imports.

Also update the demo to make use of `lazy`, type annotations, and `None`,
all of which make the demo a bit more complete.
