### PR TITLE
Use a byte search for newline detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 gem 'redcarpet', platforms: :ruby
 
 # Profiling
+gem 'benchmark', require: false
 gem 'memory_profiler', require: false
 
 group :development do

--- a/benchmark/token_lines.rb
+++ b/benchmark/token_lines.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+require 'memory_profiler'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'rouge'
+
+class BaselineFormatter < Rouge::Formatter
+  def token_lines(tokens, &block)
+    return enum_for(:token_lines, tokens) unless block
+
+    out = []
+    tokens.each do |tok, val|
+      val.scan %r/\n|[^\n]+/ do |segment|
+        if segment == "\n"
+          yield out
+          out = []
+        else
+          out << [tok, segment]
+        end
+      end
+    end
+
+    yield out if out.any?
+  end
+end
+
+class NewFormatter < Rouge::Formatter
+  LF = "\n".b.freeze
+
+  def token_lines(tokens, &b)
+    return enum_for(:token_lines, tokens) unless block_given?
+
+    out = []
+    tokens.each do |tok, val|
+      if val.valid_encoding? && val.encoding.ascii_compatible?
+        bytes = val.b
+        start = 0
+
+        while (finish = bytes.index(LF, start))
+          segment = val.byteslice(start...finish)
+          out << [tok, segment] unless segment.empty?
+
+          yield out
+          out = []
+          start = finish + LF.bytesize
+        end
+
+        segment = val.byteslice(start...)
+        out << [tok, segment] unless segment.empty?
+      else
+        val.scan %r/\n|[^\n]+/ do |s|
+          if s == "\n"
+            yield out
+            out = []
+          else
+            out << [tok, s]
+          end
+        end
+      end
+    end
+
+    # for inputs not ending in a newline
+    yield out if out.any?
+  end
+end
+
+demo_dir = File.expand_path('../lib/rouge/demos', __dir__)
+demo_files = Dir.glob(File.join(demo_dir, '*')).select { |path| File.file?(path) }
+
+tokens = demo_files.map do |path|
+  [Rouge::Token['Text'], File.read(path, encoding: Encoding::UTF_8)]
+end
+
+baseline_formatter = BaselineFormatter.new
+new_formatter = NewFormatter.new
+
+regexp_lines = baseline_formatter.token_lines(tokens).to_a
+byte_index_lines = new_formatter.token_lines(tokens).to_a
+
+unless regexp_lines == byte_index_lines
+  raise 'implementations produced different output'
+end
+
+iterations = 100
+
+baseline_allocations = MemoryProfiler.report do
+  iterations.times do
+    baseline_formatter.token_lines(tokens) { |line| line.length }
+  end
+end
+
+new_allocations = MemoryProfiler.report do
+  iterations.times do
+    new_formatter.token_lines(tokens) { |line| line.length }
+  end
+end
+
+puts "Memory allocation"
+puts
+puts format(
+  '%-20s %10d objects %12d bytes',
+  'baseline (before)',
+  baseline_allocations.total_allocated,
+  baseline_allocations.total_allocated_memsize
+)
+puts format(
+  '%-20s %10d objects %12d bytes',
+  'new (after)',
+  new_allocations.total_allocated,
+  new_allocations.total_allocated_memsize
+)
+puts
+
+results = Benchmark.bmbm(24) do |benchmark|
+  benchmark.report('baseline (before)') do
+    iterations.times { baseline_formatter.token_lines(tokens) { |line| line.length } }
+  end
+
+  benchmark.report('new (after)') do
+    iterations.times { new_formatter.token_lines(tokens) { |line| line.length } }
+  end
+end
+
+puts format('Speedup: %.2fx', results[0].real / results[1].real)

--- a/lib/rouge/formatter.rb
+++ b/lib/rouge/formatter.rb
@@ -6,6 +6,7 @@ module Rouge
   class Formatter
     # @private
     REGISTRY = {}
+    LF = "\n".b.freeze
 
     # Specify or get the unique tag for this formatter.  This is used
     # for specifying a formatter in `rougify`.
@@ -94,12 +95,29 @@ module Rouge
 
       out = []
       tokens.each do |tok, val|
-        val.scan %r/\n|[^\n]+/ do |s|
-          if s == "\n"
+        if val.valid_encoding? && val.encoding.ascii_compatible?
+          bytes = val.b
+          start = 0
+
+          while (finish = bytes.index(LF, start))
+            segment = val.byteslice(start...finish)
+            out << [tok, segment] unless segment.empty?
+
             yield out
             out = []
-          else
-            out << [tok, s]
+            start = finish + LF.bytesize
+          end
+
+          segment = val.byteslice(start...)
+          out << [tok, segment] unless segment.empty?
+        else
+          val.scan %r/\n|[^\n]+/ do |s|
+            if s == "\n"
+              yield out
+              out = []
+            else
+              out << [tok, s]
+            end
           end
         end
       end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,6 +1,86 @@
 # frozen_string_literal: true
 
+class TestFormatter < Rouge::Formatter
+  def token_lines(tokens)
+    super.to_a
+  end
+end
+
 describe Rouge::Formatter do
+  describe '#token_lines' do
+    let(:formatter) { TestFormatter.new }
+
+    it 'splits tokens into lines' do
+      tokens = [[Token['Text'], "foo\nbar"]]
+      expected = [
+        [[Token['Text'], 'foo']],
+        [[Token['Text'], 'bar']]
+      ]
+
+      assert { formatter.token_lines(tokens) == expected }
+    end
+
+    it 'splits multibyte content' do
+      tokens = [[Token['Text'], "café\n日本"]]
+      expected = [
+        [[Token['Text'], 'café']],
+        [[Token['Text'], '日本']]
+      ]
+
+      assert { formatter.token_lines(tokens) == expected }
+    end
+
+    it 'preserves tokens across multiple lines' do
+      tokens = [
+        [Token['Name'], 'foo'],
+        [Token['Text'], ' '],
+        [Token['Name'], "bar\nbaz"]
+      ]
+
+      expected = [
+        [
+          [Token['Name'], 'foo'],
+          [Token['Text'], ' '],
+          [Token['Name'], 'bar']
+        ],
+        [
+          [Token['Name'], 'baz']
+        ]
+      ]
+
+      assert { formatter.token_lines(tokens) == expected }
+    end
+
+    it 'preserves binary encoding' do
+      tokens = [[Token['Text'], "foo\nbar".b]]
+
+      expected = [
+        [[Token['Text'], 'foo'.b]],
+        [[Token['Text'], 'bar'.b]]
+      ]
+
+      assert { formatter.token_lines(tokens) == expected }
+    end
+
+    it 'preserves the error for non-ASCII-compatible encoding' do
+      value = "foo\nbar".encode(Encoding::UTF_16LE)
+      tokens = [[Token['Text'], value]]
+
+      assert_raises(Encoding::CompatibilityError) do
+        formatter.token_lines(tokens)
+      end
+    end
+
+    it 'preserves the error for invalid encoding' do
+      value = "foo\xFF\nbar".dup.force_encoding(Encoding::UTF_8)
+      tokens = [[Token['Text'], value]]
+
+      assert_raises(ArgumentError) do
+        formatter.token_lines(tokens)
+      end
+    end
+  end
+
   it 'finds terminal256' do
     assert { Rouge::Formatter.find('terminal256') }
   end


### PR DESCRIPTION
**Problem**

`Rouge::Formatter` uses regular expressions to detect newlines. This approach doesn't scale well for large files. I've faced visible performance issues (both CPU and memory) while processing files over 1Mb.

**Solution**

Use a byte search approach for ASCII compatible strings. It avoids expensive regexp overhead and improves the performance.