### PR TITLE
Fix Java import static tokenized as separate tokens

### DIFF
--- a/lib/rouge/demos/java
+++ b/lib/rouge/demos/java
@@ -1,3 +1,6 @@
+import java.util.List;
+import static java.util.Collections.sort;
+
 public class java {
     public static void main(String[] args) {
         System.out.println("Hello World");

--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -52,7 +52,7 @@ module Rouge
         rule %r/(?:#{types.join('|')})\b/, Keyword::Type
         rule %r/(?:true|false|null)\b/, Keyword::Constant
         rule %r/(?:class|interface|record)\b/, Keyword::Declaration, :class
-        rule %r/(?:import|package)\b/, Keyword::Namespace, :import
+        rule %r/(?:import(?:\s+(?:static|module))?|package)\b/, Keyword::Namespace, :import
         rule %r/"""\s*\n.*?(?<!\\)"""/m, Str::Heredoc
         rule %r/"(\\\\|\\"|[^"])*"/, Str
         rule %r/'(?:\\.|[^\\]|\\u[0-9a-f]{4})'/, Str::Char

--- a/spec/visual/samples/java
+++ b/spec/visual/samples/java
@@ -68,6 +68,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.text.MessageFormat;
 import java.util.HashSet;
+import static java.util.Collections.unmodifiableSet;
+import static java.lang.Math.PI;
 
 
 /**


### PR DESCRIPTION
`import static` and `import module` are now consumed as a single `Keyword::Namespace` token, matching Pygments' Java lexer behaviour. Previously, `static` was matched by the :import state's catch-all `Name::Namespace` rule and popped the state early, leaving the rest of the dotted path to be tokenized by the root state rules.

| Before | After |
| -- | -- |
| <img width="669" height="47" alt="Screenshot 2026-06-04 at 11 41 49 pm" src="https://github.com/user-attachments/assets/066b5833-7873-4483-b7ba-2064d61c1e4e" /> | <img width="669" height="47" alt="Screenshot 2026-06-04 at 11 41 32 pm" src="https://github.com/user-attachments/assets/8fd027fd-fd80-4587-a823-0b83d0e4c11f" /> |

Closes https://github.com/rouge-ruby/rouge/issues/1956