### PR TITLE
Add a "Plain" formatter for debugging

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -99,6 +99,7 @@ require_relative 'rouge/formatters/terminal256'
 require_relative 'rouge/formatters/terminal_truecolor'
 require_relative 'rouge/formatters/tex'
 require_relative 'rouge/formatters/null'
+require_relative 'rouge/formatters/plain'
 
 require_relative 'rouge/theme'
 require_relative 'rouge/tex_theme_renderer'

--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -334,6 +334,7 @@ module Rouge
         when 'html-line-table' then Formatters::HTMLLineTable.new(Formatters::HTML.new)
         when 'html-table' then Formatters::HTMLTable.new(Formatters::HTML.new)
         when 'null', 'raw', 'tokens' then Formatters::Null.new
+        when 'plain' then Formatters::Plain.new
         when 'tex' then Formatters::Tex.new
         else
           error! "unknown formatter preset #{opts[:formatter]}"

--- a/lib/rouge/formatters/plain.rb
+++ b/lib/rouge/formatters/plain.rb
@@ -1,0 +1,16 @@
+module Rouge
+  module Formatters
+    class Plain < Formatter
+      tag 'plain'
+
+      def initialize(*)
+      end
+
+      def stream(tokens)
+        tokens.each do |_, val|
+          yield val
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new "plain" formatter that ignores all token types and yields out the original text. Helpful for debugging - if this is ever different from the input then the lexer has a bug, and the output can be diffed easily.