### PR TITLE
Fix # comment for INI without following blank line

### DIFF
--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -15,7 +15,7 @@ module Rouge
 
       state :basic do
         rule %r/\s+/, Text::Whitespace
-        rule %r/[;#].*?\n/, Comment
+        rule %r/^[ \t]*[;#][^\n]*(?=\n|\z)/, Comment
         rule %r/\\\n/, Str::Escape
       end
 


### PR DESCRIPTION
A comment started with '#' was not rendered as a comment when that comment wasn't followed by  an empty line. 

Showing as an example in asciidoctor syntax
So this does not render correctly:
```
[source,ini]
----
# a comment
----
```
But with a trailing blank line it renders correctly:
```
[source,ini]
----
# a comment

----
```

This fix make also the above example render correctly.
It also allows leading whitespaces for # comments.