### PR TITLE
Fix edge case in markdown lexer for links followed by parenthesis

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -139,7 +139,7 @@ module Rouge
 
         rule %r/[(]/ do
           token Punctuation
-          push :inline_title
+          goto :inline_title
           push :inline_url
         end
 

--- a/spec/lexers/markdown_spec.rb
+++ b/spec/lexers/markdown_spec.rb
@@ -51,5 +51,9 @@ describe Rouge::Lexers::Markdown do
       assert_has_token("Literal.String.Backtick","\nx```ruby\nfoo\n```\n")
       deny_has_token("Name.Label","\nx```ruby\nfoo\n```\n")
     end
+
+    it 'does not treat text after an inline link as a new link target' do
+      assert_tokens_includes "[a](b) (c)\n", ["Text", " (c)\n"]
+    end
   end
 end


### PR DESCRIPTION
As explained in the related issue, text in a parenthesis after a link was highlighted like link text, when it should be plain text. 

After an inline link was parsed, the lexer stayed in `:link` state instead of returning to `:root`. Changing `push` to `goto` makes it properly return to `:root` after the link.

Resolves https://github.com/rouge-ruby/rouge/issues/1448

| Before / After |
|-----|
| <img width="1290" height="146" alt="Screenshot 2026-06-15 at 18 44 00" src="https://github.com/user-attachments/assets/3ff1d2b4-cc50-4960-9e2f-37d7ece32c42" /> |
| <img width="1290" height="146" alt="Screenshot 2026-06-15 at 18 43 41" src="https://github.com/user-attachments/assets/62eed749-98cf-4186-9e89-ab8a8955c3a7" /> |

Original attempt to fix way back in https://github.com/rouge-ruby/rouge/pull/1449 (Closed)

> [!note]
> Transparency: I did not know how to fix this and asked Claude if there was a simple fix, and I learned that the `push` to `goto` was all that was needed. I did test it manually and verified the fix myself (see screenshots). But I did not know how to write the spec, so that was Claude. If needed, I can drop the spec as I did not write it myself, let me know 🙇 

