### PR TITLE
Fix NoMethodError in Magik lexer's method_name state

### DIFF
--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -84,7 +84,7 @@ module Rouge
           pop!
         end
 
-        rule Magik.identifier do
+        rule identifier do
           token Name::Class
           pop!
         end


### PR DESCRIPTION
Follow-up to #2318.

`state :method_name` still called `Magik.identifier`, a leftover from an earlier revision of that PR that cached regexes as memoized class methods (the style @jneen's review comments on #2318 asked to move away from). That refactor was done for every other regex in the file, but this one call site was missed.

Since `RegexLexer` evaluates a state's `rule` arguments eagerly when the state is first loaded, `Magik.identifier` raises `NoMethodError: undefined method 'identifier' for class Rouge::Lexers::Magik` as soon as `:method_name` is entered - i.e. on any input containing `_method`, not just the new `[]`-method syntax. Verified against a clean checkout of current `main` (909e8ca4):

```
$ ruby -Ilib -e 'require "rouge"; Rouge::Lexers::Magik.new.lex("_method a.b()\n_endmethod\n").to_a'
NoMethodError: undefined method 'identifier' for class Rouge::Lexers::Magik
```

This fix replaces the stale class-method reference with the `identifier` local variable already used everywhere else in the file. It's a one-line change with no other effect: the sample file round-trips through the lexer with no errors, and no other tokenization changes since `identifier` is the exact same regex `Magik.identifier` was aliasing.