### PR TITLE
Fix edge case in markdown lexer for links

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -139,6 +139,7 @@ module Rouge
 
         rule %r/[(]/ do
           token Punctuation
+          pop!
           push :inline_title
           push :inline_url
         end

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -671,6 +671,12 @@ use relative paths:
 
 See my [About](/about/) page for details.   
 
+You can put text in parentheses after a link:
+
+    This [example link](http://example.com/) (is followed by a parenthesis).
+
+This [example link](http://example.com/) (is followed by a parenthesis).
+
 Reference-style links use a second set of square brackets, inside
 which you place a label of your choosing to identify the link:
 


### PR DESCRIPTION
This is a redo of https://github.com/rouge-ruby/rouge/pull/2306

Resolves https://github.com/rouge-ruby/rouge/issues/1448

Thanks to @tancnle for explaining the real issue here: https://github.com/rouge-ruby/rouge/pull/2306#pullrequestreview-4503269211

In brief, we need to exit the `:link` state with `pop!` because `:link` has no way to know whether it has already consumed an inline URL and stays on the stack, ready to match another ` (`.

To validate the fix, I added an extra example to the Markdown sample (check the rendered `(is`):

- Before:

  <img width="1356" height="216" alt="Screenshot 2026-06-19 at 15 21 49" src="https://github.com/user-attachments/assets/541df12b-bdb7-4f36-8f27-cf50290c198e" />

- After:

  <img width="1356" height="216" alt="Screenshot 2026-06-19 at 15 17 50" src="https://github.com/user-attachments/assets/2a0bad74-eb62-46e8-b1a9-48246919e2ef" />
