### PR TITLE
Markdown parser: Fix bug with --- yaml separator in code blocks

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -26,12 +26,6 @@ module Rouge
 
         rule %r/\\./, Str::Escape
 
-        rule %r/^[\S ]+\n(?:---*)\n/, Generic::Heading
-        rule %r/^[\S ]+\n(?:===*)\n/, Generic::Subheading
-
-        rule %r/^#(?=[^#]).*?$/, Generic::Heading
-        rule %r/^##*.*?$/, Generic::Subheading
-
         rule %r/^([ \t]*)(`{3,}|~{3,})([^\n]*\n)((.*?)(\n\1)(\2))?/m do |m|
           name = m[3].strip
           sublexer =
@@ -72,6 +66,12 @@ module Rouge
         rule %r/\n\n((    |\t).*?\n|\n)+/, Str::Backtick
 
         rule %r/(`+)(?:#{edot}|\n)+?\1/, Str::Backtick
+
+        rule %r/^[\S ]+\n(?:---*)\n/, Generic::Heading
+        rule %r/^[\S ]+\n(?:===*)\n/, Generic::Subheading
+
+        rule %r/^#(?=[^#]).*?$/, Generic::Heading
+        rule %r/^##*.*?$/, Generic::Subheading
 
         # various uses of * are in order of precedence
 

--- a/spec/visual/samples/markdown
+++ b/spec/visual/samples/markdown
@@ -1089,6 +1089,14 @@ $ echo "Sample feature output"
 ```
 ````
 
+```markdown
+---
+title: This sample has YAML frontmatter.
+---
+
+Some text.
+```
+
 [This is a link `with backticks`](example.com)
 [This is a link to a TOML section `[with brackets]` (and backticks)](example.com)
 [This is a link to a TOML section `[[with double brackets]]` (and backticks)](example.com)


### PR DESCRIPTION
When I put a `---` as the first line in a codeblock, it seems to get parsed as a setex header by accident. For example, this should work fine:

````markdown
```markdown
---
title: This sample has YAML frontmatter.
---

Some text.
````

### Solution

All we need to do is parse the backticks first, and move the setex header check to be after the backticks check.

### Screenshots

| Before | After |
| ---- | ----- |
| <img width="740" height="250" alt="Screenshot 2026-07-06 at 13 41 24" src="https://github.com/user-attachments/assets/ef0d0d03-05d2-4c76-a958-26b93831cf0f" /> | <img width="740" height="250" alt="Screenshot 2026-07-06 at 13 38 58" src="https://github.com/user-attachments/assets/1d710144-d8ce-484f-96c3-f1590bc943a6" /> |

