### PR TITLE
properties: fix comments at eof and escaped chars in keys

### DIFF
--- a/lib/rouge/lexers/properties.rb
+++ b/lib/rouge/lexers/properties.rb
@@ -11,10 +11,10 @@ module Rouge
       filenames '*.properties'
       mimetypes 'text/x-java-properties'
 
-      identifier = /[\w.-]+/
+      identifier = /(?:[\w.-]|\\u\h{4}|\\.)+/
 
       state :basic do
-        rule %r/[!#].*?\n/, Comment
+        rule %r/[!#].*/, Comment
         rule %r/\s+/, Text
         rule %r/\\\n/, Str::Escape
       end

--- a/spec/visual/samples/properties
+++ b/spec/visual/samples/properties
@@ -14,3 +14,5 @@ key\ with\ spaces = This is the value that could be looked up with the key "key 
 key.with.dots = This is the value that could be looked up with the key "key.with.dots".
 # Unicode
 tab : \u0009
+
+# comment at eof


### PR DESCRIPTION
Fixes #1826, and also provides for keys with spaces, which were highlighted as an error before.

Before:

<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/eccec0c1-e64a-4331-84f7-2d3ba27f5831" />

This branch:

<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/6bc8e067-b4f9-4db3-9915-8ced61d35ff0" />