### PR TITLE
Fix @ event shorthand in Vue templates

### DIFF
--- a/lib/rouge/lexers/vue.rb
+++ b/lib/rouge/lexers/vue.rb
@@ -5,6 +5,19 @@ require_relative 'html'
 module Rouge
   module Lexers
     class Vue < HTML
+      # HTML extended with Vue template attribute shorthands.
+      # Used as the delegate lexer for <template> content so that directives
+      # like @click and @click.disabled are recognised without polluting the plain
+      # HTML lexer with framework-specific syntax.
+      class TemplateHTML < HTML
+        prepend :tag do
+          rule %r/([@a-zA-Z0-9_:#\[\]()*.-]+\s*)(=)(\s*)/m do
+            groups Name::Attribute, Operator, Text
+            push :attr
+          end
+        end
+      end
+
       desc 'Vue.js single-file components'
       tag 'vue'
       aliases 'vuejs'
@@ -38,7 +51,7 @@ module Rouge
       prepend :root do
         rule %r/(<)(\s*)(template)/ do
           groups Name::Tag, Text, Keyword
-          @lang = HTML
+          @lang = TemplateHTML
           push :template
           push :lang_tag
         end
@@ -59,7 +72,10 @@ module Rouge
       end
 
       prepend :tag do
-        rule %r/[a-zA-Z0-9_:#\[\]()*.-]+\s*=\s*/m, Name::Attribute, :attr
+        rule %r/([a-zA-Z0-9_:#\[\]()*.-]+\s*)(=)(\s*)/m do
+          groups Name::Attribute, Operator, Text
+          push :attr
+        end
       end
 
       state :style do

--- a/spec/lexers/vue_spec.rb
+++ b/spec/lexers/vue_spec.rb
@@ -10,4 +10,40 @@ describe Rouge::Lexers::Vue do
       assert_guess :filename => 'foo.vue'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'template attribute shorthands' do
+      it 'tokenizes @ event shorthand as an attribute' do
+        assert_tokens_equal '<template><button @click="handler">x</button></template>',
+                            ['Name.Tag', '<'],
+                            ['Keyword', 'template'],
+                            ['Name.Tag', '><button'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '@click'],
+                            ['Operator', '='],
+                            ['Literal.String', '"handler"'],
+                            ['Name.Tag', '>'],
+                            ['Text', 'x'],
+                            ['Name.Tag', '</button></'],
+                            ['Keyword', 'template'],
+                            ['Name.Tag', '>']
+      end
+
+      it 'tokenizes @ shorthand with modifiers as an attribute' do
+        assert_tokens_equal '<template><form @submit.prevent="onSubmit"></form></template>',
+                            ['Name.Tag', '<'],
+                            ['Keyword', 'template'],
+                            ['Name.Tag', '><form'],
+                            ['Text', ' '],
+                            ['Name.Attribute', '@submit.prevent'],
+                            ['Operator', '='],
+                            ['Literal.String', '"onSubmit"'],
+                            ['Name.Tag', '></form></'],
+                            ['Keyword', 'template'],
+                            ['Name.Tag', '>']
+      end
+    end
+  end
 end

--- a/spec/visual/samples/vue
+++ b/spec/visual/samples/vue
@@ -81,3 +81,26 @@ p {
 <current-user #default="{ user }">
   {{ user.firstName }}
 </current-user>
+
+<!-- @ event shorthand and : bind shorthand -->
+<template>
+  <div class="pagination">
+    <button
+      class="join-item btn"
+      @click="currentPage = currentPage - 1"
+      :disabled="currentPage <= 1"
+    >
+      Previous
+    </button>
+    <button
+      class="join-item btn"
+      @click="currentPage = currentPage + 1"
+      :disabled="currentPage >= totalPages"
+    >
+      Next
+    </button>
+    <form @submit.prevent="onSearch">
+      <input :value="query" @input="query = $event.target.value" />
+    </form>
+  </div>
+</template>


### PR DESCRIPTION
Vue template content is delegated to an HTML lexer instance, so the Vue-only prepend `:tag` rule never fired for attributes inside `<template>`. Adding `@` to the HTML tag attribute regex fixes the Error token for `@click`, `@submit.prevent`, etc.

Closes https://github.com/rouge-ruby/rouge/issues/2026