### PR TITLE
fix: report an unknown theme by name instead of crashing

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -322,7 +322,8 @@ module Rouge
 
         @lexer_opts = opts[:lexer_opts]
 
-        theme = Theme.find(opts[:theme]).new or error! "unknown theme #{opts[:theme]}"
+        theme_class = Theme.find(opts[:theme]) or error! "unknown theme #{opts[:theme]}"
+        theme = theme_class.new
 
         # TODO: document this in --help
         @formatter = case opts[:formatter]

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -38,6 +38,20 @@ describe Rouge::CLI do
       }
     end
 
+    describe 'an unknown theme' do
+      let(:argv) { %w(highlight -l ruby -t no-such-theme) }
+      it('reports the theme by name instead of crashing') {
+        error = nil
+        begin
+          subject
+        rescue Rouge::CLI::Error => e
+          error = e
+        end
+        assert { !error.nil? }
+        assert { error.message == 'unknown theme no-such-theme' }
+      }
+    end
+
     describe 'guessing a lexer by mimetype' do
       let(:argv) { %w(highlight -m application/javascript) }
       it('parses') {


### PR DESCRIPTION
`rougify highlight -t <unknown-theme>` dies with an unhandled `NoMethodError` instead of the error message the code already contains:

```
$ rougify highlight -t no-such-theme file.rb
lib/rouge/cli.rb:325:in 'initialize': undefined method 'new' for nil (NoMethodError)
```

The line is:

```ruby
theme = Theme.find(opts[:theme]).new or error! "unknown theme #{opts[:theme]}"
```

`.new` binds tighter than `or`, so when `Theme.find` returns nil the crash happens before `or` is ever evaluated - the `unknown theme` message is unreachable. Splitting the lookup from the instantiation makes the intended message fire:

```
$ rougify highlight -t no-such-theme file.rb
unknown theme no-such-theme
```

Two lines changed, plus a spec in the existing `Rouge::CLI::Highlight` block asserting the `Rouge::CLI::Error` message. With the fix reverted that spec errors with the original `NoMethodError`; with it, `rake check:specs` is green at 1325 runs / 5804 assertions.
