### PR TITLE
Improve gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,18 @@ gemspec
 
 gem 'rake'
 
-gem 'minitest', '>= 5.0'
+if RUBY_VERSION < '3.2'
+  gem 'minitest', '~> 5.0'
+else
+  gem 'minitest', '~> 6.0'
+end
 gem 'minitest-power_assert'
 gem 'minitest-focus'
-gem 'power_assert', '~> 2.0'
+if RUBY_VERSION < '3.2'
+  gem 'power_assert', '~> 2.0'
+else
+  gem 'power_assert', '~> 3.0'
+end
 
 # don't try to install redcarpet under jruby
 gem 'redcarpet', platforms: :ruby
@@ -26,7 +34,7 @@ group :development do
 
   gem 'rubocop'
   gem 'rubocop-performance', '~> 1.26'
-  gem 'rubocop-minitest', '~> 0.38'
+  gem 'rubocop-minitest', '~> 0.40'
   gem 'rubocop-rake', '~> 0.7'
 
   # docs


### PR DESCRIPTION
Proposing we update the Gemfile to more obviously reflect that we're already using/support `minitest` 6.0+ (for Ruby 3.2+) and `rubocop-minitest` 0.40+ and allow conditional usage of `power_assert` 3.0+ on Ruby 3.2+ as `power_assert` [3.0](https://github.com/ruby/power_assert/releases#release-v3.0.0) drops support for Ruby < 3.2 and we still support Ruby 3.0 and 3.1.

Locally running:
- minitest (6.0.6)
- power_assert (3.0.1)
- rubocop-minitest (0.40.0)