### PR TITLE
Fix over-greedy character-literal regex in Magik lexer

### DIFF
--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -84,7 +84,7 @@ module Rouge
           pop!
         end
 
-        rule Magik.identifier do
+        rule identifier do
           token Name::Class
           pop!
         end

--- a/lib/rouge/lexers/magik.rb
+++ b/lib/rouge/lexers/magik.rb
@@ -64,7 +64,7 @@ module Rouge
         rule %r/:#{identifier}/, Str::Symbol
         rule %r/@[\s]*#{identifier}:#{identifier}/, Name::Label
         rule %r/@[\s]*#{identifier}/, Name::Label
-        rule %r/%u[0-9a-z]{4}|%[^\s]+/i, Literal::String::Char
+        rule %r/%(?:\w+|\W)/, Literal::String::Char
         rule number, Literal::Number
         rule %r/#{identifier}:#{identifier}/, Name
         rule identifier, Name


### PR DESCRIPTION
`%[^\s]+` consumed every non-whitespace character up to the next space, so a character literal immediately followed by punctuation was lexed as one token instead of two. For example `%a.foo` came out as a single `Literal::String::Char` `"%a.foo"`, swallowing the `.foo` slot access into the literal.

Replaced with `%(?:\w+|\W)`, which matches Magik's actual character-literal grammar - `CHARACTER_REGEXP = "%(\\W|\\w+)"` in `magik-tools`' `MagikGrammar.java`, and the same pattern documented in the Magik TextMate grammar (`%(?:\W|\w+)`).

Verified three ways:
- Against a live Magik session: `write(%a.is_letter?())` parses fine and only fails at *runtime* ("Object a does not understand message is_letter?()"), proving the real parser treats `%a` and `.is_letter?()` as separate tokens.
- Against `tree-sitter-magik`: parsing `x << %a.foo` produces a `character_literal` node spanning just `%a`, with `foo` as a separate `identifier` message - matching this fix exactly.
- The existing character-literal samples in `spec/visual/samples/magik` (`%q`, `%u000A`, `%newline`, `%space`, `%tab`, ...) still lex identically, and the full sample file round-trips through the lexer unchanged otherwise.