### PR TITLE
shell: use Str::Interpol instead of Str::Escape

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -204,7 +204,7 @@ module Rouge
         rule %r/\$[(]/, Str::Interpol, :paren_interp
 
         # see https://www.gnu.org/software/bash/manual/bash.html#Command-Substitution-1
-        rule %r/\$[{][\s|]/, Str::Escape, :curly_interp
+        rule %r/\$[{][\s|]/, Str::Interpol, :curly_interp
 
         rule %r/\${#?/, Keyword, :curly
         rule %r/`/, Str::Backtick, :backticks


### PR DESCRIPTION
Fixes the issue raised here:

https://github.com/rouge-ruby/rouge/pull/2309#discussion_r3453271014