### PR TITLE
Add support for bash 5.3 curly substitutions

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -161,6 +161,18 @@ module Rouge
         mixin :root
       end
 
+      state :curly_interp do
+        rule %r/[}]/, Str::Interpol, :pop!
+        rule %r/[{]/, Operator, :curly_inner
+        mixin :root
+      end
+
+      state :curly_inner do
+        rule %r/[{]/, Operator, :push
+        rule %r/[}]/, Operator, :pop!
+        mixin :root
+      end
+
       state :math do
         rule %r/\)\)/, Keyword, :pop!
         rule %r([-+*/%^|&!]|\*\*|\|\||<<|>>), Operator
@@ -189,7 +201,11 @@ module Rouge
         rule %r/\\$/, Str::Escape # line continuation
         rule %r/\\./, Str::Escape
         rule %r/\$\(\(/, Keyword, :math
-        rule %r/\$\(/, Str::Interpol, :paren_interp
+        rule %r/\$[(]/, Str::Interpol, :paren_interp
+
+        # see https://www.gnu.org/software/bash/manual/bash.html#Command-Substitution-1
+        rule %r/\$[{][\s|]/, Str::Escape, :curly_interp
+
         rule %r/\${#?/, Keyword, :curly
         rule %r/`/, Str::Backtick, :backticks
         rule %r/\$#?(\w+|.)/, Name::Variable

--- a/spec/visual/samples/shell
+++ b/spec/visual/samples/shell
@@ -1,5 +1,8 @@
 echo $'ansi\tstrings'
 
+echo ${ local X=12345 ; echo $X; }
+echo ${| REPLY=12345; }
+
 echo <<HERE
  HEREE
   HERE


### PR DESCRIPTION
Ref: https://www.gnu.org/software/bash/manual/bash.html#Command-Substitution-1

Allows `${ command; command; }` and `${| command; command; }`.