### PR TITLE
Add a more helpful #inspect method for lexers

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -351,6 +351,35 @@ module Rouge
       @debug = Lexer.debug_enabled? && bool_option('debug')
     end
 
+    def inspect
+      parts = []
+      inspect_parts do |*new_parts|
+        parts.concat(new_parts)
+      end
+
+      parts.join
+    end
+
+    def inspect_parts(&b)
+      yield "#<", self.class.name, " "
+
+      first = true
+      @options.each do |k, v|
+        yield (first ? '?' : '&')
+        first = false
+
+        yield k, "=", v
+      end
+
+      inspect_details(&b)
+
+      yield ">"
+    end
+
+    def inspect_details
+      # pass
+    end
+
     def eager_load!
       self.class.eager_load!
     end

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -281,6 +281,18 @@ module Rouge
       end
     end
 
+    def inspect_details
+      yield ' stack:['
+      first = true
+      stack.each do |state|
+        yield ',' unless first
+        first = false
+        yield state.name
+      end
+
+      yield ']'
+    end
+
     # @private
     def get_state(state_name)
       self.class.get_state(state_name)


### PR DESCRIPTION
Shows the options, and for RegexLexers, shows the state stack as well. Much more compact than the default, and makes `rougify debug` look much nicer when delegation is involved.