### PR TITLE
Add bitwise shift operators to shell math context

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -163,7 +163,7 @@ module Rouge
 
       state :math do
         rule %r/\)\)/, Keyword, :pop!
-        rule %r([-+*/%^|&!]|\*\*|\|\|), Operator
+        rule %r([-+*/%^|&!]|\*\*|\|\||<<|>>), Operator
         rule %r/\d+(#\w+)?/, Num
         mixin :root
       end

--- a/spec/visual/samples/shell
+++ b/spec/visual/samples/shell
@@ -17,6 +17,25 @@ if [ -n "$BASH_VERSION" ]; then . "$RY_PREFIX/lib/ry.bash_completion"; fi
 
 echo $((16#0F)) # should be 15
 
+# arithmetic operators
+echo $(( 3 + 2 ))
+echo $(( 10 - 4 ))
+echo $(( 6 * 7 ))
+echo $(( 15 / 3 ))
+echo $(( 17 % 5 ))
+echo $(( 2 ** 8 ))
+
+# bitwise operators
+echo $(( 0xFF & 0x0F ))
+echo $(( 0xF0 | 0x0F ))
+echo $(( 0xFF ^ 0xF0 ))
+echo $(( 1 << 4 ))
+echo $(( 256 >> 3 ))
+
+# logical operators
+echo $(( !0 ))
+echo $(( 1 || 0 ))
+
 echo "Balanced paren interpolation: $( if (( a == b )) ; then echo "equal" ; fi )"
 echo "Balanced paren interpolation: $( ( seq 10; seq 10 ) | grep 0 )"
 


### PR DESCRIPTION
`<<` and `>>` were missing from the operator regex in the `:math` state, so left-shift and right-shift inside `$((...))` arithmetic expressions were not highlighted as `Operator` tokens.

| Before | After
| -- | -- |
| <img width="547" height="302" alt="Screenshot 2026-06-04 at 10 57 04 pm" src="https://github.com/user-attachments/assets/d3b2f32d-4ed3-4bfc-be38-bd7c96826d61" /> | <img width="547" height="302" alt="Screenshot 2026-06-04 at 10 56 34 pm" src="https://github.com/user-attachments/assets/d752733d-ef54-488b-b1f1-fa93315aca54" /> |

Closes https://github.com/rouge-ruby/rouge/issues/2128