### PR TITLE
Remove redundant alias declarations, and warn on duplicate registration

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -225,6 +225,12 @@ module Rouge
       def register(name, lexer)
         # reset an existing list of lexers
         @all = nil if defined?(@all)
+        name = name.to_s
+
+        if registry.key?(name)
+          Kernel.warn("duplicate lexer tag/alias: #{name}")
+        end
+
         registry[name.to_s] = lexer
       end
 

--- a/lib/rouge/lexers/apiblueprint.rb
+++ b/lib/rouge/lexers/apiblueprint.rb
@@ -9,7 +9,7 @@ module Rouge
       desc 'Markdown based API description language.'
 
       tag 'apiblueprint'
-      aliases 'apiblueprint', 'apib'
+      aliases 'apib'
       filenames '*.apib'
       mimetypes 'text/vnd.apiblueprint'
 

--- a/lib/rouge/lexers/cypher.rb
+++ b/lib/rouge/lexers/cypher.rb
@@ -5,7 +5,6 @@ module Rouge
   module Lexers
     class Cypher < RegexLexer
       tag 'cypher'
-      aliases 'cypher'
       filenames '*.cypher'
       mimetypes 'application/x-cypher-query'
 

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -10,7 +10,7 @@ module Rouge
       desc "Elixir language (elixir-lang.org)"
 
       tag 'elixir'
-      aliases 'elixir', 'exs'
+      aliases 'exs'
 
       filenames '*.ex', '*.exs'
 

--- a/lib/rouge/lexers/gdscript.rb
+++ b/lib/rouge/lexers/gdscript.rb
@@ -7,7 +7,7 @@ module Rouge
       title "GDScript"
       desc "The Godot Engine programming language (https://godotengine.org/)"
       tag 'gdscript'
-      aliases 'gd', 'gdscript'
+      aliases 'gd', 'godot'
       filenames '*.gd'
       mimetypes 'text/x-gdscript', 'application/x-gdscript'
 

--- a/lib/rouge/lexers/go.rb
+++ b/lib/rouge/lexers/go.rb
@@ -7,7 +7,7 @@ module Rouge
       title "Go"
       desc 'The Go programming language (http://golang.org)'
       tag 'go'
-      aliases 'go', 'golang'
+      aliases 'golang'
       filenames '*.go'
 
       mimetypes 'text/x-go', 'application/x-go'

--- a/lib/rouge/lexers/hack.rb
+++ b/lib/rouge/lexers/hack.rb
@@ -9,7 +9,7 @@ module Rouge
       title 'Hack'
       desc 'The Hack programming language (hacklang.org)'
       tag 'hack'
-      aliases 'hack', 'hh'
+      aliases 'hh'
       filenames '*.php', '*.hh'
 
       def self.detect?(text)

--- a/lib/rouge/lexers/haxe.rb
+++ b/lib/rouge/lexers/haxe.rb
@@ -7,7 +7,7 @@ module Rouge
       desc "Haxe Cross-platform Toolkit (http://haxe.org)"
 
       tag 'haxe'
-      aliases 'hx', 'haxe'
+      aliases 'hx'
       filenames '*.hx'
       mimetypes 'text/haxe', 'text/x-haxe', 'text/x-hx'
 

--- a/lib/rouge/lexers/jsx.rb
+++ b/lib/rouge/lexers/jsx.rb
@@ -8,7 +8,7 @@ module Rouge
       title 'JSX'
       desc 'An XML-like syntax extension to JavaScript (facebook.github.io/jsx/)'
       tag 'jsx'
-      aliases 'jsx', 'react'
+      aliases 'react'
       filenames '*.jsx'
 
       mimetypes 'text/x-jsx', 'application/x-jsx'

--- a/lib/rouge/lexers/lean.rb
+++ b/lib/rouge/lexers/lean.rb
@@ -8,7 +8,6 @@ module Rouge
       title 'Lean'
       desc 'The Lean programming language (leanprover.github.io)'
       tag 'lean'
-      aliases 'lean'
       filenames '*.lean'
 
       def self.keywords

--- a/lib/rouge/lexers/mojo.rb
+++ b/lib/rouge/lexers/mojo.rb
@@ -9,7 +9,6 @@ module Rouge
       title "Mojo"
       desc "The Mojo programming language (modular.com)"
       tag 'mojo'
-      aliases 'mojo'
       filenames '*.mojo', '*.🔥'
       mimetypes 'text/x-mojo', 'application/x-mojo'
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -7,7 +7,7 @@ module Rouge
       title "PHP"
       desc "The PHP scripting language (php.net)"
       tag 'php'
-      aliases 'php', 'php3', 'php4', 'php5'
+      aliases 'php3', 'php4', 'php5'
       filenames '*.php', '*.php[345t]','*.phtml',
                 # Support Drupal file extensions, see:
                 # https://github.com/gitlabhq/gitlabhq/issues/8900

--- a/lib/rouge/lexers/plist.rb
+++ b/lib/rouge/lexers/plist.rb
@@ -5,7 +5,6 @@ module Rouge
     class Plist < RegexLexer
       desc 'plist'
       tag 'plist'
-      aliases 'plist'
       filenames '*.plist', '*.pbxproj'
 
       mimetypes 'text/x-plist', 'application/x-plist'

--- a/lib/rouge/lexers/postscript.rb
+++ b/lib/rouge/lexers/postscript.rb
@@ -8,7 +8,7 @@ module Rouge
       title "PostScript"
       desc "The PostScript language (adobe.com/devnet/postscript.html)"
       tag "postscript"
-      aliases "postscr", "postscript", "ps", "eps"
+      aliases "postscr", "ps", "eps"
       filenames "*.ps", "*.eps"
       mimetypes "application/postscript"
 

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -7,7 +7,6 @@ module Rouge
       title "Prolog"
       desc "The Prolog programming language (http://en.wikipedia.org/wiki/Prolog)"
       tag 'prolog'
-      aliases 'prolog'
       filenames '*.pro', '*.P', '*.prolog', '*.pl'
       mimetypes 'text/x-prolog'
 

--- a/lib/rouge/lexers/prometheus.rb
+++ b/lib/rouge/lexers/prometheus.rb
@@ -5,7 +5,6 @@ module Rouge
     class Prometheus < RegexLexer
       desc 'prometheus'
       tag 'prometheus'
-      aliases 'prometheus'
       filenames '*.prometheus'
 
       mimetypes 'text/x-prometheus', 'application/x-prometheus'

--- a/lib/rouge/lexers/qml.rb
+++ b/lib/rouge/lexers/qml.rb
@@ -9,7 +9,6 @@ module Rouge
       title "QML"
       desc 'QML, a UI markup language'
       tag 'qml'
-      aliases 'qml'
       filenames '*.qml'
 
       mimetypes 'application/x-qml', 'text/x-qml'

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -7,7 +7,7 @@ module Rouge
       title "R"
       desc 'The R statistics language (r-project.org)'
       tag 'r'
-      aliases 'r', 'R', 's', 'S'
+      aliases 'R', 's', 'S'
       filenames '*.R', '*.r', '.Rhistory', '.Rprofile'
       mimetypes 'text/x-r-source', 'text/x-r', 'text/x-R'
 

--- a/lib/rouge/lexers/scala.rb
+++ b/lib/rouge/lexers/scala.rb
@@ -7,7 +7,6 @@ module Rouge
       title "Scala"
       desc "The Scala programming language (scala-lang.org)"
       tag 'scala'
-      aliases 'scala'
       filenames '*.scala', '*.sbt'
 
       mimetypes 'text/x-scala', 'application/x-scala'

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -7,7 +7,6 @@ module Rouge
       title "Smarty"
       desc 'Smarty Template Engine'
       tag 'smarty'
-      aliases 'smarty'
       filenames '*.tpl', '*.smarty'
       mimetypes 'application/x-smarty', 'text/x-smarty'
 

--- a/lib/rouge/lexers/tap.rb
+++ b/lib/rouge/lexers/tap.rb
@@ -6,7 +6,6 @@ module Rouge
       title 'TAP'
       desc 'Test Anything Protocol'
       tag 'tap'
-      aliases 'tap'
       filenames '*.tap'
 
       mimetypes 'text/x-tap', 'application/x-tap'

--- a/lib/rouge/lexers/tulip.rb
+++ b/lib/rouge/lexers/tulip.rb
@@ -5,7 +5,6 @@ module Rouge
     class Tulip < RegexLexer
       desc 'the tulip programming language (twitter.com/tuliplang)'
       tag 'tulip'
-      aliases 'tulip'
 
       filenames '*.tlp'
 


### PR DESCRIPTION
Quite a lot of lexers were including their own tag in an `alias` declaration, which is redundant. This PR removes them, and adds a warning if a lexer is registered as a tag or alias that already exists.