### PR TITLE
allow sed commands without spaces

### DIFF
--- a/lib/rouge/lexers/sed.rb
+++ b/lib/rouge/lexers/sed.rb
@@ -107,7 +107,7 @@ module Rouge
         rule %r/[pd]/, Keyword
 
         # commands that take a number argument
-        rule %r/([qQl])(\s+)(\d+)/i do
+        rule %r/([qQl])(\s*)(\d+)/i do
           groups Keyword, Text, Num
           pop!
         end
@@ -116,13 +116,13 @@ module Rouge
         rule %r/[={}dDgGhHlnpPqx]/, Keyword, :pop!
 
         # commands that take a filename argument
-        rule %r/([rRwW])(\s+)(\S+)/ do
+        rule %r/([rRwW])(\s*)(\S+)/ do
           groups Keyword, Text, Name
           pop!
         end
 
         # commands that take a label argument
-        rule %r/([:btT])(\s+)(\S+)/ do
+        rule %r/([:btT])(\s*)(\S+)/ do
           groups Keyword, Text, Name::Label
           pop!
         end

--- a/spec/visual/samples/sed
+++ b/spec/visual/samples/sed
@@ -2302,3 +2302,17 @@ x
 # The End ;(
 
 ### colorized by sedsed, a sed script debugger/indenter/tokenizer/HTMLizer
+
+blabel
+tlabel
+:label
+atext
+itext
+ctext
+q123
+Q456
+l789
+r/tmp/foo.txt
+R/tmp/foo.txt
+w/tmp/foo.txt
+W/tmp/foo.txt


### PR DESCRIPTION
Fixes #2323 

Also removes the requirement for spaces before other commands. I think it makes sense for Rouge lexers to be somewhat forgiving, even in cases that would error in some implementations.